### PR TITLE
Replace maven plugin for react development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 /dc-cudami-editor/nbproject/private/
 /dc-cudami-editor/nbproject/project.xml
 /dc-cudami-editor/nbproject/project.properties
+/dc-cudami-editor/bin

--- a/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
+++ b/dc-cudami-admin/dc-cudami-admin-webapp/pom.xml
@@ -33,6 +33,11 @@
     <version.webjar-jquery>3.4.1</version.webjar-jquery>
     <version.webjar-jquery-ui>1.12.1</version.webjar-jquery-ui>
     <version.webjar-respond>1.4.2</version.webjar-respond>
+
+    <!-- plugins -->
+    <version.frontend-maven-plugin>1.9.1</version.frontend-maven-plugin>
+    <version.node>v12.16.1</version.node>
+    <version.npm>6.14.4</version.npm>
   </properties>
 
   <dependencies>
@@ -246,6 +251,45 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>${version.frontend-maven-plugin}</version>
+        <configuration>
+          <installDirectory>../../dc-cudami-editor/bin</installDirectory>
+          <workingDirectory>../../dc-cudami-editor</workingDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <configuration>
+              <nodeVersion>${version.node}</nodeVersion>
+              <npmVersion>${version.npm}</npmVersion>
+            </configuration>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <id>install node and npm</id>
+          </execution>
+          <execution>
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <id>npm install</id>
+          </execution>
+          <execution>
+            <configuration>
+              <arguments>--outputPath=${project.basedir}/target/classes/static/js</arguments>
+            </configuration>
+            <goals>
+              <goal>webpack</goal>
+            </goals>
+            <id>webpack build</id>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
@@ -254,43 +298,6 @@
           </delimiters>
           <useDefaultDelimiters>false</useDefaultDelimiters>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <configuration>
-              <arguments>
-                <argument>install</argument>
-              </arguments>
-              <executable>npm</executable>
-              <workingDirectory>../../dc-cudami-editor</workingDirectory>
-            </configuration>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <id>exec-npm-install</id>
-            <phase>initialize</phase>
-          </execution>
-          <execution>
-            <configuration>
-              <arguments>
-                <argument>webpack</argument>
-                <argument>
-                  --outputPath=${project.basedir}/target/classes/static/js
-                </argument>
-              </arguments>
-              <executable>npx</executable>
-              <workingDirectory>../../dc-cudami-editor</workingDirectory>
-            </configuration>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <id>exec-webpack</id>
-            <phase>generate-resources</phase>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This PR replaces the `exec-maven-plugin` with the `frontend-maven-plugin` for easier development of the react code. The new plugin ensures that the needed tools `node` and `npm` are installed in certain versions.