### PR TITLE
Editor: Add possibility to set start/end date of publication

### DIFF
--- a/dc-cudami-editor/package-lock.json
+++ b/dc-cudami-editor/package-lock.json
@@ -1578,6 +1578,11 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
+    "@types/react-calendar": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar/-/react-calendar-3.0.1.tgz",
+      "integrity": "sha512-taCzghjYNgJZvHWB9tQKfRcmALtPBCu+Nl1VurpUYK6RT+ZASXI+ysjBaMstqd0uP4bbVt8ITMEprNqKLrrGzA=="
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1800,6 +1805,11 @@
         "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@wojtekmaj/date-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.0.2.tgz",
+      "integrity": "sha512-sOu+uH3jzsECLg3YGH++/pLWs8S4eKiXMwMIcotE62CO9AB/HRyhZ0ISwann/30DLnfCw4skvr8h9gF3aafhPA=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -3987,6 +3997,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-element-overflow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/detect-element-overflow/-/detect-element-overflow-1.2.0.tgz",
+      "integrity": "sha512-Jtr9ivYPhpd9OJux+hjL0QjUKiS1Ghgy8tvIufUjFslQgIWvgGr4mn57H190APbKkiOmXnmtMI6ytaKzMusecg=="
+    },
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -5655,6 +5670,14 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-user-locale": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.3.0.tgz",
+      "integrity": "sha512-c5N8P0upjxCF9unIC2vTA+B+8nN7kU/D/TeItMAVYhWIIksyoULM1aflKflXM3w+Ij6vF/JZys+QcwIoDuy3Ag==",
+      "requires": {
+        "lodash.once": "^4.1.1"
       }
     },
     "get-value": {
@@ -8023,6 +8046,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -8107,6 +8135,11 @@
         }
       }
     },
+    "make-event-props": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.2.0.tgz",
+      "integrity": "sha512-BmWFkm/jZzVH9A0tEBdkjAARUz/eha+5IRyfOndeSMKRadkgR5DawoBHoRwLxkYmjJOI5bHkXKpaZocxj+dKgg=="
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -8186,6 +8219,11 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
+    },
+    "merge-class-names": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.3.0.tgz",
+      "integrity": "sha512-k0Qaj36VBpKgdc8c188LEZvo6v/zzry/FUufwopWbMSp6/knfVFU/KIB55/hJjeIpg18IH2WskXJCRnM/1BrdQ=="
     },
     "merge-deep": {
       "version": "3.0.2",
@@ -10621,6 +10659,33 @@
         "section-iterator": "^2.0.0"
       }
     },
