### PR TITLE
Extend image suggestions

### DIFF
--- a/dc-cudami-editor/src/api.js
+++ b/dc-cudami-editor/src/api.js
@@ -94,9 +94,15 @@ export async function searchImages(
   try {
     const result = await fetch(url)
     const json = await result.json()
-    return json.content ?? []
+    return {
+      suggestions: json.content,
+      totalElements: json.totalElements,
+    }
   } catch (err) {
-    return []
+    return {
+      suggestions: [],
+      totalElements: 0,
+    }
   }
 }
 

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.css
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.css
@@ -1,3 +1,11 @@
+.suggestion-container {
+  max-height: 350px;
+  overflow-y: scroll;
+  position: absolute;
+  width: calc(100% - 2.5rem);
+  z-index: 1;
+}
+
 .suggestion-list .suggestion-image {
   max-width: 50px;
 }

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.jsx
@@ -136,6 +136,7 @@ class ImageAutocomplete extends Component {
         theme={{
           suggestion: 'align-items-center d-flex list-group-item',
           suggestionHighlighted: 'active',
+          suggestionsContainer: 'suggestion-container',
           suggestionsList: 'list-group suggestion-list',
         }}
       />

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react'
-import {FormGroup, Input} from 'reactstrap'
+import {Alert, FormGroup, Input} from 'reactstrap'
 import Autosuggest from 'react-autosuggest'
 import {withTranslation} from 'react-i18next'
 
@@ -8,11 +8,14 @@ import {mimeExtensionMapping} from '../utils'
 import {searchImages} from '../../../api'
 
 class ImageAutocomplete extends Component {
+  maxElements = 25
+
   constructor(props) {
     super(props)
     this.state = {
       searchTerm: '',
       suggestions: [],
+      totalElements: 0,
     }
   }
 
@@ -47,6 +50,7 @@ class ImageAutocomplete extends Component {
   onSuggestionsClearRequested = () => {
     this.setState({
       suggestions: [],
+      totalElements: 0,
     })
   }
 
@@ -54,12 +58,15 @@ class ImageAutocomplete extends Component {
     if (searchTerm.length < 2) {
       return
     }
-    const suggestions = await searchImages(
+    const {suggestions, totalElements} = await searchImages(
       this.props.apiContextPath,
-      searchTerm
+      searchTerm,
+      0,
+      this.maxElements
     )
     this.setState({
       suggestions,
+      totalElements,
     })
   }
 
@@ -82,6 +89,22 @@ class ImageAutocomplete extends Component {
         </div>
         {this.getLabelValue(label)}
       </>
+    )
+  }
+
+  renderSuggestionsContainer = ({containerProps, children}) => {
+    return (
+      <div {...containerProps}>
+        {this.state.totalElements > this.maxElements && (
+          <Alert className="mb-0" color="info">
+            {this.props.t('selectImage.moreElementsFound', {
+              maxElements: this.maxElements,
+              totalElements: this.state.totalElements,
+            })}
+          </Alert>
+        )}
+        {children}
+      </div>
     )
   }
 
@@ -108,6 +131,7 @@ class ImageAutocomplete extends Component {
         onSuggestionSelected={this.selectFileResource}
         renderInputComponent={this.renderInputComponent}
         renderSuggestion={this.renderSuggestion}
+        renderSuggestionsContainer={this.renderSuggestionsContainer}
         suggestions={suggestions}
         theme={{
           suggestion: 'align-items-center d-flex list-group-item',

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -87,6 +87,7 @@
     "sameTab": "in gleichem Tab",
     "save": "Speichern",
     "selectImage": {
+      "moreElementsFound": "{{ maxElements }} von {{ totalElements }} Treffern, bitte verfeinern Sie Ihre Suche.",
       "searchTerm": "Suchbegriff (aus Bild-Titel, Dateiname, Kurzbeschreibung)",
       "uploadSuccessful": "Bild erfolgreich hochgeladen",
       "useSearch": "Vorhandenes Bild verwenden",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -85,6 +85,7 @@
     "right": "right",
     "save": "Save",
     "selectImage": {
+      "moreElementsFound": "{{ maxElements }} out of {{ totalElemenets }} results, please refine your search.",
       "searchTerm": "Search term (from label, file name, description)",
       "uploadSuccessful": "Image uploaded successfully",
       "useSearch": "Use existing image",


### PR DESCRIPTION
This PR adds an information message, when there are more suggestions than the configured maximum (changed from 10 to 25). Additionally the styling was changed a bit to reflect the changes.

Before:
![before](https://user-images.githubusercontent.com/19190936/83258588-ce91c180-a1b6-11ea-8ac1-5e396479e688.gif)

After:
![after](https://user-images.githubusercontent.com/19190936/83258609-d6e9fc80-a1b6-11ea-9d03-e73d96837bee.gif)