### PR TITLE
Add label to image upload

### DIFF
--- a/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
@@ -23,6 +23,7 @@ class ImageAdderModal extends Component {
     super(props)
     this.state = {
       attributes: this.initialAttributes,
+      doUpdateRequest: false,
       fileResource: {},
       metadataOpen: true,
       renderingHintsOpen: false,
@@ -78,6 +79,7 @@ class ImageAdderModal extends Component {
     this.props.onToggle()
     this.setState({
       attributes: this.initialAttributes,
+      doUpdateRequest: false,
       fileResource: this.state.initialFileResource,
       metadataOpen: true,
       renderingHintsOpen: false,
@@ -86,6 +88,7 @@ class ImageAdderModal extends Component {
 
   resetFileResource = () => {
     this.setState({
+      doUpdateRequest: false,
       fileResource: this.state.initialFileResource,
     })
   }
@@ -116,6 +119,8 @@ class ImageAdderModal extends Component {
         this.state.fileResource
       )
       resourceId = uuid
+    } else if (this.state.doUpdateRequest) {
+      updateFileResource(this.props.apiContextPath, this.state.fileResource)
     }
     return resourceId
   }

--- a/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
@@ -6,7 +6,7 @@ import {withTranslation} from 'react-i18next'
 import ImageMetadataForm from './imageAdder/ImageMetadataForm'
 import ImageRenderingHintsForm from './imageAdder/ImageRenderingHintsForm'
 import ImageSelector from './imageAdder/ImageSelector'
-import {loadIdentifiable, saveFileResource} from '../../api'
+import {loadIdentifiable, saveFileResource, updateFileResource} from '../../api'
 
 class ImageAdderModal extends Component {
   initialAttributes = {
@@ -29,7 +29,8 @@ class ImageAdderModal extends Component {
       tooltipsOpen: {
         altText: false,
         caption: false,
-        label: false,
+        labelUpload: false,
+        labelUrl: false,
         search: false,
         title: false,
         upload: false,

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageLabelInput.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageLabelInput.jsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import classNames from 'classnames'
+import {
+  FormGroup,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  Popover,
+  PopoverBody,
+} from 'reactstrap'
+import {useTranslation} from 'react-i18next'
+import {FaQuestionCircle} from 'react-icons/fa'
+
+const ImageLabelInput = ({
+  className,
+  label,
+  name,
+  onChange,
+  toggleTooltip,
+  tooltipName,
+  tooltipsOpen,
+}) => {
+  const {t} = useTranslation()
+  return (
+    <FormGroup className={classNames(['mb-0', className])}>
+      <InputGroup>
+        <Input
+          name={name}
+          onChange={(evt) =>
+            onChange({
+              label: {
+                [Object.keys(label)[0]]: evt.target.value,
+              },
+            })
+          }
+          placeholder={t('label')}
+          required
+          type="text"
+          value={label ? Object.values(label)[0] : ''}
+        />
+        <InputGroupAddon addonType="append">
+          <InputGroupText>
+            <FaQuestionCircle
+              id={`${name}-tooltip`}
+              style={{cursor: 'pointer'}}
+            />
+            <Popover
+              isOpen={tooltipsOpen[tooltipName]}
+              placement="left"
+              target={`${name}-tooltip`}
+              toggle={() => toggleTooltip(tooltipName)}
+            >
+              <PopoverBody>{t('tooltips.label')}</PopoverBody>
+            </Popover>
+          </InputGroupText>
+        </InputGroupAddon>
+      </InputGroup>
+    </FormGroup>
+  )
+}
+
+export default ImageLabelInput

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageLabelInput.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageLabelInput.jsx
@@ -27,13 +27,7 @@ const ImageLabelInput = ({
       <InputGroup>
         <Input
           name={name}
-          onChange={(evt) =>
-            onChange({
-              label: {
-                [Object.keys(label)[0]]: evt.target.value,
-              },
-            })
-          }
+          onChange={onChange}
           placeholder={t('label')}
           required
           type="text"

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
@@ -182,7 +182,18 @@ class ImageSelector extends Component {
                 className="mt-3"
                 label={fileResource.label}
                 name="label-upload"
-                onChange={onChange}
+                onChange={(evt) =>
+                  onChange(
+                    {
+                      label: {
+                        [Object.keys(fileResource.label)[0]]: evt.target.value,
+                      },
+                    },
+                    {
+                      doUpdateRequest: true,
+                    }
+                  )
+                }
                 toggleTooltip={toggleTooltip}
                 tooltipName="labelUpload"
                 tooltipsOpen={tooltipsOpen}
@@ -202,7 +213,13 @@ class ImageSelector extends Component {
               <ImageLabelInput
                 label={fileResource.label}
                 name="label-url"
-                onChange={onChange}
+                onChange={(evt) =>
+                  onChange({
+                    label: {
+                      [Object.keys(fileResource.label)[0]]: evt.target.value,
+                    },
+                  })
+                }
                 toggleTooltip={toggleTooltip}
                 tooltipName="labelUrl"
                 tooltipsOpen={tooltipsOpen}

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
@@ -7,9 +7,6 @@ import {
   CardHeader,
   FormGroup,
   Input,
-  InputGroup,
-  InputGroupAddon,
-  InputGroupText,
   Nav,
   NavItem,
   NavLink,
@@ -22,6 +19,7 @@ import {withTranslation} from 'react-i18next'
 import {FaQuestionCircle} from 'react-icons/fa'
 
 import ImageAutocomplete from './ImageAutocomplete'
+import ImageLabelInput from './ImageLabelInput'
 import {mimeExtensionMapping} from '../utils'
 import FileUploadForm from '../../FileUploadForm'
 import {uploadFile} from '../../../api'
@@ -180,6 +178,15 @@ class ImageSelector extends Component {
                 onChange={(file) => this.uploadImage(file)}
                 progress={this.state.progress}
               />
+              <ImageLabelInput
+                className="mt-3"
+                label={fileResource.label}
+                name="label-upload"
+                onChange={onChange}
+                toggleTooltip={toggleTooltip}
+                tooltipName="labelUpload"
+                tooltipsOpen={tooltipsOpen}
+              />
             </TabPane>
             <TabPane tabId="url">
               <FormGroup>
@@ -192,45 +199,14 @@ class ImageSelector extends Component {
                   value={fileResource.uri}
                 />
               </FormGroup>
-              <FormGroup className="mb-0">
-                <InputGroup>
-                  <Input
-                    name="label"
-                    onChange={(evt) =>
-                      onChange({
-                        label: {
-                          [Object.keys(fileResource.label)[0]]:
-                            evt.target.value,
-                        },
-                      })
-                    }
-                    placeholder={t('label')}
-                    required
-                    type="text"
-                    value={
-                      fileResource.label
-                        ? Object.values(fileResource.label)[0]
-                        : ''
-                    }
-                  />
-                  <InputGroupAddon addonType="append">
-                    <InputGroupText>
-                      <FaQuestionCircle
-                        id="label-tooltip"
-                        style={{cursor: 'pointer'}}
-                      />
-                      <Popover
-                        isOpen={tooltipsOpen.label}
-                        placement="left"
-                        target="label-tooltip"
-                        toggle={() => toggleTooltip('label')}
-                      >
-                        <PopoverBody>{t('tooltips.label')}</PopoverBody>
-                      </Popover>
-                    </InputGroupText>
-                  </InputGroupAddon>
-                </InputGroup>
-              </FormGroup>
+              <ImageLabelInput
+                label={fileResource.label}
+                name="label-url"
+                onChange={onChange}
+                toggleTooltip={toggleTooltip}
+                tooltipName="labelUrl"
+                tooltipsOpen={tooltipsOpen}
+              />
             </TabPane>
             <TabPane tabId="search">
               <ImageAutocomplete

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
@@ -47,6 +47,17 @@ class ImageSelector extends Component {
     }
   }
 
+  updateLabel = (newValue, additionalFields = {}) => {
+    this.props.onChange(
+      {
+        label: {
+          [Object.keys(this.props.fileResource.label)[0]]: newValue,
+        },
+      },
+      additionalFields
+    )
+  }
+
   updateProgress = (progress) => {
     this.setState({
       progress,
@@ -183,16 +194,9 @@ class ImageSelector extends Component {
                 label={fileResource.label}
                 name="label-upload"
                 onChange={(evt) =>
-                  onChange(
-                    {
-                      label: {
-                        [Object.keys(fileResource.label)[0]]: evt.target.value,
-                      },
-                    },
-                    {
-                      doUpdateRequest: true,
-                    }
-                  )
+                  this.updateLabel(evt.target.value, {
+                    doUpdateRequest: true,
+                  })
                 }
                 toggleTooltip={toggleTooltip}
                 tooltipName="labelUpload"
@@ -213,13 +217,7 @@ class ImageSelector extends Component {
               <ImageLabelInput
                 label={fileResource.label}
                 name="label-url"
-                onChange={(evt) =>
-                  onChange({
-                    label: {
-                      [Object.keys(fileResource.label)[0]]: evt.target.value,
-                    },
-                  })
-                }
+                onChange={(evt) => this.updateLabel(evt.target.value)}
                 toggleTooltip={toggleTooltip}
                 tooltipName="labelUrl"
                 tooltipsOpen={tooltipsOpen}


### PR DESCRIPTION
This PR adds the possibility to change the label, that was automatically set to the filename on upload:

![Screenshot_2020-05-27-upload-label](https://user-images.githubusercontent.com/19190936/82999837-e24bf500-a009-11ea-8290-8c1fd550533c.png)

The functionallity was lost in #354.