### PR TITLE
Fix language tab sorting

### DIFF
--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigWeb.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigWeb.java
@@ -8,13 +8,17 @@ import de.digitalcollections.commons.springmvc.controller.ErrorController;
 import de.digitalcollections.commons.springmvc.thymeleaf.SpacesDialect;
 import de.digitalcollections.cudami.admin.converter.GrantedAuthorityJsonFilter;
 import de.digitalcollections.cudami.admin.interceptors.CreateAdminUserInterceptor;
+import de.digitalcollections.cudami.admin.util.LanguageSortingHelper;
 import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import nz.net.ultraq.thymeleaf.LayoutDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -130,6 +134,12 @@ public class SpringConfigWeb implements WebMvcConfigurer {
     // In case you want the filter to apply to specific URL patterns only (defaults to "/*")
     registration.addUrlPatterns("/*");
     return registration;
+  }
+
+  @Bean
+  public LanguageSortingHelper languageSortingHelper(
+      @Value("${cudami.prioritisedSortedLanguages}") List<Locale> prioritisedSortedLanguages) {
+    return new LanguageSortingHelper(prioritisedSortedLanguages);
   }
 
   @Bean

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ArticlesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ArticlesController.java
@@ -74,9 +74,15 @@ public class ArticlesController extends AbstractController {
 
   @GetMapping("/articles/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Article article = service.get(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, article.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("uuid", article.getUuid());
+
     return "articles/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ArticlesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ArticlesController.java
@@ -127,11 +127,11 @@ public class ArticlesController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     Article article = (Article) service.get(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, article.getLabel().getLocales());
 
     model.addAttribute("article", article);
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
 
     LinkedHashSet<FileResource> relatedFileResources = service.getRelatedFileResources(article);
     model.addAttribute("relatedFileResources", relatedFileResources);

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ArticlesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ArticlesController.java
@@ -7,15 +7,19 @@ import de.digitalcollections.commons.springmvc.controller.AbstractController;
 import de.digitalcollections.cudami.admin.backend.api.repository.LocaleRepository;
 import de.digitalcollections.cudami.admin.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.admin.business.api.service.identifiable.entity.ArticleService;
+import de.digitalcollections.cudami.admin.util.LanguageSortingHelper;
 import de.digitalcollections.model.api.identifiable.entity.Article;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -37,11 +41,16 @@ public class ArticlesController extends AbstractController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArticlesController.class);
 
+  LanguageSortingHelper languageSortingHelper;
   LocaleRepository localeRepository;
   ArticleService service;
 
   @Autowired
-  public ArticlesController(LocaleRepository localeRepository, ArticleService service) {
+  public ArticlesController(
+      LanguageSortingHelper languageSortingHelper,
+      LocaleRepository localeRepository,
+      ArticleService service) {
+    this.languageSortingHelper = languageSortingHelper;
     this.localeRepository = localeRepository;
     this.service = service;
   }
@@ -116,9 +125,13 @@ public class ArticlesController extends AbstractController {
 
   @GetMapping("/articles/{uuid}")
   public String view(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Article article = (Article) service.get(uuid);
+    List<Locale> availableLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, article.getLabel().getLocales());
+
     model.addAttribute("article", article);
-    model.addAttribute("availableLanguages", article.getLabel().getLocales());
+    model.addAttribute("availableLanguages", availableLanguages);
 
     LinkedHashSet<FileResource> relatedFileResources = service.getRelatedFileResources(article);
     model.addAttribute("relatedFileResources", relatedFileResources);

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
@@ -127,10 +127,10 @@ public class CollectionsController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) throws HttpException {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     Collection collection = cudamiCollectionsClient.getCollection(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, collection.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("collection", collection);
 
     return "collections/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
@@ -73,9 +73,15 @@ public class CollectionsController extends AbstractController {
 
   @GetMapping("/collections/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) throws HttpException {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Collection collection = cudamiCollectionsClient.getCollection(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, collection.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("uuid", collection.getUuid());
+
     return "collections/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ContentTreesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ContentTreesController.java
@@ -74,9 +74,15 @@ public class ContentTreesController extends AbstractController {
 
   @RequestMapping(value = "/contenttrees/{uuid}/edit", method = RequestMethod.GET)
   public String edit(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     ContentTree contentTree = service.get(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, contentTree.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("uuid", contentTree.getUuid());
+
     return "contenttrees/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ContentTreesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ContentTreesController.java
@@ -7,13 +7,17 @@ import de.digitalcollections.commons.springmvc.controller.AbstractController;
 import de.digitalcollections.cudami.admin.backend.api.repository.LocaleRepository;
 import de.digitalcollections.cudami.admin.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.admin.business.api.service.identifiable.entity.ContentTreeService;
+import de.digitalcollections.cudami.admin.util.LanguageSortingHelper;
 import de.digitalcollections.model.api.identifiable.entity.ContentTree;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
+import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -37,11 +41,16 @@ public class ContentTreesController extends AbstractController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ContentTreesController.class);
 
+  LanguageSortingHelper languageSortingHelper;
   LocaleRepository localeRepository;
   ContentTreeService service;
 
   @Autowired
-  public ContentTreesController(LocaleRepository localeRepository, ContentTreeService service) {
+  public ContentTreesController(
+      LanguageSortingHelper languageSortingHelper,
+      LocaleRepository localeRepository,
+      ContentTreeService service) {
+    this.languageSortingHelper = languageSortingHelper;
     this.localeRepository = localeRepository;
     this.service = service;
   }
@@ -117,8 +126,12 @@ public class ContentTreesController extends AbstractController {
 
   @GetMapping("/contenttrees/{uuid}")
   public String view(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     ContentTree contentTree = (ContentTree) service.get(uuid);
-    model.addAttribute("availableLanguages", contentTree.getLabel().getLocales());
+    List<Locale> availableLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, contentTree.getLabel().getLocales());
+
+    model.addAttribute("availableLanguages", availableLanguages);
     model.addAttribute("contentTree", contentTree);
 
     return "contenttrees/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ContentTreesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ContentTreesController.java
@@ -128,10 +128,10 @@ public class ContentTreesController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     ContentTree contentTree = (ContentTree) service.get(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, contentTree.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("contentTree", contentTree);
 
     return "contenttrees/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CorporationsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CorporationsController.java
@@ -73,9 +73,15 @@ public class CorporationsController extends AbstractController {
 
   @GetMapping("/corporations/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) throws HttpException {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Corporation corporation = cudamiCorporationsClient.getCorporation(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, corporation.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("uuid", corporation.getUuid());
+
     return "corporations/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CorporationsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CorporationsController.java
@@ -6,15 +6,19 @@ import de.digitalcollections.commons.springdata.domain.PageableConverter;
 import de.digitalcollections.commons.springmvc.controller.AbstractController;
 import de.digitalcollections.cudami.admin.backend.api.repository.LocaleRepository;
 import de.digitalcollections.cudami.admin.business.api.service.exceptions.IdentifiableServiceException;
+import de.digitalcollections.cudami.admin.util.LanguageSortingHelper;
 import de.digitalcollections.cudami.client.CudamiCorporationsClient;
 import de.digitalcollections.cudami.client.exceptions.HttpException;
 import de.digitalcollections.model.api.identifiable.entity.Corporation;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
+import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -36,12 +40,16 @@ public class CorporationsController extends AbstractController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CorporationsController.class);
 
+  LanguageSortingHelper languageSortingHelper;
   LocaleRepository localeRepository;
   CudamiCorporationsClient cudamiCorporationsClient;
 
   @Autowired
   public CorporationsController(
-      LocaleRepository localeRepository, CudamiCorporationsClient cudamiCorporationsClient) {
+      LanguageSortingHelper languageSortingHelper,
+      LocaleRepository localeRepository,
+      CudamiCorporationsClient cudamiCorporationsClient) {
+    this.languageSortingHelper = languageSortingHelper;
     this.localeRepository = localeRepository;
     this.cudamiCorporationsClient = cudamiCorporationsClient;
   }
@@ -117,9 +125,14 @@ public class CorporationsController extends AbstractController {
 
   @GetMapping("/corporations/{uuid}")
   public String view(@PathVariable UUID uuid, Model model) throws HttpException {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Corporation corporation = cudamiCorporationsClient.getCorporation(uuid);
-    model.addAttribute("availableLanguages", corporation.getLabel().getLocales());
+    List<Locale> availableLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, corporation.getLabel().getLocales());
+
+    model.addAttribute("availableLanguages", availableLanguages);
     model.addAttribute("corporation", corporation);
+
     return "corporations/view";
   }
 }

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CorporationsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CorporationsController.java
@@ -127,10 +127,10 @@ public class CorporationsController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) throws HttpException {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     Corporation corporation = cudamiCorporationsClient.getCorporation(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, corporation.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("corporation", corporation);
 
     return "corporations/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ProjectsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ProjectsController.java
@@ -73,9 +73,15 @@ public class ProjectsController extends AbstractController {
 
   @GetMapping("/projects/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) throws HttpException {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Project project = cudamiProjectsClient.getProject(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, project.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("uuid", project.getUuid());
+
     return "projects/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ProjectsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ProjectsController.java
@@ -126,10 +126,10 @@ public class ProjectsController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) throws HttpException {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     Project project = cudamiProjectsClient.getProject(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, project.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("project", project);
 
     return "projects/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ProjectsController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/ProjectsController.java
@@ -6,15 +6,19 @@ import de.digitalcollections.commons.springdata.domain.PageableConverter;
 import de.digitalcollections.commons.springmvc.controller.AbstractController;
 import de.digitalcollections.cudami.admin.backend.api.repository.LocaleRepository;
 import de.digitalcollections.cudami.admin.business.api.service.exceptions.IdentifiableServiceException;
+import de.digitalcollections.cudami.admin.util.LanguageSortingHelper;
 import de.digitalcollections.cudami.client.CudamiProjectsClient;
 import de.digitalcollections.cudami.client.exceptions.HttpException;
 import de.digitalcollections.model.api.identifiable.entity.Project;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
+import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -36,12 +40,16 @@ public class ProjectsController extends AbstractController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProjectsController.class);
 
+  LanguageSortingHelper languageSortingHelper;
   LocaleRepository localeRepository;
   CudamiProjectsClient cudamiProjectsClient;
 
   @Autowired
   public ProjectsController(
-      LocaleRepository localeRepository, CudamiProjectsClient cudamiProjectsClient) {
+      LanguageSortingHelper languageSortingHelper,
+      LocaleRepository localeRepository,
+      CudamiProjectsClient cudamiProjectsClient) {
+    this.languageSortingHelper = languageSortingHelper;
     this.localeRepository = localeRepository;
     this.cudamiProjectsClient = cudamiProjectsClient;
   }
@@ -116,9 +124,14 @@ public class ProjectsController extends AbstractController {
 
   @GetMapping("/projects/{uuid}")
   public String view(@PathVariable UUID uuid, Model model) throws HttpException {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Project project = cudamiProjectsClient.getProject(uuid);
-    model.addAttribute("availableLanguages", project.getLabel().getLocales());
+    List<Locale> availableLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, project.getLabel().getLocales());
+
+    model.addAttribute("availableLanguages", availableLanguages);
     model.addAttribute("project", project);
+
     return "projects/view";
   }
 }

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/WebsitesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/WebsitesController.java
@@ -126,10 +126,10 @@ public class WebsitesController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     Website website = (Website) service.get(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, website.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("website", website);
 
     return "websites/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/WebsitesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/WebsitesController.java
@@ -7,13 +7,17 @@ import de.digitalcollections.commons.springmvc.controller.AbstractController;
 import de.digitalcollections.cudami.admin.backend.api.repository.LocaleRepository;
 import de.digitalcollections.cudami.admin.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.admin.business.api.service.identifiable.entity.WebsiteService;
+import de.digitalcollections.cudami.admin.util.LanguageSortingHelper;
 import de.digitalcollections.model.api.identifiable.entity.Website;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
+import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -35,11 +39,16 @@ public class WebsitesController extends AbstractController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebsitesController.class);
 
+  LanguageSortingHelper languageSortingHelper;
   LocaleRepository localeRepository;
   WebsiteService service;
 
   @Autowired
-  public WebsitesController(LocaleRepository localeRepository, WebsiteService service) {
+  public WebsitesController(
+      LanguageSortingHelper languageSortingHelper,
+      LocaleRepository localeRepository,
+      WebsiteService service) {
+    this.languageSortingHelper = languageSortingHelper;
     this.localeRepository = localeRepository;
     this.service = service;
   }
@@ -115,8 +124,12 @@ public class WebsitesController extends AbstractController {
 
   @GetMapping("/websites/{uuid}")
   public String view(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Website website = (Website) service.get(uuid);
-    model.addAttribute("availableLanguages", website.getLabel().getLocales());
+    List<Locale> availableLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, website.getLabel().getLocales());
+
+    model.addAttribute("availableLanguages", availableLanguages);
     model.addAttribute("website", website);
 
     return "websites/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/WebsitesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/WebsitesController.java
@@ -72,10 +72,16 @@ public class WebsitesController extends AbstractController {
 
   @GetMapping("/websites/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Website website = service.get(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, website.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("url", website.getUrl());
     model.addAttribute("uuid", website.getUuid());
+
     return "websites/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/ContentNodesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/ContentNodesController.java
@@ -141,10 +141,10 @@ public class ContentNodesController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     ContentNode contentNode = (ContentNode) service.get(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, contentNode.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("contentNode", contentNode);
 
     LinkedHashSet<FileResource> relatedFileResources = service.getRelatedFileResources(contentNode);

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/ContentNodesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/ContentNodesController.java
@@ -80,9 +80,15 @@ public class ContentNodesController extends AbstractController {
 
   @GetMapping("/contentnodes/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     ContentNode contentNode = (ContentNode) service.get(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, contentNode.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("uuid", contentNode.getUuid());
+
     return "contentnodes/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/ContentNodesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/ContentNodesController.java
@@ -7,15 +7,19 @@ import de.digitalcollections.commons.springmvc.controller.AbstractController;
 import de.digitalcollections.cudami.admin.backend.api.repository.LocaleRepository;
 import de.digitalcollections.cudami.admin.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.admin.business.api.service.identifiable.entity.parts.ContentNodeService;
+import de.digitalcollections.cudami.admin.util.LanguageSortingHelper;
 import de.digitalcollections.model.api.identifiable.entity.parts.ContentNode;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -38,11 +42,16 @@ public class ContentNodesController extends AbstractController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ContentNodesController.class);
 
+  LanguageSortingHelper languageSortingHelper;
   LocaleRepository localeRepository;
   ContentNodeService service;
 
   @Autowired
-  public ContentNodesController(LocaleRepository localeRepository, ContentNodeService service) {
+  public ContentNodesController(
+      LanguageSortingHelper languageSortingHelper,
+      LocaleRepository localeRepository,
+      ContentNodeService service) {
+    this.languageSortingHelper = languageSortingHelper;
     this.localeRepository = localeRepository;
     this.service = service;
   }
@@ -130,8 +139,12 @@ public class ContentNodesController extends AbstractController {
 
   @GetMapping("/contentnodes/{uuid}")
   public String view(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     ContentNode contentNode = (ContentNode) service.get(uuid);
-    model.addAttribute("availableLanguages", contentNode.getLabel().getLocales());
+    List<Locale> availableLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, contentNode.getLabel().getLocales());
+
+    model.addAttribute("availableLanguages", availableLanguages);
     model.addAttribute("contentNode", contentNode);
 
     LinkedHashSet<FileResource> relatedFileResources = service.getRelatedFileResources(contentNode);

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/WebpagesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/WebpagesController.java
@@ -146,10 +146,10 @@ public class WebpagesController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     Webpage webpage = (Webpage) service.get(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, webpage.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("webpage", webpage);
 
     LinkedHashSet<FileResource> relatedFileResources = service.getRelatedFileResources(webpage);

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/WebpagesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/parts/WebpagesController.java
@@ -80,9 +80,15 @@ public class WebpagesController extends AbstractController {
 
   @GetMapping("/webpages/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     Webpage webpage = (Webpage) service.get(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, webpage.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("uuid", webpage.getUuid());
+
     return "webpages/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/resource/FileResourcesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/resource/FileResourcesController.java
@@ -80,10 +80,16 @@ public class FileResourcesController extends AbstractController {
 
   @GetMapping("/fileresources/{uuid}/edit")
   public String edit(@PathVariable UUID uuid, Model model) {
+    final Locale displayLocale = LocaleContextHolder.getLocale();
     FileResource fileResource = service.get(uuid);
-    model.addAttribute("activeLanguage", localeRepository.getDefaultLanguage());
+    List<Locale> existingLanguages =
+        languageSortingHelper.sortLanguages(displayLocale, fileResource.getLabel().getLocales());
+
+    model.addAttribute("activeLanguage", existingLanguages.get(0));
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("filename", fileResource.getFilename());
     model.addAttribute("uuid", fileResource.getUuid());
+
     return "fileresources/edit";
   }
 

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/resource/FileResourcesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/resource/FileResourcesController.java
@@ -171,10 +171,10 @@ public class FileResourcesController extends AbstractController {
   public String view(@PathVariable UUID uuid, Model model) {
     final Locale displayLocale = LocaleContextHolder.getLocale();
     FileResource resource = service.get(uuid);
-    List<Locale> availableLanguages =
+    List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, resource.getLabel().getLocales());
 
-    model.addAttribute("availableLanguages", availableLanguages);
+    model.addAttribute("existingLanguages", existingLanguages);
     model.addAttribute("fileresource", resource);
 
     return "fileresources/view";

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/resource/FileResourcesController.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/resource/FileResourcesController.java
@@ -53,7 +53,9 @@ public class FileResourcesController extends AbstractController {
 
   @Autowired
   public FileResourcesController(
-      LanguageSortingHelper languageSortingHelper, LocaleRepository localeRepository, CudamiFileResourceService service) {
+      LanguageSortingHelper languageSortingHelper,
+      LocaleRepository localeRepository,
+      CudamiFileResourceService service) {
     this.languageSortingHelper = languageSortingHelper;
     this.localeRepository = localeRepository;
     this.service = service;

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/util/LanguageSortingHelper.java
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/java/de/digitalcollections/cudami/admin/util/LanguageSortingHelper.java
@@ -1,0 +1,26 @@
+package de.digitalcollections.cudami.admin.util;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+public class LanguageSortingHelper {
+  List<Locale> prioritisedSortedLanguages;
+
+  public LanguageSortingHelper(List<Locale> prioritisedSortedLanguages) {
+    this.prioritisedSortedLanguages = prioritisedSortedLanguages;
+  }
+
+  public List<Locale> sortLanguages(Locale displayLocale, List<Locale> languagesToSort) {
+    List<Locale> sortedLanguages =
+        prioritisedSortedLanguages.stream()
+            .filter(languagesToSort::contains)
+            .collect(Collectors.toList());
+    languagesToSort.stream()
+        .filter(l -> !prioritisedSortedLanguages.contains(l))
+        .sorted(Comparator.comparing(l -> l.getDisplayLanguage(displayLocale)))
+        .forEach(sortedLanguages::add);
+    return sortedLanguages;
+  }
+}

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/application.yml
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 cudami:
   defaultLocale-gui: en
+  prioritisedSortedLanguages: ''
   server:
     address: http://localhost:9000
     url: http://localhost:9000

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/articles/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/articles/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "article",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/articles/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/articles/view.html
@@ -41,12 +41,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${article}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/collections/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/collections/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "collection",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/collections/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/collections/view.html
@@ -41,12 +41,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${collection}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contentnodes/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contentnodes/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "contentNode",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contentnodes/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contentnodes/view.html
@@ -41,12 +41,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${contentNode}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contenttrees/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contenttrees/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "contentTree",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contenttrees/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/contenttrees/view.html
@@ -41,12 +41,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${contentTree}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/corporations/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/corporations/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "corporation",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/corporations/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/corporations/view.html
@@ -41,12 +41,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${corporation}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/fileresources/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/fileresources/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "fileResource",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/fileresources/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/fileresources/view.html
@@ -45,12 +45,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${fileresource}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/projects/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/projects/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "project",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/projects/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/projects/view.html
@@ -41,12 +41,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${project}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/webpages/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/webpages/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "webpage",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/webpages/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/webpages/view.html
@@ -41,12 +41,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${webpage}, ${language})"></div>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/websites/edit.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/websites/edit.html
@@ -15,6 +15,7 @@
         CudamiEditor({
           activeLanguage: /*[[${activeLanguage}]]*/,
           apiContextPath: /*[[@{/}]]*/ '',
+          existingLanguages: /*[[${existingLanguages}]]*/,
           id: "editor",
           type: "website",
           uiLocale: /*[[${#locale.language}]]*/,

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/websites/view.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/websites/view.html
@@ -45,12 +45,12 @@
       <div class="row main-content">
         <div class="col-sm-12">
           <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item" th:each="language,iter : ${availableLanguages}">
+            <li class="nav-item" th:each="language,iter : ${existingLanguages}">
               <a class="nav-link" th:classappend="${iter.index} == 0 ? active" th:href="${'#' + language}" data-toggle="tab" th:text="${language.getDisplayName(#locale)}" role="tab">language</a>
             </li>
           </ul>
           <div class="tab-content">
-            <div th:each="language,iter : ${availableLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
+            <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
               <div class="card">
                 <div class="card-body bg-light">
                   <div th:replace="fragments/identifiable::renderTeaser(${website}, ${language})"></div>

--- a/dc-cudami-editor/src/App.jsx
+++ b/dc-cudami-editor/src/App.jsx
@@ -8,6 +8,7 @@ const App = () => {
     <IdentifiableForm
       activeLanguage="en"
       debug={true}
+      existingLanguages={["de", "en"]}
       mockApi={true}
       type="webpage"
       uiLocale="en"

--- a/dc-cudami-editor/src/components/ArticleForm.jsx
+++ b/dc-cudami-editor/src/components/ArticleForm.jsx
@@ -39,7 +39,7 @@ const WebpageForm = props => {
             <FormIdInput id={props.identifiable.uuid} />
           )}
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -52,12 +52,12 @@ const WebpageForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/components/CollectionForm.jsx
+++ b/dc-cudami-editor/src/components/CollectionForm.jsx
@@ -41,7 +41,7 @@ const CollectionForm = props => {
             <FormIdInput id={props.identifiable.uuid} />
           )}
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -54,12 +54,12 @@ const CollectionForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/components/ContentNodeForm.jsx
+++ b/dc-cudami-editor/src/components/ContentNodeForm.jsx
@@ -40,7 +40,7 @@ const ContentNodeForm = props => {
             <FormIdInput id={props.identifiable.uuid} />
           )}
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -53,12 +53,12 @@ const ContentNodeForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/components/ContentTreeForm.jsx
+++ b/dc-cudami-editor/src/components/ContentTreeForm.jsx
@@ -40,7 +40,7 @@ const ContentTreeForm = props => {
             <FormIdInput id={props.identifiable.uuid} />
           )}
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -53,12 +53,12 @@ const ContentTreeForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/components/CorporationForm.jsx
+++ b/dc-cudami-editor/src/components/CorporationForm.jsx
@@ -41,7 +41,7 @@ const CorporationForm = props => {
             <FormIdInput id={props.identifiable.uuid} />
           )}
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -54,12 +54,12 @@ const CorporationForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/components/FileResourceForm.jsx
+++ b/dc-cudami-editor/src/components/FileResourceForm.jsx
@@ -45,7 +45,7 @@ const FileResourceForm = props => {
         <Col sm="12">
           <FormIdInput id={props.identifiable.uuid} />
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -58,12 +58,12 @@ const FileResourceForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/components/IdentifiableForm.jsx
+++ b/dc-cudami-editor/src/components/IdentifiableForm.jsx
@@ -38,6 +38,7 @@ class IdentifiableForm extends Component {
     this.state = {
       activeLanguage: props.activeLanguage,
       availableLanguages: [],
+      existingLanguages: props.existingLanguages || [props.activeLanguage],
       identifiable: null,
       invalidLanguages: [],
       modalsOpen: {
@@ -91,6 +92,7 @@ class IdentifiableForm extends Component {
       availableLanguages: this.state.availableLanguages.filter(
         language => language.name !== selectedLanguage.name
       ),
+      existingLanguages: [...this.state.existingLanguages, selectedLanguage.name],
       identifiable: {
         ...this.state.identifiable,
         label: {
@@ -144,6 +146,7 @@ class IdentifiableForm extends Component {
         activeLanguage={this.state.activeLanguage}
         apiContextPath={this.props.apiContextPath}
         canAddLanguage={this.state.availableLanguages.length > 0}
+        existingLanguages={this.state.existingLanguages}
         identifiable={this.state.identifiable}
         onAddLanguage={this.toggleModal}
         onSubmit={this.submitIdentifiable}

--- a/dc-cudami-editor/src/components/WebpageForm.jsx
+++ b/dc-cudami-editor/src/components/WebpageForm.jsx
@@ -39,7 +39,7 @@ const WebpageForm = props => {
             <FormIdInput id={props.identifiable.uuid} />
           )}
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -52,12 +52,12 @@ const WebpageForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/components/WebsiteForm.jsx
+++ b/dc-cudami-editor/src/components/WebsiteForm.jsx
@@ -47,7 +47,7 @@ const WebsiteForm = props => {
             url={props.identifiable.url}
           />
           <Nav tabs>
-            {Object.entries(props.identifiable.label).map(([language]) => (
+            {props.existingLanguages.map((language) => (
               <LanguageTab
                 activeLanguage={props.activeLanguage}
                 key={language}
@@ -60,12 +60,12 @@ const WebsiteForm = props => {
             )}
           </Nav>
           <TabContent activeTab={props.activeLanguage}>
-            {Object.entries(props.identifiable.label).map(
-              ([language, text]) => (
+            {props.existingLanguages.map(
+              (language) => (
                 <LanguageTabContent
                   description={props.identifiable.description[language]}
                   key={language}
-                  label={text}
+                  label={props.identifiable.label[language]}
                   language={language}
                   onUpdate={(updateKey, updateValue) =>
                     props.onUpdate({

--- a/dc-cudami-editor/src/lib/CudamiEditor.jsx
+++ b/dc-cudami-editor/src/lib/CudamiEditor.jsx
@@ -10,6 +10,7 @@ export default function(config) {
       activeLanguage={config.activeLanguage}
       apiContextPath={config.apiContextPath}
       debug={config.debug}
+      existingLanguages={config.existingLanguages}
       parentType={config.parentType}
       parentUuid={config.parentUuid}
       type={config.type}

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <version.commons-dbcp2>2.7.0</version.commons-dbcp2>
     <version.commons-lang3>3.9</version.commons-lang3>
-    <version.dc-model>4.0.0</version.dc-model>
+    <version.dc-model>4.0.1</version.dc-model>
     <version.feign>10.6.0</version.feign>
     <version.feign-form-spring>3.5.0</version.feign-form-spring>
     <version.flyway>6.0.8</version.flyway>


### PR DESCRIPTION
This PR changes the sorting of the language tabs in the view and the edit pages to be sorted alphabetically. Additionally it's possible to define prioritised languages, that will be sorted to the front.