### PR TITLE
Rename html title input to tooltip

### DIFF
--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageMetadataForm.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageMetadataForm.jsx
@@ -40,7 +40,7 @@ const ImageMetadataForm = (props) => {
             <Input
               name="title"
               onChange={(evt) => onChange('title', evt.target.value)}
-              placeholder={t('title')}
+              placeholder={t('tooltip')}
               type="text"
               value={attributes.title}
             />

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -80,6 +80,7 @@
     "selectImage": "Bild auswählen",
     "text": "Langtext",
     "title": "Titel",
+    "tooltip": "Tooltip",
     "uploadFileResource": "Neue Datei hochladen",
     "width": "Breite"
   }

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -78,6 +78,7 @@
     "selectImage": "Select image",
     "text": "Long text",
     "title": "Title",
+    "tooltip": "Tooltip",
     "uploadFileResource": "Upload a new file",
     "width": "Width"
   }


### PR DESCRIPTION
This PR changes the placeholder of the html title input in the dialog to insert and image.