### PR TITLE
Refactor forms to be real forms with validation and correct types

### DIFF
--- a/dc-cudami-editor/src/components/modals/IframeAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/IframeAdderModal.jsx
@@ -2,11 +2,11 @@ import {publish, subscribe} from 'pubsub-js'
 import React, {Component} from 'react'
 import {
   Button,
+  Form,
   FormGroup,
   Input,
   Modal,
   ModalBody,
-  ModalFooter,
   ModalHeader,
 } from 'reactstrap'
 import {withTranslation} from 'react-i18next'
@@ -42,36 +42,42 @@ class IframeAdderModal extends Component {
           {t('insert.iframe')}
         </ModalHeader>
         <ModalBody>
-          <FormGroup>
-            <Input
-              onChange={evt => this.setState({src: evt.target.value})}
-              placeholder="URL"
-              type="text"
-              value={this.state.src}
-            />
-          </FormGroup>
-          <FormGroup>
-            <Input
-              onChange={evt => this.setState({width: evt.target.value})}
-              placeholder={t('width')}
-              type="text"
-              value={this.state.width}
-            />
-          </FormGroup>
-          <FormGroup className="mb-0">
-            <Input
-              onChange={evt => this.setState({height: evt.target.value})}
-              placeholder={t('height')}
-              type="text"
-              value={this.state.height}
-            />
-          </FormGroup>
+          <Form
+            onSubmit={evt => {
+              evt.preventDefault()
+              this.addIframeToEditor()
+            }}
+          >
+            <FormGroup>
+              <Input
+                onChange={evt => this.setState({src: evt.target.value})}
+                placeholder="URL"
+                required
+                type="url"
+                value={this.state.src}
+              />
+            </FormGroup>
+            <FormGroup>
+              <Input
+                onChange={evt => this.setState({width: evt.target.value})}
+                placeholder={t('width')}
+                type="text"
+                value={this.state.width}
+              />
+            </FormGroup>
+            <FormGroup className="mb-0">
+              <Input
+                onChange={evt => this.setState({height: evt.target.value})}
+                placeholder={t('height')}
+                type="text"
+                value={this.state.height}
+              />
+            </FormGroup>
+            <Button className="float-right mt-3" color="primary" type="submit">
+              {t('add')}
+            </Button>
+          </Form>
         </ModalBody>
-        <ModalFooter>
-          <Button color="primary" onClick={this.addIframeToEditor}>
-            {t('add')}
-          </Button>
-        </ModalFooter>
       </Modal>
     )
   }

--- a/dc-cudami-editor/src/components/modals/IframeAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/IframeAdderModal.jsx
@@ -8,6 +8,7 @@ import {
   Modal,
   ModalBody,
   ModalHeader,
+  FormText,
 } from 'reactstrap'
 import {withTranslation} from 'react-i18next'
 
