### PR TITLE
Add closing of all tooltips to destroy of modal and tab switching

### DIFF
--- a/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/ImageAdderModal.jsx
@@ -83,13 +83,21 @@ class ImageAdderModal extends Component {
       fileResource: this.state.initialFileResource,
       metadataOpen: true,
       renderingHintsOpen: false,
+      tooltipsOpen: this.getClosedTooltipsState(),
     })
   }
 
-  resetFileResource = () => {
+  getClosedTooltipsState = () => {
+    return Object.fromEntries(
+      Object.entries(this.state.tooltipsOpen).map(([name, _]) => [name, false])
+    )
+  }
+
+  onTabChanged = () => {
     this.setState({
       doUpdateRequest: false,
       fileResource: this.state.initialFileResource,
+      tooltipsOpen: this.getClosedTooltipsState(),
     })
   }
 
@@ -128,12 +136,7 @@ class ImageAdderModal extends Component {
   toggleTooltip = (name) => {
     this.setState({
       tooltipsOpen: {
-        ...Object.fromEntries(
-          Object.entries(this.state.tooltipsOpen).map(([name, _]) => [
-            name,
-            false,
-          ])
-        ),
+        ...this.getClosedTooltipsState(),
         [name]: !this.state.tooltipsOpen[name],
       },
     })
@@ -177,7 +180,7 @@ class ImageAdderModal extends Component {
               onChange={(updateFields, additionalFields) =>
                 this.updateFileResource(updateFields, additionalFields)
               }
-              resetFileResource={() => this.resetFileResource()}
+              onTabChanged={this.onTabChanged}
               toggleTooltip={(name) => this.toggleTooltip(name)}
               tooltipsOpen={this.state.tooltipsOpen}
             />

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
@@ -40,7 +40,7 @@ class ImageSelector extends Component {
       activeTab !== this.state.activeTab &&
       evt.currentTarget === evt.target
     ) {
-      this.props.resetFileResource()
+      this.props.onTabChanged()
       this.setState({
         activeTab,
       })


### PR DESCRIPTION
This PR fixes crashing when the `ImageAdderModal` is closed and reopened again without closing the open tooltip before closing.