### PR TITLE
fix sql of contentnode select

### DIFF
--- a/dc-cudami-admin/dc-cudami-admin-backend-api/pom.xml
+++ b/dc-cudami-admin/dc-cudami-admin-backend-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-admin</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Admin (Backend API)</name>

--- a/dc-cudami-admin/dc-cudami-admin-backend-rest/pom.xml
+++ b/dc-cudami-admin/dc-cudami-admin-backend-rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-admin</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Admin (Backend IMPL REST)</name>

--- a/dc-cudami-admin/dc-cudami-admin-business/pom.xml
+++ b/dc-cudami-admin/dc-cudami-admin-business/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-admin</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Admin (Business)</name>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-admin</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Admin (Webapp)</name>

--- a/dc-cudami-admin/pom.xml
+++ b/dc-cudami-admin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Admin</name>

--- a/dc-cudami-client/pom.xml
+++ b/dc-cudami-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Client</name>

--- a/dc-cudami-server/dc-cudami-server-backend-api/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-server</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Server (Backend API)</name>

--- a/dc-cudami-server/dc-cudami-server-backend-file/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-file/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-server</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
   
   <name>DigitalCollections: cudami Server (Backend IMPL File)</name>

--- a/dc-cudami-server/dc-cudami-server-backend-inmemory/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-inmemory/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-server</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Server (Backend IMPL InMemory)</name>

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-server</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Server (Backend IMPL JDBI PostgreSql)</name>

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/parts/ContentNodeRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/parts/ContentNodeRepositoryImpl.java
@@ -161,7 +161,7 @@ public class ContentNodeRepositoryImpl<E extends Entity>
   public ContentNode getParent(UUID uuid) {
     String query =
         "SELECT"
-            + " uuid, label, description, created, last_modified,"
+            + " uuid, label, description, created, last_modified"
             + " FROM contentnodes"
             + " INNER JOIN contentnode_contentnodes cc ON uuid = cc.parent_contentnode_uuid"
             + " WHERE cc.child_contentnode_uuid = :uuid";

--- a/dc-cudami-server/dc-cudami-server-business/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-business/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-server</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Server (Business)</name>

--- a/dc-cudami-server/dc-cudami-server-webapp/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-webapp/pom.xml
@@ -230,9 +230,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <classifier>exec</classifier>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/dc-cudami-server/dc-cudami-server-webapp/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-server</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Server (Webapp)</name>
@@ -161,6 +161,38 @@
       <groupId>org.webjars</groupId>
       <artifactId>hal-browser</artifactId>
     </dependency>
+    
+    <!-- direct declarations to force version -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-parameter-names</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.10.1</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -198,6 +230,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <classifier>exec</classifier>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/dc-cudami-server/pom.xml
+++ b/dc-cudami-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Server</name>

--- a/dc-cudami-templates/pom.xml
+++ b/dc-cudami-templates/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Templates</name>

--- a/dc-cudami-templates/template-website-springboot/pom.xml
+++ b/dc-cudami-templates/template-website-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.cudami</groupId>
     <artifactId>dc-cudami-templates</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: cudami Templates (Website Spring Boot)</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>de.digitalcollections.cudami</groupId>
   <artifactId>dc-cudami</artifactId>
-  <version>3.2.2</version>
+  <version>3.2.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>DigitalCollections: cudami</name>


### PR DESCRIPTION
- bump version to next snapshot
- fix sql typo
- fix jackson version conflict (2.9 vs 2.10) by directly declaring 2.10 version; version in all dependencies have to be bumped to version 2.10 of jackson