### PR TITLE
Remove editor placeholder

### DIFF
--- a/dc-cudami-editor/package-lock.json
+++ b/dc-cudami-editor/package-lock.json
@@ -16,15 +16,6 @@
         "prosemirror-view": "^1.1.1"
       }
     },
-    "@aeaton/prosemirror-placeholder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@aeaton/prosemirror-placeholder/-/prosemirror-placeholder-0.1.0.tgz",
-      "integrity": "sha1-HEpW1u26Xs/1Gder/ayga+TIgpA=",
-      "requires": {
-        "prosemirror-state": "^1.1.0",
-        "prosemirror-view": "^1.1.1"
-      }
-    },
     "@aeaton/react-prosemirror": {
       "version": "0.22.1",
       "resolved": "https://registry.npmjs.org/@aeaton/react-prosemirror/-/react-prosemirror-0.22.1.tgz",

--- a/dc-cudami-editor/package-lock.json
+++ b/dc-cudami-editor/package-lock.json
@@ -5794,9 +5794,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/dc-cudami-editor/package.json
+++ b/dc-cudami-editor/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@aeaton/prosemirror-footnotes": "^0.1.0",
-    "@aeaton/prosemirror-placeholder": "^0.1.0",
     "@aeaton/react-prosemirror": "^0.22.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.19",
     "@fortawesome/free-brands-svg-icons": "^5.9.0",

--- a/dc-cudami-editor/src/config/plugins.js
+++ b/dc-cudami-editor/src/config/plugins.js
@@ -2,13 +2,11 @@ import {history} from 'prosemirror-history'
 import {dropCursor} from 'prosemirror-dropcursor'
 import {gapCursor} from 'prosemirror-gapcursor'
 import {columnResizing, tableEditing} from 'prosemirror-tables'
-import {placeholder} from '@aeaton/prosemirror-placeholder'
 import {footnotes} from '@aeaton/prosemirror-footnotes'
 
 import 'prosemirror-tables/style/tables.css'
 import 'prosemirror-gapcursor/style/gapcursor.css'
 import '@aeaton/prosemirror-footnotes/style/footnotes.css'
-import '@aeaton/prosemirror-placeholder/style/placeholder.css'
 
 import keys from './keys'
 import rules from './rules'
@@ -16,7 +14,6 @@ import rules from './rules'
 export default [
   rules,
   keys,
-  placeholder(),
   footnotes(),
   dropCursor(),
   gapCursor(),


### PR DESCRIPTION
This PR removes the placeholder in the editor, when the content is empty. The problem is, that it's not possible to translate the placeholder text.