### PR TITLE
Add polyfill for Object.fromEntries

### DIFF
--- a/dc-cudami-editor/package.json
+++ b/dc-cudami-editor/package.json
@@ -20,6 +20,7 @@
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
     "i18next": "^17.0.6",
+    "object.fromentries": "^2.0.2",
     "prosemirror-commands": "^1.0.8",
     "prosemirror-dropcursor": "^1.1.1",
     "prosemirror-gapcursor": "^1.0.4",

--- a/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
@@ -1,3 +1,4 @@
+import * as fromEntries from 'object.fromentries'
 import {publish, subscribe} from 'pubsub-js'
 import React, {Component} from 'react'
 import {Button, Form, Label, Modal, ModalBody, ModalHeader} from 'reactstrap'
@@ -53,7 +54,7 @@ class ImageAdderModal extends Component {
   }
 
   addImageToEditor = resourceId => {
-    const filteredAttributes = Object.fromEntries(
+    const filteredAttributes = fromEntries(
       Object.entries(this.state.attributes).filter(([_, value]) => value !== '')
     )
     const data = {

--- a/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
@@ -1,4 +1,4 @@
-import * as fromEntries from 'object.fromentries'
+import fromEntries from 'object.fromentries'
 import {publish, subscribe} from 'pubsub-js'
 import React, {Component} from 'react'
 import {Button, Form, Label, Modal, ModalBody, ModalHeader} from 'reactstrap'
@@ -54,7 +54,11 @@ class ImageAdderModal extends Component {
   }
 
   addImageToEditor = resourceId => {
-    const filteredAttributes = fromEntries(
+    /* TODO: needs more investigation */
+    if (!Object.fromEntries) {
+      fromEntries.shim()
+    }
+    const filteredAttributes = Object.fromEntries(
       Object.entries(this.state.attributes).filter(([_, value]) => value !== '')
     )
     const data = {


### PR DESCRIPTION
This PR adds a polyfill for `Object.fromEntries` to make the editor work in MS Edge.