### PR TITLE
Update bootswatch

### DIFF
--- a/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
@@ -25,7 +25,7 @@
     <version.dc-commons-springdata>4.1.1-SNAPSHOT</version.dc-commons-springdata>
     <version.dc-commons-springmvc>4.1.2-SNAPSHOT</version.dc-commons-springmvc>
     <version.thymeleaf-spring-data-dialect>3.4.1</version.thymeleaf-spring-data-dialect>
-    <version.webjar-bootstrap>4.3.1</version.webjar-bootstrap>
+    <version.webjar-bootstrap>4.4.1</version.webjar-bootstrap>
     <version.webjar-bootswatch>4.2.1</version.webjar-bootswatch>
     <version.webjar-fontawesome>5.12.0</version.webjar-fontawesome>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
@@ -26,7 +26,7 @@
     <version.dc-commons-springmvc>4.1.2-SNAPSHOT</version.dc-commons-springmvc>
     <version.thymeleaf-spring-data-dialect>3.4.1</version.thymeleaf-spring-data-dialect>
     <version.webjar-bootstrap>4.4.1</version.webjar-bootstrap>
-    <version.webjar-bootswatch>4.2.1</version.webjar-bootswatch>
+    <version.webjar-bootswatch>4.4.1</version.webjar-bootswatch>
     <version.webjar-fontawesome>5.12.0</version.webjar-fontawesome>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -190,11 +190,6 @@
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>
-      <artifactId>bootswatch</artifactId>
-      <version>${version.webjar-bootswatch}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.webjars</groupId>
       <artifactId>font-awesome</artifactId>
       <version>${version.webjar-fontawesome}</version>
     </dependency>
@@ -212,6 +207,11 @@
       <groupId>org.webjars.npm</groupId>
       <artifactId>bootstrap</artifactId>
       <version>${version.webjar-bootstrap}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>bootswatch</artifactId>
+      <version>${version.webjar-bootswatch}</version>
     </dependency>
     <dependency>
       <groupId>org.webjars.npm</groupId>

--- a/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/base.html
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/src/main/resources/templates/base.html
@@ -14,7 +14,7 @@
     <title layout:title-pattern="$LAYOUT_TITLE: $CONTENT_TITLE">cudami</title>
 
     <!-- Bootstrap core CSS -->
-    <link th:href="@{|/webjars/bootswatch/${webjarVersions.bootswatch}/yeti/bootstrap.min.css|}" rel="stylesheet" />
+    <link th:href="@{|/webjars/bootswatch/${webjarVersions.bootswatch}/dist/yeti/bootstrap.min.css|}" rel="stylesheet" />
 
     <!-- Font awesome CSS -->
     <link th:href="@{|/webjars/font-awesome/${webjarVersions['font-awesome']}/css/all.css|}" rel="stylesheet" />


### PR DESCRIPTION
This PR updates bootswatch to the latest version `4.4.1`. It is only available as `npm` webjar, so the path to `bootstrap.min.css` changed.