### PR TITLE
Fix attribute rendering

### DIFF
--- a/dc-cudami-client/src/main/resources/templates/cudami/fragments/structuredcontent.html
+++ b/dc-cudami-client/src/main/resources/templates/cudami/fragments/structuredcontent.html
@@ -127,7 +127,15 @@
             <th:block th:text="' ' + ${attribute.key} + '='"></th:block>"<th:block th:text="${attribute.value}"></th:block>"</th:block>
           <th:block th:utext="'>'"></th:block>
         </th:block>
-        <th:block th:unless="${mark.type} == 'link'" th:utext="'<' + ${mark.type} + '>'"></th:block>
+        <th:block th:unless="${mark.type} == 'link'">
+          <th:block th:switch="${mark.type}">
+            <th:block th:case="'strikethrough'" th:utext="'<s>'"></th:block>
+            <th:block th:case="'subscript'" th:utext="'<sub>'"></th:block>
+            <th:block th:case="'superscript'" th:utext="'<sup>'"></th:block>
+            <th:block th:case="'underline'" th:utext="'<u>'"></th:block>
+            <th:block th:case="*" th:utext="'<' + ${mark.type} + '>'"></th:block>
+          </th:block>
+        </th:block>
       </th:block>
     </th:block>
     <th:block th:utext="${block.text}">...</th:block>
@@ -137,12 +145,17 @@
           <th:block th:utext="'</a>'"></th:block>
         </th:block>
         <th:block th:unless="${mark.type} == 'link'">
-          <th:block th:utext="'</' + ${mark.type} + '>'"></th:block>
+          <th:block th:switch="${mark.type}">
+            <th:block th:case="'strikethrough'" th:utext="'</s>'"></th:block>
+            <th:block th:case="'subscript'" th:utext="'</sub>'"></th:block>
+            <th:block th:case="'superscript'" th:utext="'</sup>'"></th:block>
+            <th:block th:case="'underline'" th:utext="'</u>'"></th:block>
+            <th:block th:case="*" th:utext="'</' + ${mark.type} + '>'"></th:block>
+          </th:block>
         </th:block>
       </th:block>
     </th:block>
   </th:block>
 </th:block>
-
 </body>
 </html>

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageHtmlController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageHtmlController.java
@@ -36,19 +36,22 @@ public class WebpageHtmlController {
       method = RequestMethod.GET)
   public String getWebpageAsHtml(
       @ApiPathParam(
-          description =
-          "UUID of the webpage, e.g. <tt>599a120c-2dd5-11e8-b467-0ed5f89f718b</tt>")
-      @PathVariable("uuid") UUID uuid,
+              description =
+                  "UUID of the webpage, e.g. <tt>599a120c-2dd5-11e8-b467-0ed5f89f718b</tt>")
+          @PathVariable("uuid")
+          UUID uuid,
       @ApiQueryParam(
-          name = "pLocale",
-          description =
-          "Desired locale, e.g. <tt>de_DE</tt>. If unset, contents in all languages will be returned")
-      @RequestParam(name = "pLocale", required = false) Locale pLocale,
+              name = "pLocale",
+              description =
+                  "Desired locale, e.g. <tt>de_DE</tt>. If unset, contents in all languages will be returned")
+          @RequestParam(name = "pLocale", required = false)
+          Locale pLocale,
       @ApiQueryParam(
-          name = "renderLabel",
-          description =
-          "Switch for (de)activating rendering of webpage label. If 'false', label rendering will be skipped")
-      @RequestParam(name = "renderLabel", required = false, defaultValue = "true") String renderLabel,
+              name = "renderLabel",
+              description =
+                  "Switch for (de)activating rendering of webpage label. If 'false', label rendering will be skipped")
+          @RequestParam(name = "renderLabel", required = false, defaultValue = "true")
+          String renderLabel,
       Model model)
       throws IdentifiableServiceException {
     Webpage webpage;


### PR DESCRIPTION
This PR fixes the rendering of the mark attributes `strikethrough`, `subscript`, `superscript` and `underline`.