### PR TITLE
Fix v2 webpages

### DIFF
--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
@@ -45,7 +45,7 @@ public interface CudamiClient {
   @RequestLine("GET /v2/locales")
   List<Locale> getSupportedLocales() throws HttpException;
 
-  @RequestLine("GET /v2/webpages/{uuid}")
+  @RequestLine("GET /v3/webpages/{uuid}")
   Webpage getWebpage(@Param("uuid") String uuid) throws HttpException;
 
   @RequestLine("GET /v2/webpages/{uuid}?pLocale={locale}")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageController.java
@@ -68,7 +68,7 @@ public class WebpageController {
       description =
           "Get a webpage as JSON or XML, depending on extension or <tt>format</tt> request parameter or accept header")
   @RequestMapping(
-      value = {"/latest/webpages/{uuid}", "/v2/webpages/{uuid}"},
+      value = {"/latest/webpages/{uuid}", "/v3/webpages/{uuid}"},
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE},
       method = RequestMethod.GET)
   @ApiResponseObject

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageHtmlController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageHtmlController.java
@@ -28,6 +28,7 @@ public class WebpageHtmlController {
   @RequestMapping(
       value = {
         "/latest/webpages/{uuid}.html",
+        "/v3/webpages/{uuid}.html",
         "/v2/webpages/{uuid}.html",
         "/v1/webpages/{uuid}.html"
       },

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
@@ -65,6 +65,8 @@ public class V1WebpageController {
           Locale pLocale)
       throws IdentifiableServiceException, JsonProcessingException {
     Webpage webpage = loadWebpage(pLocale, uuid);
+    webpage.setCreated(null);
+    webpage.setLastModified(null);
     JSONObject result = new JSONObject(objectMapper.writeValueAsString(webpage));
     if (result.has("description")) {
       result.put(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v2/identifiable/entity/parts/V2WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v2/identifiable/entity/parts/V2WebpageController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@Api(description = "The V1 webpage controller", name = "V1 Webpage controller")
+@Api(description = "The V2 webpage controller", name = "V2 Webpage controller")
 public class V2WebpageController {
 
   private final DigitalCollectionsObjectMapper objectMapper = new DigitalCollectionsObjectMapper();
@@ -45,13 +45,13 @@ public class V2WebpageController {
 
   @Autowired private WebpageService webpageService;
 
-  @ApiMethod(description = "Get a webpage as JSON (Version 1)")
+  @ApiMethod(description = "Get a webpage as JSON (Version 2)")
   @RequestMapping(
       value = {"/v2/webpages/{uuid}.json", "/v2/webpages/{uuid}"},
       produces = {MediaType.APPLICATION_JSON_VALUE},
       method = RequestMethod.GET)
   @ApiResponseObject
-  public ResponseEntity<String> getWebpageV1Json(
+  public ResponseEntity<String> getWebpageV2Json(
       @ApiPathParam(
               description =
                   "UUID of the webpage, e.g. <tt>599a120c-2dd5-11e8-b467-0ed5f89f718b</tt>")
@@ -83,13 +83,13 @@ public class V2WebpageController {
     return new ResponseEntity<>(result.toString(), HttpStatus.OK);
   }
 
-  @ApiMethod(description = "Get a webpage as XML (Version 1)")
+  @ApiMethod(description = "Get a webpage as XML (Version 2)")
   @RequestMapping(
       value = {"/v2/webpages/{uuid}.xml"},
       produces = {MediaType.APPLICATION_XML_VALUE},
       method = RequestMethod.GET)
   @ApiResponseObject
-  public ResponseEntity<String> getWebpageV1Xml(
+  public ResponseEntity<String> getWebpageV2Xml(
       @ApiPathParam(
               description =
                   "UUID of the webpage, e.g. <tt>599a120c-2dd5-11e8-b467-0ed5f89f718b</tt>")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v2/identifiable/entity/parts/V2WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v2/identifiable/entity/parts/V2WebpageController.java
@@ -1,0 +1,191 @@
+package de.digitalcollections.cudami.server.controller.v2.identifiable.entity.parts;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.parts.WebpageService;
+import de.digitalcollections.model.api.identifiable.entity.parts.Webpage;
+import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
+import de.digitalcollections.model.xml.xstream.DigitalCollectionsXStreamMarshaller;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.XMLOutputter;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.jsondoc.core.annotation.Api;
+import org.jsondoc.core.annotation.ApiMethod;
+import org.jsondoc.core.annotation.ApiPathParam;
+import org.jsondoc.core.annotation.ApiQueryParam;
+import org.jsondoc.core.annotation.ApiResponseObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.oxm.XmlMappingException;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Api(description = "The V1 webpage controller", name = "V1 Webpage controller")
+public class V2WebpageController {
+
+  private final DigitalCollectionsObjectMapper objectMapper = new DigitalCollectionsObjectMapper();
+  private final DigitalCollectionsXStreamMarshaller xStreamMarshaller =
+      new DigitalCollectionsXStreamMarshaller();
+
+  @Autowired private WebpageService webpageService;
+
+  @ApiMethod(description = "Get a webpage as JSON (Version 1)")
+  @RequestMapping(
+      value = {"/v2/webpages/{uuid}.json", "/v2/webpages/{uuid}"},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = RequestMethod.GET)
+  @ApiResponseObject
+  public ResponseEntity<String> getWebpageV1Json(
+      @ApiPathParam(
+              description =
+                  "UUID of the webpage, e.g. <tt>599a120c-2dd5-11e8-b467-0ed5f89f718b</tt>")
+          @PathVariable("uuid")
+          UUID uuid,
+      @ApiQueryParam(
+              name = "pLocale",
+              description =
+                  "Desired locale, e.g. <tt>de_DE</tt>. If unset, contents in all languages will be returned")
+          @RequestParam(name = "pLocale", required = false)
+          Locale pLocale)
+      throws IdentifiableServiceException, JsonProcessingException {
+    Webpage webpage = loadWebpage(pLocale, uuid);
+    webpage.setCreated(null);
+    webpage.setLastModified(null);
+    JSONObject result = new JSONObject(objectMapper.writeValueAsString(webpage));
+    if (result.has("description")) {
+      result.put(
+          "description",
+          convertLocalizedStructuredContentJson(result.getJSONObject("description")));
+    }
+    if (result.has("label")) {
+      result.put("label", convertLocalizedTextJson(result.getJSONObject("label")));
+    }
+    if (result.has("text")) {
+      result.put("text", convertLocalizedStructuredContentJson(result.getJSONObject("text")));
+    }
+    result.put("type", "RESOURCE");
+    return new ResponseEntity<>(result.toString(), HttpStatus.OK);
+  }
+
+  @ApiMethod(description = "Get a webpage as XML (Version 1)")
+  @RequestMapping(
+      value = {"/v2/webpages/{uuid}.xml"},
+      produces = {MediaType.APPLICATION_XML_VALUE},
+      method = RequestMethod.GET)
+  @ApiResponseObject
+  public ResponseEntity<String> getWebpageV1Xml(
+      @ApiPathParam(
+              description =
+                  "UUID of the webpage, e.g. <tt>599a120c-2dd5-11e8-b467-0ed5f89f718b</tt>")
+          @PathVariable("uuid")
+          UUID uuid,
+      @ApiQueryParam(
+              name = "pLocale",
+              description =
+                  "Desired locale, e.g. <tt>de_DE</tt>. If unset, contents in all languages will be returned")
+          @RequestParam(name = "pLocale", required = false)
+          Locale pLocale)
+      throws IdentifiableServiceException, JsonProcessingException, XmlMappingException,
+          IOException {
+    Webpage webpage = loadWebpage(pLocale, uuid);
+    StringWriter sw = new StringWriter();
+    xStreamMarshaller.marshalWriter(webpage, sw);
+    String result = sw.toString();
+    return new ResponseEntity<>(migrateWebpageXml(result), HttpStatus.OK);
+  }
+
+  private JSONObject convertLocalizedStructuredContentJson(JSONObject json) {
+    JSONObject localizedStructuredContent = new JSONObject();
+    localizedStructuredContent.put("localizedStructuredContent", json);
+    return localizedStructuredContent;
+  }
+
+  private void convertLocalizedStructuredContentXml(Element xml) {
+    Element content = xml.getChild("entry");
+    xml.setContent(createLSCElement(content));
+  }
+
+  private JSONObject convertLocalizedTextJson(JSONObject json) {
+    JSONObject result = new JSONObject();
+    JSONArray translations = new JSONArray();
+    json.keySet()
+        .forEach(
+            (locale) -> {
+              JSONObject translation = new JSONObject();
+              translation.put("locale", locale);
+              translation.put("text", json.get(locale));
+              translations.put(translation);
+            });
+    result.put("translations", translations);
+    return result;
+  }
+
+  private void convertLocalizedTextXml(Element xml) {
+    List<Element> contents = xml.getChildren("entry");
+    Element translations = new Element("translations");
+    contents.forEach(
+        (entry) -> {
+          Element translation = new Element("translation");
+          translation.addContent(entry.getChild("locale").clone());
+          Element text = new Element("text");
+          text.addContent(entry.getChild("string").getText());
+          translation.addContent(text);
+          translations.addContent(translation);
+        });
+    xml.setContent(translations);
+  }
+
+  private Element createLSCElement(Element content) {
+    Element localizedStructuredContent = new Element("localizedStructuredContent");
+    localizedStructuredContent.setContent(content.clone());
+    return localizedStructuredContent;
+  }
+
+  private Webpage loadWebpage(Locale pLocale, UUID uuid) throws IdentifiableServiceException {
+    Webpage webpage;
+    if (pLocale == null) {
+      webpage = (Webpage) webpageService.get(uuid);
+    } else {
+      webpage = webpageService.get(uuid, pLocale);
+    }
+    return webpage;
+  }
+
+  private String migrateWebpageXml(String xml) {
+    try {
+      SAXBuilder saxBuilder = new SAXBuilder();
+      Document doc = saxBuilder.build(new StringReader(xml));
+      Element description = doc.getRootElement().getChild("description");
+      if (description != null) {
+        convertLocalizedStructuredContentXml(description);
+      }
+      Element text = doc.getRootElement().getChild("text");
+      if (text != null) {
+        convertLocalizedStructuredContentXml(text);
+      }
+      Element label = doc.getRootElement().getChild("label");
+      if (label != null) {
+        convertLocalizedTextXml(label);
+      }
+      return new XMLOutputter().outputString(doc);
+    } catch (IOException | JDOMException ex) {
+      return xml;
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the retrieving of webpages (`v2`) by changing the structure of json and xml to the state of the latest release. Additionally a new `v3` endpoint for this usecase is introduced. Besides some date fields are removed in the `v1` webpage endpoint.