+    "react-calendar": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-3.1.0.tgz",
+      "integrity": "sha512-xoKdRe6FrnZ30LD9pyr20fhet1uwSbc6srLGm1ib7G4b7tAXniZrwzrJ4YV/Hbmmwf/zAFGyXtBzLAIV1KNvuA==",
+      "requires": {
+        "@wojtekmaj/date-utils": "^1.0.2",
+        "get-user-locale": "^1.2.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-date-picker": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-8.0.1.tgz",
+      "integrity": "sha512-FDM34LTOQ+QoOlsJeKtLZf+11NU2p1hcTy6K1xFgwuvuIwTEpUPJAnyQbgqEbzsHvMVPuNlGJSoSRFbImPWNkw==",
+      "requires": {
+        "@types/react-calendar": "^3.0.0",
+        "@wojtekmaj/date-utils": "^1.0.2",
+        "get-user-locale": "^1.2.0",
+        "make-event-props": "^1.1.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0",
+        "react-calendar": "^3.0.0",
+        "react-fit": "^1.0.3",
+        "update-input-width": "^1.1.1"
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -10808,6 +10873,15 @@
       "integrity": "sha512-OXfSpA8YY/OsKNITXPAOr+Rar8izqNZkx/N7B5vkp00AhQOFvj8ctC4bWInq1Mzpm4De5+XfpXAYbj4D4ze1QA==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-fit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-fit/-/react-fit-1.2.0.tgz",
+      "integrity": "sha512-dT6dsaF2cgBeiKsgixzFRgkQK7wp8vjvLdpaVoT+nLx1v+olncOJFBnkK+w83CDHIY6s85DDwYDbkwgHdm8FqA==",
+      "requires": {
+        "detect-element-overflow": "^1.2.0",
+        "prop-types": "^15.6.0"
       }
     },
     "react-i18next": {
@@ -13043,6 +13117,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+    },
+    "update-input-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-1.2.1.tgz",
+      "integrity": "sha512-zygDshqDb2C2/kgfoD423n5htv/3OBF7aTaz2u2zZy998EJki8njOHOeZjKEd8XSYeDziIX1JXfMsKaIRJeJ/Q=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/dc-cudami-editor/package.json
+++ b/dc-cudami-editor/package.json
@@ -35,6 +35,7 @@
     "pubsub-js": "^1.8.0",
     "react": "^16.13.1",
     "react-autosuggest": "^10.0.2",
+    "react-date-picker": "^8.0.1",
     "react-dom": "^16.13.1",
     "react-file-drop": "^3.0.6",
     "react-i18next": "^11.5.0",

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -1,0 +1,72 @@
+import React, {Component} from 'react'
+import {FormGroup, Label, Row, Col} from 'reactstrap'
+import DatePicker from 'react-date-picker'
+import {withTranslation} from 'react-i18next'
+
+class PublicationDatesForm extends Component {
+    state = {
+      startPublicationDate: new Date(),
+      endPublicationDate: new Date(),
+    }
+
+    startPublicationDateOnChange = (startPublicationDate) => {
+      this.setState({ startPublicationDate });
+    }
+
+    endPublicationDateOnChange = (endPublicationDate) => {
+      this.setState({ endPublicationDate });
+    }
+
+    constructor(props) {
+      super(props)
+      this.state = { startPublicationDate: null, endPublicationDate: null }
+    }
+
+    render() {
+      const {t} = this.props
+      const { startPublicationDate, endPublicationDate } = this.state
+      
+      return (
+        <FormGroup>
+          <Row>
+            <Col>
+                <Label className="font-weight-bold" for="publication-start-date">
+                {t('startPublicationDate')}:
+              </Label>
+            </Col>
+            <Col>
+                <DatePicker
+                calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
+                clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
+                dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
+                monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
+                nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
+                onChange={this.startPublicationDateOnChange}
+                value={startPublicationDate}
+                yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
+              />  
+            </Col>
+            <Col>
+              <Label className="font-weight-bold" for="publication-end-date">
+                {t('endPublicationDate')}:
+              </Label>
+            </Col>
+            <Col>
+              <DatePicker
+                calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
+                clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
+                dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
+                monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
+                nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
+                onChange={this.endPublicationDateOnChange}
+                value={endPublicationDate}
+                yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
+              />
+            </Col>
+          </Row>
+        </FormGroup>
+      )
+    }
+  }
+  
+export default withTranslation()(PublicationDatesForm)

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -1,72 +1,50 @@
 import React, {Component} from 'react'
 import {FormGroup, Label, Row, Col} from 'reactstrap'
 import DatePicker from 'react-date-picker'
-import {withTranslation} from 'react-i18next'
+import {useTranslation} from 'react-i18next'
 
-class PublicationDatesForm extends Component {
-    state = {
-      startPublicationDate: new Date(),
-      endPublicationDate: new Date(),
-    }
-
-    startPublicationDateOnChange = (startPublicationDate) => {
-      this.setState({ startPublicationDate });
-    }
-
-    endPublicationDateOnChange = (endPublicationDate) => {
-      this.setState({ endPublicationDate });
-    }
-
-    constructor(props) {
-      super(props)
-      this.state = { startPublicationDate: null, endPublicationDate: null }
-    }
-
-    render() {
-      const {t} = this.props
-      const { startPublicationDate, endPublicationDate } = this.state
-      
-      return (
-        <FormGroup>
-          <Row>
-            <Col>
-                <Label className="font-weight-bold" for="publication-start-date">
-                {t('startPublicationDate')}:
-              </Label>
-            </Col>
-            <Col>
-                <DatePicker
-                calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
-                clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
-                dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
-                monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
-                nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
-                onChange={this.startPublicationDateOnChange}
-                value={startPublicationDate}
-                yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
-              />  
-            </Col>
-            <Col>
-              <Label className="font-weight-bold" for="publication-end-date">
-                {t('endPublicationDate')}:
-              </Label>
-            </Col>
-            <Col>
-              <DatePicker
-                calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
-                clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
-                dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
-                monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
-                nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
-                onChange={this.endPublicationDateOnChange}
-                value={endPublicationDate}
-                yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
-              />
-            </Col>
-          </Row>
-        </FormGroup>
-      )
-    }
-  }
+const PublicationDatesForm = (props) => {
+  const {t} = useTranslation()
+  return (
+    <FormGroup>
+      <Row>
+        <Col>
+            <Label className="font-weight-bold" for="publication-start-date">
+            {t('startPublicationDate')}:
+          </Label>
+        </Col>
+        <Col>
+            <DatePicker
+            calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
+            clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
+            dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
+            monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
+            nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
+            onChange={props.onChange("publicationStart", props.identifiable.publicationStart || null)}
+            value={props.identifiable.publicationEnd}
+            yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
+          />
+        </Col>
+        <Col>
+          <Label className="font-weight-bold" for="publication-end-date">
+            {t('endPublicationDate')}:
+          </Label>
+        </Col>
+        <Col>
+          <DatePicker
+            calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
+            clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
+            dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
+            monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
+            nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
+            onChange={props.onChange("publicationEnd", props.identifiable.publicationEnd || null)}
+            value={props.identifiable.publicationEnd}
+            yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
+          />
+        </Col>
+      </Row>
+    </FormGroup>
+  )
+}
   
-export default withTranslation()(PublicationDatesForm)
+export default PublicationDatesForm

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -10,20 +10,33 @@ const PublicationDatesForm = (props) => {
     <FormGroup>
       <Row>
         <Col>
-            <Label className="font-weight-bold" for="publication-start-date">
+          <Label className="font-weight-bold" for="publication-start-date">
             {t('startPublicationDate')}:
           </Label>
         </Col>
         <Col>
-            <DatePicker
+          <DatePicker
             calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
             clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
             dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
             monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
             nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
-            onChange={(date) => props.onChange("publicationStart", `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`)}
+            onChange={(date) =>
+              props.onChange(
+                'publicationStart',
+                date
+                  ? date.getFullYear() +
+                      '-' +
+                      ('0' + (date.getMonth() + 1)).slice(-2) +
+                      '-' +
+                      ('0' + date.getDate()).slice(-2)
+                  : undefined
+              )
+            }
             required={false}
-            value={props.publicationStartDate ? new Date(props.publicationStartDate) : null}
+            value={
+              props.publicationStartDate && new Date(props.publicationStartDate)
+            }
             yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
           />
         </Col>
@@ -39,9 +52,22 @@ const PublicationDatesForm = (props) => {
             dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
             monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
             nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
-            onChange={(date) => props.onChange("publicationEnd", `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`)}
+            onChange={(date) =>
+              props.onChange(
+                'publicationEnd',
+                date
+                  ? date.getFullYear() +
+                      '-' +
+                      ('0' + (date.getMonth() + 1)).slice(-2) +
+                      '-' +
+                      ('0' + date.getDate()).slice(-2)
+                  : undefined
+              )
+            }
             required={false}
-            value={props.publicationEndDate ? new Date(props.publicationEndDate) : null}
+            value={
+              props.publicationEndDate && new Date(props.publicationEndDate)
+            }
             yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
           />
         </Col>
@@ -49,5 +75,5 @@ const PublicationDatesForm = (props) => {
     </FormGroup>
   )
 }
-  
+
 export default PublicationDatesForm

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -13,7 +13,7 @@ const PublicationDatesForm = (props) => {
       // we add 12 hours (could be related to the time zone of the user)
       // to the user-defined date to workaround this issue 😒
       date.setHours(date.getHours() + 12)
-      return date.toISOString().slice(0,10)
+      return date.toISOString().slice(0, 10)
     }
     return undefined
   }

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -7,13 +7,13 @@ const PublicationDatesForm = (props) => {
   const {t} = useTranslation()
 
   const formatDate = (date) => {
-    if (date != undefined) {
+    if (date) {
       // Selected datetime will be displayed correctly in DatePicker.
       // But after reloading, there's a minus one-day offset. Here
-      // we add 12 hours to the user-defined date to workaround
-      // this issue 😒
+      // we add 12 hours (could be related to the time zone of the user)
+      // to the user-defined date to workaround this issue 😒
       date.setHours(date.getHours() + 12)
-      return date.toISOString()
+      return date.toISOString().slice(0,10)
     }
     return undefined
   }

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -6,6 +6,18 @@ import {useTranslation} from 'react-i18next'
 const PublicationDatesForm = (props) => {
   const {t} = useTranslation()
 
+  const formatDate = (date) => {
+    if (date != undefined) {
+      // Selected datetime will be displayed correctly in DatePicker.
+      // But after reloading, there's a minus one-day offset. Here
+      // we add 12 hours to the user-defined date to workaround
+      // this issue 😒
+      date.setHours(date.getHours() + 12)
+      return date.toISOString()
+    }
+    return undefined
+  }
+
   return (
     <FormGroup>
       <Row>
@@ -19,20 +31,11 @@ const PublicationDatesForm = (props) => {
             calendarAriaLabel={t('datePicker.toggleCalendar')}
             clearAriaLabel={t('datePicker.clearDate')}
             dayAriaLabel={t('datePicker.day')}
-            id={"publication-start-date"}
+            id={'publication-start-date'}
             monthAriaLabel={t('datePicker.month')}
             nativeInputAriaLabel={t('datePicker.date')}
             onChange={(date) =>
-              props.onChange(
-                'publicationStart',
-                date
-                  ? date.getFullYear() +
-                      '-' +
-                      ('0' + (date.getMonth() + 1)).slice(-2) +
-                      '-' +
-                      ('0' + date.getDate()).slice(-2)
-                  : undefined
-              )
+              props.onChange('publicationStart', formatDate(date))
             }
             required={false}
             value={
@@ -51,20 +54,11 @@ const PublicationDatesForm = (props) => {
             calendarAriaLabel={t('datePicker.toggleCalendar')}
             clearAriaLabel={t('datePicker.clearDate')}
             dayAriaLabel={t('datePicker.day')}
-            id={"publication-end-date"}
+            id={'publication-end-date'}
             monthAriaLabel={t('datePicker.month')}
             nativeInputAriaLabel={t('datePicker.date')}
             onChange={(date) =>
-              props.onChange(
-                'publicationEnd',
-                date
-                  ? date.getFullYear() +
-                      '-' +
-                      ('0' + (date.getMonth() + 1)).slice(-2) +
-                      '-' +
-                      ('0' + date.getDate()).slice(-2)
-                  : undefined
-              )
+              props.onChange('publicationEnd', formatDate(date))
             }
             required={false}
             value={

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -5,6 +5,7 @@ import {useTranslation} from 'react-i18next'
 
 const PublicationDatesForm = (props) => {
   const {t} = useTranslation()
+
   return (
     <FormGroup>
       <Row>
@@ -20,8 +21,9 @@ const PublicationDatesForm = (props) => {
             dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
             monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
             nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
-            onChange={props.onChange("publicationStart", props.identifiable.publicationStart || null)}
-            value={props.identifiable.publicationEnd}
+            onChange={(date) => props.onChange("publicationStart", `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`)}
+            required={false}
+            value={props.publicationStartDate ? new Date(props.publicationStartDate) : null}
             yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
           />
         </Col>
@@ -37,8 +39,9 @@ const PublicationDatesForm = (props) => {
             dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
             monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
             nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
-            onChange={props.onChange("publicationEnd", props.identifiable.publicationEnd || null)}
-            value={props.identifiable.publicationEnd}
+            onChange={(date) => props.onChange("publicationEnd", `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`)}
+            required={false}
+            value={props.publicationEndDate ? new Date(props.publicationEndDate) : null}
             yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
           />
         </Col>

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -16,11 +16,11 @@ const PublicationDatesForm = (props) => {
         </Col>
         <Col>
           <DatePicker
-            calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
-            clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
-            dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
-            monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
-            nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
+            calendarAriaLabel={t('datePicker.toggleCalendar')}
+            clearAriaLabel={t('datePicker.clearDate')}
+            dayAriaLabel={t('datePicker.day')}
+            monthAriaLabel={t('datePicker.month')}
+            nativeInputAriaLabel={t('datePicker.date')}
             onChange={(date) =>
               props.onChange(
                 'publicationStart',
@@ -37,7 +37,7 @@ const PublicationDatesForm = (props) => {
             value={
               props.publicationStartDate && new Date(props.publicationStartDate)
             }
-            yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
+            yearAriaLabel={t('datePicker.year')}
           />
         </Col>
         <Col>
@@ -47,11 +47,11 @@ const PublicationDatesForm = (props) => {
         </Col>
         <Col>
           <DatePicker
-            calendarAriaLabel={t('datePickerAriaLabel.calendarAriaLabel')}
-            clearAriaLabel={t('datePickerAriaLabel.clearAriaLabel')}
-            dayAriaLabel={t('datePickerAriaLabel.dayAriaLabel')}
-            monthAriaLabel={t('datePickerAriaLabel.monthAriaLabel')}
-            nativeInputAriaLabel={t('datePickerAriaLabel.nativeInputAriaLabel')}
+            calendarAriaLabel={t('datePicker.toggleCalendar')}
+            clearAriaLabel={t('datePicker.clearDate')}
+            dayAriaLabel={t('datePicker.day')}
+            monthAriaLabel={t('datePicker.month')}
+            nativeInputAriaLabel={t('datePicker.date')}
             onChange={(date) =>
               props.onChange(
                 'publicationEnd',
@@ -68,7 +68,7 @@ const PublicationDatesForm = (props) => {
             value={
               props.publicationEndDate && new Date(props.publicationEndDate)
             }
-            yearAriaLabel={t('datePickerAriaLabel.yearAriaLabel')}
+            yearAriaLabel={t('datePicker.year')}
           />
         </Col>
       </Row>

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -19,6 +19,7 @@ const PublicationDatesForm = (props) => {
             calendarAriaLabel={t('datePicker.toggleCalendar')}
             clearAriaLabel={t('datePicker.clearDate')}
             dayAriaLabel={t('datePicker.day')}
+            id={"publication-start-date"}
             monthAriaLabel={t('datePicker.month')}
             nativeInputAriaLabel={t('datePicker.date')}
             onChange={(date) =>
@@ -50,6 +51,7 @@ const PublicationDatesForm = (props) => {
             calendarAriaLabel={t('datePicker.toggleCalendar')}
             clearAriaLabel={t('datePicker.clearDate')}
             dayAriaLabel={t('datePicker.day')}
+            id={"publication-end-date"}
             monthAriaLabel={t('datePicker.month')}
             nativeInputAriaLabel={t('datePicker.date')}
             onChange={(date) =>

--- a/dc-cudami-editor/src/components/PublicationDatesForm.jsx
+++ b/dc-cudami-editor/src/components/PublicationDatesForm.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react'
-import {FormGroup, Label, Row, Col} from 'reactstrap'
+import {Col, FormGroup, Label, Row} from 'reactstrap'
 import DatePicker from 'react-date-picker'
 import {useTranslation} from 'react-i18next'
 

--- a/dc-cudami-editor/src/components/WebpageForm.jsx
+++ b/dc-cudami-editor/src/components/WebpageForm.jsx
@@ -39,6 +39,13 @@ const WebpageForm = (props) => {
           {props.identifiable.uuid && (
             <FormIdInput id={props.identifiable.uuid} />
           )}
+          <PublicationDatesForm
+            onChange={(updateKey, updateValue) =>
+              props.onUpdate({...props.identifiable, [updateKey]: updateValue})
+            }
+            publicationEndDate={props.identifiable.publicationEnd}
+            publicationStartDate={props.identifiable.publicationStart}
+          />
           <Nav tabs>
             {props.existingLanguages.map((language) => (
               <LanguageTab
@@ -90,18 +97,6 @@ const WebpageForm = (props) => {
               </LanguageTabContent>
             ))}
           </TabContent>
-          <Row>
-            <Col sm="12">
-              <hr />
-            </Col>
-          </Row>
-          <PublicationDatesForm
-            onChange={(updateKey, updateValue) =>
-              props.onUpdate({...props.identifiable, [updateKey]: updateValue})
-            }
-            publicationEndDate={props.identifiable.publicationEnd}
-            publicationStartDate={props.identifiable.publicationStart}
-          />
         </Col>
       </Row>
     </Form>

--- a/dc-cudami-editor/src/components/WebpageForm.jsx
+++ b/dc-cudami-editor/src/components/WebpageForm.jsx
@@ -99,8 +99,8 @@ const WebpageForm = (props) => {
             onChange={(updateKey, updateValue) =>
               props.onUpdate({...props.identifiable, [updateKey]: updateValue})
             }
-            publicationEndDate={props.publicationEndDate}
-            publicationStartDate={props.publicationStartDate}
+            publicationEndDate={props.identifiable.publicationEnd}
+            publicationStartDate={props.identifiable.publicationStart}
           />
         </Col>
       </Row>

--- a/dc-cudami-editor/src/components/WebpageForm.jsx
+++ b/dc-cudami-editor/src/components/WebpageForm.jsx
@@ -99,6 +99,8 @@ const WebpageForm = (props) => {
             onChange={(updateKey, updateValue) =>
               props.onUpdate({...props.identifiable, [updateKey]: updateValue})
             }
+            publicationEndDate={props.publicationEndDate}
+            publicationStartDate={props.publicationStartDate}
           />
         </Col>
       </Row>

--- a/dc-cudami-editor/src/components/WebpageForm.jsx
+++ b/dc-cudami-editor/src/components/WebpageForm.jsx
@@ -87,10 +87,19 @@ const WebpageForm = (props) => {
                     <hr />
                   </Col>
                 </Row>
-                <PublicationDatesForm />
               </LanguageTabContent>
             ))}
           </TabContent>
+          <Row>
+            <Col sm="12">
+              <hr />
+            </Col>
+          </Row>
+          <PublicationDatesForm
+            onChange={(updateKey, updateValue) =>
+              props.onUpdate({...props.identifiable, [updateKey]: updateValue})
+            }
+          />
         </Col>
       </Row>
     </Form>

--- a/dc-cudami-editor/src/components/WebpageForm.jsx
+++ b/dc-cudami-editor/src/components/WebpageForm.jsx
@@ -8,6 +8,7 @@ import FormButtons from './FormButtons'
 import LanguageAdder from './LanguageAdder'
 import LanguageTab from './LanguageTab'
 import LanguageTabContent from './LanguageTabContent'
+import PublicationDatesForm from './PublicationDatesForm'
 
 const WebpageForm = (props) => {
   const {t} = useTranslation()
@@ -81,6 +82,12 @@ const WebpageForm = (props) => {
                     })
                   }}
                 />
+                <Row>
+                  <Col sm="12">
+                    <hr />
+                  </Col>
+                </Row>
+                <PublicationDatesForm />
               </LanguageTabContent>
             ))}
           </TabContent>

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -26,6 +26,14 @@
     "createTopic": "Neues Thema anlegen",
     "createWebpage": "Neue Webseite anlegen",
     "createWebsite": "Neue Website anlegen",
+    "datePickerAriaLabel": {
+      "calendarAriaLabel": "Kalender ein-/ausblenden",
+      "clearAriaLabel": "Datum löschen",
+      "dayAriaLabel": "Tag",
+      "monthAriaLabel": "Monat",
+      "nativeInputAriaLabel": "Datum",
+      "yearAriaLabel": "Jahr"
+    },
     "defineRenderingHints": "Darstellungshinweise festlegen",
     "description": "Kurzbeschreibung",
     "dragAndDropImage": "Datei zum Hochladen hier hereinziehen und ablegen",
@@ -38,6 +46,7 @@
     "editTopic": "Thema bearbeiten",
     "editWebpage": "Webseite bearbeiten",
     "editWebsite": "Website {{ url }} bearbeiten",
+    "endPublicationDate": "End-Publikationsdatum",
     "enterMetadata": "Metadaten eingeben",
     "file": "Datei",
     "forExample": "z.B.",
@@ -84,6 +93,7 @@
       "useUpload": "Bild hochladen",
       "useUrl": "Bild per Weblink einbinden"
     },
+    "startPublicationDate": "Start-Publikationsdatum",
     "text": "Langtext",
     "title": "Titel",
     "tooltip": "Tooltip",

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -26,13 +26,13 @@
     "createTopic": "Neues Thema anlegen",
     "createWebpage": "Neue Webseite anlegen",
     "createWebsite": "Neue Website anlegen",
-    "datePickerAriaLabel": {
-      "calendarAriaLabel": "Kalender ein-/ausblenden",
-      "clearAriaLabel": "Datum löschen",
-      "dayAriaLabel": "Tag",
-      "monthAriaLabel": "Monat",
-      "nativeInputAriaLabel": "Datum",
-      "yearAriaLabel": "Jahr"
+    "datePicker": {
+      "clearDate": "Datum löschen",
+      "date": "Datum",
+      "day": "Tag",
+      "month": "Monat",
+      "toggleCalendar": "Kalender ein-/ausblenden",
+      "year": "Jahr"
     },
     "defineRenderingHints": "Darstellungshinweise festlegen",
     "description": "Kurzbeschreibung",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -26,13 +26,13 @@
     "createTopic": "Create a new topic",
     "createWebpage": "Create a new webpage",
     "createWebsite": "Create a new website",
-    "datePickerAriaLabel": {
-      "calendarAriaLabel": "Toggle calendar",
-      "clearAriaLabel": "Clear value",
-      "dayAriaLabel": "Day",
-      "monthAriaLabel": "Month",
-      "nativeInputAriaLabel": "Date",
-      "yearAriaLabel": "Year"
+    "datePicker": {
+      "clearDate": "Clear date",
+      "date": "Date",
+      "day": "Day",
+      "month": "Month",
+      "toggleCalendar": "Toggle calendar",
+      "year": "Year"
     },
     "defineRenderingHints": "Define rendering hints",
     "description": "Abstract",
@@ -46,7 +46,7 @@
     "editTopic": "Edit topic",
     "editWebpage": "Edit webpage",
     "editWebsite": "Edit website {{ url }}",
-    "endPublicationDate": "End of publication date",
+    "endPublicationDate": "End of publication",
     "enterMetadata": "Enter metadata",
     "file": "File",
     "forExample": "e.g.",
@@ -91,7 +91,7 @@
       "useUpload": "Upload image",
       "useUrl": "Integrate image via web link"
     },
-    "startPublicationDate": "Start publication date",
+    "startPublicationDate": "Start of publication",
     "text": "Long text",
     "title": "Title",
     "tooltip": "Tooltip",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -26,6 +26,14 @@
     "createTopic": "Create a new topic",
     "createWebpage": "Create a new webpage",
     "createWebsite": "Create a new website",
+    "datePickerAriaLabel": {
+      "calendarAriaLabel": "Toggle calendar",
+      "clearAriaLabel": "Clear value",
+      "dayAriaLabel": "Day",
+      "monthAriaLabel": "Month",
+      "nativeInputAriaLabel": "Date",
+      "yearAriaLabel": "Year"
+    },
     "defineRenderingHints": "Define rendering hints",
     "description": "Abstract",
     "dragAndDropImage": "Drag and drop file to upload here",
@@ -38,6 +46,7 @@
     "editTopic": "Edit topic",
     "editWebpage": "Edit webpage",
     "editWebsite": "Edit website {{ url }}",
+    "endPublicationDate": "End of publication date",
     "enterMetadata": "Enter metadata",
     "file": "File",
     "forExample": "e.g.",
@@ -82,6 +91,7 @@
       "useUpload": "Upload image",
       "useUrl": "Integrate image via web link"
     },
+    "startPublicationDate": "Start publication date",
     "text": "Long text",
     "title": "Title",
     "tooltip": "Tooltip",


### PR DESCRIPTION
This PR adds the possibility to set a start/end publication date in the (webpage) editor:

![image](https://user-images.githubusercontent.com/20651387/82997506-c004a800-a006-11ea-9367-ccec4e514ff0.png)

Technically, it uses the great `react-date-picker` from [here](https://github.com/wojtekmaj/react-date-picker).