### PR TITLE
Add description texts for image input fields

### DIFF
--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageMetadataForm.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageMetadataForm.jsx
@@ -7,8 +7,12 @@ import {
   Collapse,
   FormGroup,
   Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
 } from 'reactstrap'
 import {useTranslation} from 'react-i18next'
+import {FaQuestionCircle} from 'react-icons/fa'
 
 const ImageMetadataForm = (props) => {
   const {t} = useTranslation()
@@ -28,31 +32,52 @@ const ImageMetadataForm = (props) => {
       <Collapse isOpen={isOpen}>
         <CardBody>
           <FormGroup>
-            <Input
-              name="caption"
-              onChange={(evt) => onChange('caption', evt.target.value)}
-              placeholder={t('caption')}
-              type="text"
-              value={attributes.caption}
-            />
+            <InputGroup>
+              <Input
+                name="caption"
+                onChange={(evt) => onChange('caption', evt.target.value)}
+                placeholder={t('caption')}
+                type="text"
+                value={attributes.caption}
+              />
+              <InputGroupAddon addonType="append">
+                <InputGroupText>
+                  <FaQuestionCircle title={t('tooltips.caption')} />
+                </InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
           </FormGroup>
           <FormGroup>
-            <Input
-              name="title"
-              onChange={(evt) => onChange('title', evt.target.value)}
-              placeholder={t('tooltip')}
-              type="text"
-              value={attributes.title}
-            />
+            <InputGroup>
+              <Input
+                name="title"
+                onChange={(evt) => onChange('title', evt.target.value)}
+                placeholder={t('tooltip')}
+                type="text"
+                value={attributes.title}
+              />
+              <InputGroupAddon addonType="append">
+                <InputGroupText>
+                  <FaQuestionCircle title={t('tooltips.tooltip')} />
+                </InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
           </FormGroup>
           <FormGroup className="mb-0">
-            <Input
-              name="altText"
-              onChange={(evt) => onChange('altText', evt.target.value)}
-              placeholder={t('altText')}
-              type="text"
-              value={attributes.altText}
-            />
+            <InputGroup>
+              <Input
+                name="altText"
+                onChange={(evt) => onChange('altText', evt.target.value)}
+                placeholder={t('altText')}
+                type="text"
+                value={attributes.altText}
+              />
+              <InputGroupAddon addonType="append">
+                <InputGroupText>
+                  <FaQuestionCircle title={t('tooltips.altText')} />
+                </InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
           </FormGroup>
         </CardBody>
       </Collapse>

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
@@ -1,6 +1,16 @@
 import React, {Component} from 'react'
-import {Card, CardBody, CardHeader, FormGroup, Input} from 'reactstrap'
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  FormGroup,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+} from 'reactstrap'
 import {withTranslation} from 'react-i18next'
+import {FaQuestionCircle} from 'react-icons/fa'
 
 import FileUploadForm from '../../FileUploadForm'
 import {uploadFile} from '../../../api'
@@ -66,22 +76,29 @@ class ImageSelector extends Component {
             />
           </FormGroup>
           <FormGroup>
-            <Input
-              name="label"
-              onChange={(evt) =>
-                onChange({
-                  label: {
-                    [Object.keys(fileResource.label)[0]]: evt.target.value,
-                  },
-                })
-              }
-              placeholder={t('label')}
-              required
-              type="text"
-              value={
-                fileResource.label ? Object.values(fileResource.label)[0] : ''
-              }
-            />
+            <InputGroup>
+              <Input
+                name="label"
+                onChange={(evt) =>
+                  onChange({
+                    label: {
+                      [Object.keys(fileResource.label)[0]]: evt.target.value,
+                    },
+                  })
+                }
+                placeholder={t('label')}
+                required
+                type="text"
+                value={
+                  fileResource.label ? Object.values(fileResource.label)[0] : ''
+                }
+              />
+              <InputGroupAddon addonType="append">
+                <InputGroupText>
+                  <FaQuestionCircle title={t('tooltips.label')} />
+                </InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
           </FormGroup>
         </CardBody>
       </Card>

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -81,6 +81,12 @@
     "text": "Langtext",
     "title": "Titel",
     "tooltip": "Tooltip",
+    "tooltips": {
+      "altText": "wird im Screen-Reader vorgelesen bzw. ausgegeben, falls das Bild nicht angezeigt werden kann",
+      "caption": "wird als Bildunterschrift ausgegeben",
+      "label": "Name des Bildes (zur Wiederauffindbarkeit im System)",
+      "tooltip": "wird beim Bewegen der Maus über das Bild eingeblendet"
+    },
     "uploadFileResource": "Neue Datei hochladen",
     "width": "Breite"
   }

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -79,6 +79,12 @@
     "text": "Long text",
     "title": "Title",
     "tooltip": "Tooltip",
+    "tooltips": {
+      "altText": "is read out in the screen reader or is output if image cannot be displayed",
+      "caption": "is displayed as a caption",
+      "label": "name of the image (for retrievability in the system)",
+      "tooltip": "appears when the mouse moves over the image"
+    },
     "uploadFileResource": "Upload a new file",
     "width": "Width"
   }


### PR DESCRIPTION
This PR adds description texts for the image input fields:

![Screenshot_2020-04-20 cudami Editor](https://user-images.githubusercontent.com/19190936/79764401-9c728180-8325-11ea-9571-74a6005ecf2d.png)

They are displayed, when the user hovers over the question mark.