### PR TITLE
Add cleanup functionality to react editor

### DIFF
--- a/dc-cudami-editor/src/components/IdentifiableForm.js
+++ b/dc-cudami-editor/src/components/IdentifiableForm.js
@@ -91,6 +91,9 @@ class IdentifiableForm extends Component {
     });
   }
 
+  /*
+   * Removes languages with empty content from the json
+   */
   cleanUpJson = (editorJson) => {
     const initialEditorDocString = '{"type":"doc","content":[{"type":"paragraph"}]}';
     return Object.entries(editorJson).reduce((json, [language, doc]) => {

--- a/dc-cudami-editor/src/components/IdentifiableForm.js
+++ b/dc-cudami-editor/src/components/IdentifiableForm.js
@@ -130,10 +130,7 @@ class IdentifiableForm extends Component {
   }
 
   isEmptyContent = (content) => {
-    if (content.length === 1 && !content[0].content) {
-      return true;
-    }
-    return false;
+    return content.length === 1 && !content[0].content;
   }
 
   isFormValid = () => {

--- a/dc-cudami-editor/src/components/IdentifiableForm.js
+++ b/dc-cudami-editor/src/components/IdentifiableForm.js
@@ -91,6 +91,19 @@ class IdentifiableForm extends Component {
     });
   }
 
+  cleanUpJson = (editorJson) => {
+    const initialEditorDocString = '{"type":"doc","content":[{"type":"paragraph"}]}';
+    return Object.entries(editorJson).reduce((json, [language, doc]) => {
+      if (JSON.stringify(doc) === initialEditorDocString) {
+        return json;
+      }
+      return {
+        ...json,
+        [language]: doc
+      };
+    }, {});
+  }
+
   getFormComponent = () => {
     const FORM_COMPONENT_MAPPING = {
       article: ArticleForm,
@@ -133,16 +146,23 @@ class IdentifiableForm extends Component {
 
   submitIdentifiable = () => {
     if (this.isFormValid()){
-      if (this.state.identifiable.uuid) {
+      const identifiable = {
+        ...this.state.identifiable,
+        description: this.cleanUpJson(this.state.identifiable.description)
+      }
+      if (identifiable.text) {
+        identifiable.text = this.cleanUpJson(this.state.identifiable.text)
+      }
+      if (identifiable.uuid) {
         updateIdentifiable(
           this.props.apiContextPath,
-          this.state.identifiable,
+          identifiable,
           this.props.type
         );
       } else {
         saveIdentifiable(
           this.props.apiContextPath,
-          this.state.identifiable,
+          identifiable,
           this.props.parentType,
           this.props.parentUuid,
           this.props.type

--- a/dc-cudami-editor/src/components/IdentifiableForm.js
+++ b/dc-cudami-editor/src/components/IdentifiableForm.js
@@ -95,9 +95,8 @@ class IdentifiableForm extends Component {
    * Removes languages with empty content from the json
    */
   cleanUpJson = (editorJson) => {
-    const initialEditorDocString = '{"type":"doc","content":[{"type":"paragraph"}]}';
     return Object.entries(editorJson).reduce((json, [language, doc]) => {
-      if (JSON.stringify(doc) === initialEditorDocString) {
+      if (this.isEmptyContent(doc.content)) {
         return json;
       }
       return {
@@ -128,6 +127,13 @@ class IdentifiableForm extends Component {
       onUpdate={this.updateIdentifiable}
       type={this.props.type}
     />;
+  }
+
+  isEmptyContent = (content) => {
+    if (content.length === 1 && !content[0].content) {
+      return true;
+    }
+    return false;
   }
 
   isFormValid = () => {


### PR DESCRIPTION
This PR adds functionality to clean up the json fields `description` and `text`, i.e. remove languages with empty content.