@@ -64,6 +65,11 @@ class IframeAdderModal extends Component {
                 type="text"
                 value={this.state.width}
               />
+              <FormText className="ml-1">
+                {t('forExample')}
+                <code className="ml-1">500</code>, <code>300px</code> or
+                <code className="ml-1">50%</code>
+              </FormText>
             </FormGroup>
             <FormGroup className="mb-0">
               <Input
@@ -72,6 +78,11 @@ class IframeAdderModal extends Component {
                 type="text"
                 value={this.state.height}
               />
+              <FormText className="ml-1">
+                {t('forExample')}
+                <code className="ml-1">500</code>, <code>300px</code> or
+                <code className="ml-1">50%</code>
+              </FormText>
             </FormGroup>
             <Button className="float-right mt-3" color="primary" type="submit">
               {t('add')}

--- a/dc-cudami-editor/src/components/modals/LanguageAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/LanguageAdderModal.jsx
@@ -1,12 +1,5 @@
 import React, {Component} from 'react'
-import {
-  Button,
-  Input,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-} from 'reactstrap'
+import {Button, Form, Input, Modal, ModalBody, ModalHeader} from 'reactstrap'
 import {withTranslation} from 'react-i18next'
 
 class LanguageAdderModal extends Component {
@@ -15,7 +8,7 @@ class LanguageAdderModal extends Component {
     this.state = {}
   }
 
-  add = () => {
+  addLanguage = () => {
     const selectedLanguage = this.props.availableLanguages.filter(
       language => language.name === this.state.selectedLanguage
     )[0]
@@ -42,22 +35,27 @@ class LanguageAdderModal extends Component {
       >
         <ModalHeader toggle={this.toggle}>{t('chooseLanguage')}</ModalHeader>
         <ModalBody>
-          <Input
-            onChange={evt => this.setLanguage(evt.target.value)}
-            type="select"
+          <Form
+            onSubmit={evt => {
+              evt.preventDefault()
+              this.addLanguage()
+            }}
           >
-            {this.props.availableLanguages.map(language => (
-              <option key={language.name} value={language.name}>
-                {language.displayName}
-              </option>
-            ))}
-          </Input>
+            <Input
+              onChange={evt => this.setLanguage(evt.target.value)}
+              type="select"
+            >
+              {this.props.availableLanguages.map(language => (
+                <option key={language.name} value={language.name}>
+                  {language.displayName}
+                </option>
+              ))}
+            </Input>
+            <Button className="float-right mt-3" color="primary" type="submit">
+              {t('add')}
+            </Button>
+          </Form>
         </ModalBody>
-        <ModalFooter>
-          <Button color="primary" onClick={this.add}>
-            {t('add')}
-          </Button>
-        </ModalFooter>
       </Modal>
     )
   }

--- a/dc-cudami-editor/src/components/modals/LinkAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/LinkAdderModal.jsx
@@ -2,11 +2,11 @@ import {publish, subscribe} from 'pubsub-js'
 import React, {Component} from 'react'
 import {
   Button,
+  Form,
   FormGroup,
   Input,
   Modal,
   ModalBody,
-  ModalFooter,
   ModalHeader,
 } from 'reactstrap'
 import {withTranslation} from 'react-i18next'
@@ -40,28 +40,34 @@ class LinkAdderModal extends Component {
           {t('insertLink')}
         </ModalHeader>
         <ModalBody>
-          <FormGroup>
-            <Input
-              onChange={evt => this.setState({href: evt.target.value})}
-              placeholder="URL"
-              type="url"
-              value={this.state.href}
-            />
-          </FormGroup>
-          <FormGroup className="mb-0">
-            <Input
-              onChange={evt => this.setState({title: evt.target.value})}
-              placeholder={t('label')}
-              type="text"
-              value={this.state.height}
-            />
-          </FormGroup>
+          <Form
+            onSubmit={evt => {
+              evt.preventDefault()
+              this.addLinkToEditor()
+            }}
+          >
+            <FormGroup>
+              <Input
+                onChange={evt => this.setState({href: evt.target.value})}
+                placeholder="URL"
+                required
+                type="url"
+                value={this.state.href}
+              />
+            </FormGroup>
+            <FormGroup className="mb-0">
+              <Input
+                onChange={evt => this.setState({title: evt.target.value})}
+                placeholder={t('label')}
+                type="text"
+                value={this.state.height}
+              />
+            </FormGroup>
+            <Button className="float-right mt-3" color="primary" type="submit">
+              {t('add')}
+            </Button>
+          </Form>
         </ModalBody>
-        <ModalFooter>
-          <Button color="primary" onClick={this.addLinkToEditor}>
-            {t('add')}
-          </Button>
-        </ModalFooter>
       </Modal>
     )
   }

--- a/dc-cudami-editor/src/components/modals/TableAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/TableAdderModal.jsx
@@ -54,7 +54,9 @@ class TableAdderModal extends Component {
               <Input
                 id="table-rows"
                 min="1"
-                onChange={evt => this.setState({rows: evt.target.value})}
+                onChange={evt =>
+                  this.setState({rows: parseInt(evt.target.value)})
+                }
                 required
                 type="number"
                 value={this.state.rows}
@@ -67,7 +69,9 @@ class TableAdderModal extends Component {
               <Input
                 id="table-columns"
                 min="1"
-                onChange={evt => this.setState({columns: evt.target.value})}
+                onChange={evt =>
+                  this.setState({columns: parseInt(evt.target.value)})
+                }
                 required
                 type="number"
                 value={this.state.columns}

--- a/dc-cudami-editor/src/components/modals/TableAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/TableAdderModal.jsx
@@ -2,12 +2,12 @@ import {publish, subscribe} from 'pubsub-js'
 import React, {Component} from 'react'
 import {
   Button,
+  Form,
   FormGroup,
   Input,
   Label,
   Modal,
   ModalBody,
-  ModalFooter,
   ModalHeader,
 } from 'reactstrap'
 import {withTranslation} from 'react-i18next'
@@ -41,34 +41,43 @@ class TableAdderModal extends Component {
           {t('insert.table')}
         </ModalHeader>
         <ModalBody>
-          <FormGroup>
-            <Label className="font-weight-bold" for="rows">
-              {t('numberOfRows')}
-            </Label>
-            <Input
-              id="rows"
-              onChange={evt => this.setState({rows: evt.target.value})}
-              type="text"
-              value={this.state.rows}
-            />
-          </FormGroup>
-          <FormGroup className="mb-0">
-            <Label className="font-weight-bold" for="columns">
-              {t('numberOfColumns')}
-            </Label>
-            <Input
-              id="columns"
-              onChange={evt => this.setState({columns: evt.target.value})}
-              type="text"
-              value={this.state.columns}
-            />
-          </FormGroup>
+          <Form
+            onSubmit={evt => {
+              evt.preventDefault()
+              this.addTableToEditor()
+            }}
+          >
+            <FormGroup>
+              <Label className="font-weight-bold" for="table-rows">
+                {t('numberOfRows')}
+              </Label>
+              <Input
+                id="table-rows"
+                min="1"
+                onChange={evt => this.setState({rows: evt.target.value})}
+                required
+                type="number"
+                value={this.state.rows}
+              />
+            </FormGroup>
+            <FormGroup className="mb-0">
+              <Label className="font-weight-bold" for="table-columns">
+                {t('numberOfColumns')}
+              </Label>
+              <Input
+                id="table-columns"
+                min="1"
+                onChange={evt => this.setState({columns: evt.target.value})}
+                required
+                type="number"
+                value={this.state.columns}
+              />
+            </FormGroup>
+            <Button className="float-right mt-3" color="primary" type="submit">
+              {t('add')}
+            </Button>
+          </Form>
         </ModalBody>
-        <ModalFooter>
-          <Button color="primary" onClick={this.addTableToEditor}>
-            {t('add')}
-          </Button>
-        </ModalFooter>
       </Modal>
     )
   }

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -35,6 +35,7 @@
     "editWebpage": "Webseite bearbeiten",
     "editWebsite": "Website {{ url }} bearbeiten",
     "file": "Datei",
+    "forExample": "z.B.",
     "height": "Höhe",
     "history": {
       "redo": "Letzte rückgängig gemachte Änderung wiederholen",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -35,6 +35,7 @@
     "editWebpage": "Edit webpage",
     "editWebsite": "Edit website {{ url }}",
     "file": "File",
+    "forExample": "e.g.",
     "height": "Height",
     "history": {
       "redo": "Redo last undone change",


### PR DESCRIPTION
This PR refactores the forms in the modals to be real forms with a `form` element at the top - this is important to use HTML5 form validation. Additionally the input types are optimized.