### PR TITLE
Add project name to docker-compose setup

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=cudami


### PR DESCRIPTION
This PR adds a project name to the `docker-compose` setup to avoid conflicts with other `docker-compose` setups.