### PR TITLE
Fix v1 webpage controller

### DIFF
--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
@@ -113,46 +113,41 @@ public class V1WebpageController {
   private JSONObject convertLocalizedStructuredContentJson(JSONObject json) {
     JSONObject localizedStructuredContent = new JSONObject();
     JSONObject documents = new JSONObject();
-    json.keySet()
-        .forEach(
-            (locale) -> {
-              if (locale.equals("de")) {
-                documents.put("de_DE", json.get(locale));
-              } else {
-                documents.put(locale, json.get(locale));
-              }
-            });
+    for (String locale : json.keySet()) {
+      if (locale.equals("de")) {
+        documents.put("de_DE", json.get(locale));
+      } else {
+        documents.put(locale, json.get(locale));
+      }
+    }
     localizedStructuredContent.put("documents", documents);
     return localizedStructuredContent;
   }
 
   private void convertLocalizedStructuredContentXml(Element xml) {
     List<Element> contents = xml.getChildren("entry");
-    contents.forEach(
-        (entry) -> {
-          Element locale = entry.getChild("locale");
-          if (locale.getText().equals("de")) {
-            locale.setText("de_DE");
-          }
-        });
+    for (Element entry : contents) {
+      Element locale = entry.getChild("locale");
+      if (locale.getText().equals("de")) {
+        locale.setText("de_DE");
+      }
+    }
     xml.setContent(createDocumentsElement(contents));
   }
 
   private JSONObject convertLocalizedTextJson(JSONObject json) {
     JSONObject result = new JSONObject();
     JSONArray translations = new JSONArray();
-    json.keySet()
-        .forEach(
-            (locale) -> {
-              JSONObject translation = new JSONObject();
-              if (locale.equals("de")) {
-                translation.put("locale", "de_DE");
-              } else {
-                translation.put("locale", locale);
-              }
-              translation.put("text", json.get(locale));
-              translations.put(translation);
-            });
+    for (String locale : json.keySet()) {
+      JSONObject translation = new JSONObject();
+      if (locale.equals("de")) {
+        translation.put("locale", "de_DE");
+      } else {
+        translation.put("locale", locale);
+      }
+      translation.put("text", json.get(locale));
+      translations.put(translation);
+    }
     result.put("translations", translations);
     return result;
   }
@@ -160,29 +155,27 @@ public class V1WebpageController {
   private void convertLocalizedTextXml(Element xml) {
     List<Element> contents = xml.getChildren("entry");
     Element translations = new Element("translations");
-    contents.forEach(
-        (entry) -> {
-          Element translation = new Element("translation");
-          Element locale = entry.getChild("locale");
-          if (locale.getText().equals("de")) {
-            translation.addContent(locale.clone().setText("de_DE"));
-          } else {
-            translation.addContent(locale.clone());
-          }
-          Element text = new Element("text");
-          text.addContent(entry.getChild("string").getText());
-          translation.addContent(text);
-          translations.addContent(translation);
-        });
+    for (Element entry : contents) {
+      Element translation = new Element("translation");
+      Element locale = entry.getChild("locale");
+      if (locale.getText().equals("de")) {
+        translation.addContent(locale.clone().setText("de_DE"));
+      } else {
+        translation.addContent(locale.clone());
+      }
+      Element text = new Element("text");
+      text.addContent(entry.getChild("string").getText());
+      translation.addContent(text);
+      translations.addContent(translation);
+    }
     xml.setContent(translations);
   }
 
   private Element createDocumentsElement(List<Element> contents) {
     Element documents = new Element("documents");
-    contents.forEach(
-        (content) -> {
-          documents.addContent(content.clone());
-        });
+    for (Element entry : contents) {
+      documents.addContent(entry.clone());
+    }
     return documents;
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
@@ -117,8 +117,8 @@ public class V1WebpageController {
   }
 
   private void convertLocalizedStructuredContentXml(Element xml) {
-    Element content = xml.getChild("entry");
-    xml.setContent(createDocumentsElement(content));
+    List<Element> contents = xml.getChildren("entry");
+    xml.setContent(createDocumentsElement(contents));
   }
 
   private JSONObject convertLocalizedTextJson(JSONObject json) {
@@ -151,9 +151,12 @@ public class V1WebpageController {
     xml.setContent(translations);
   }
 
-  private Element createDocumentsElement(Element content) {
+  private Element createDocumentsElement(List<Element> contents) {
     Element documents = new Element("documents");
-    documents.setContent(content.clone());
+    contents.forEach(
+        (content) -> {
+          documents.addContent(content.clone());
+        });
     return documents;
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/v1/identifiable/entity/parts/V1WebpageController.java
@@ -112,12 +112,29 @@ public class V1WebpageController {
 
   private JSONObject convertLocalizedStructuredContentJson(JSONObject json) {
     JSONObject localizedStructuredContent = new JSONObject();
-    localizedStructuredContent.put("documents", json);
+    JSONObject documents = new JSONObject();
+    json.keySet()
+        .forEach(
+            (locale) -> {
+              if (locale.equals("de")) {
+                documents.put("de_DE", json.get(locale));
+              } else {
+                documents.put(locale, json.get(locale));
+              }
+            });
+    localizedStructuredContent.put("documents", documents);
     return localizedStructuredContent;
   }
 
   private void convertLocalizedStructuredContentXml(Element xml) {
     List<Element> contents = xml.getChildren("entry");
+    contents.forEach(
+        (entry) -> {
+          Element locale = entry.getChild("locale");
+          if (locale.getText().equals("de")) {
+            locale.setText("de_DE");
+          }
+        });
     xml.setContent(createDocumentsElement(contents));
   }
 
@@ -128,7 +145,11 @@ public class V1WebpageController {
         .forEach(
             (locale) -> {
               JSONObject translation = new JSONObject();
-              translation.put("locale", locale);
+              if (locale.equals("de")) {
+                translation.put("locale", "de_DE");
+              } else {
+                translation.put("locale", locale);
+              }
               translation.put("text", json.get(locale));
               translations.put(translation);
             });
@@ -142,7 +163,12 @@ public class V1WebpageController {
     contents.forEach(
         (entry) -> {
           Element translation = new Element("translation");
-          translation.addContent(entry.getChild("locale").clone());
+          Element locale = entry.getChild("locale");
+          if (locale.getText().equals("de")) {
+            translation.addContent(locale.clone().setText("de_DE"));
+          } else {
+            translation.addContent(locale.clone());
+          }
           Element text = new Element("text");
           text.addContent(entry.getChild("string").getText());
           translation.addContent(text);


### PR DESCRIPTION
This PR fixes two bugs in the `V1WebpageController`:

* if there were multiple languages in the fields `description` and `text`, only one was converted to the old structure of json and xml
* in version 1 of the endpoints, `de_DE` was expected and not `de`, so it's converted