### PR TITLE
Add image preview for uploaded and selected images

### DIFF
--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageAutocomplete.jsx
@@ -4,7 +4,7 @@ import Autosuggest from 'react-autosuggest'
 import {withTranslation} from 'react-i18next'
 
 import './ImageAutocomplete.css'
-import {mimeExtensionMapping} from '../utils'
+import {getImageUrl} from '../utils'
 import {searchImages} from '../../../api'
 
 class ImageAutocomplete extends Component {
@@ -28,15 +28,6 @@ class ImageAutocomplete extends Component {
       return label[defaultLanguage]
     }
     return Object.values(label)[0]
-  }
-
-  getPreviewImageUrl = (previewImage, width = 'full') => {
-    const subMimeType = previewImage.mimeType.split('/')[1]
-    return previewImage.iiifBaseUrl
-      ? `${previewImage.iiifBaseUrl}/full/${width}/0/default.${
-          mimeExtensionMapping[subMimeType] ?? 'jpg'
-        }`
-      : previewImage.uri
   }
 
   getSuggestionAsString = (suggestion) =>
@@ -83,10 +74,7 @@ class ImageAutocomplete extends Component {
     return (
       <>
         <div className="mr-3 suggestion-image">
-          <img
-            className="img-fluid"
-            src={this.getPreviewImageUrl(previewImage, '50,')}
-          />
+          <img className="img-fluid" src={getImageUrl(previewImage, '50,')} />
         </div>
         {this.getLabelValue(label)}
       </>
@@ -111,8 +99,8 @@ class ImageAutocomplete extends Component {
 
   selectFileResource = (_, {suggestion}) => {
     this.props.onChange({
-      ...suggestion,
-      uri: this.getPreviewImageUrl(suggestion.previewImage),
+      ...suggestion.previewImage,
+      uri: getImageUrl(suggestion.previewImage),
     })
   }
 

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImagePreview.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImagePreview.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import {getImageUrl} from '../utils'
+
+const ImagePreview = ({iiifBaseUrl, filename, mimeType, uri}) => {
+  const imageUrl = getImageUrl({iiifBaseUrl, mimeType, uri}, '250,')
+  return (
+    <figure className="d-block figure text-center">
+      <img className="figure-img img-fluid" src={imageUrl} />
+      {filename && (
+        <figcaption className="figure-caption">{filename}</figcaption>
+      )}
+    </figure>
+  )
+}
+
+export default ImagePreview

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageSelector.jsx
@@ -20,7 +20,8 @@ import {FaQuestionCircle} from 'react-icons/fa'
 
 import ImageAutocomplete from './ImageAutocomplete'
 import ImageLabelInput from './ImageLabelInput'
-import {mimeExtensionMapping} from '../utils'
+import ImagePreview from './ImagePreview'
+import {getImageUrl} from '../utils'
 import FileUploadForm from '../../FileUploadForm'
 import {uploadFile} from '../../../api'
 
@@ -80,12 +81,9 @@ class ImageSelector extends Component {
       showUploadSuccess: true,
     })
     setTimeout(() => this.setState({showUploadSuccess: false}), 3000)
-    const subMimeType = responseJson.mimeType.split('/')[1]
     onChange({
       ...responseJson,
-      uri: `${responseJson.iiifBaseUrl}/full/full/0/default.${
-        mimeExtensionMapping[subMimeType] ?? 'jpg'
-      }`,
+      uri: getImageUrl(responseJson),
     })
   }
 
@@ -182,6 +180,14 @@ class ImageSelector extends Component {
         <CardBody className="text-center">
           <TabContent activeTab={this.state.activeTab} className="border-0 p-0">
             <TabPane tabId="upload">
+              {fileResource.uuid && (
+                <ImagePreview
+                  iiifBaseUrl={fileResource.iiifBaseUrl}
+                  filename={fileResource.filename}
+                  mimeType={fileResource.mimeType}
+                  uri={fileResource.uri}
+                />
+              )}
               <Alert color="success" isOpen={this.state.showUploadSuccess}>
                 {t('selectImage.uploadSuccessful')}
               </Alert>
@@ -224,6 +230,14 @@ class ImageSelector extends Component {
               />
             </TabPane>
             <TabPane tabId="search">
+              {fileResource.uuid && (
+                <ImagePreview
+                  iiifBaseUrl={fileResource.iiifBaseUrl}
+                  filename={fileResource.filename}
+                  mimeType={fileResource.mimeType}
+                  uri={fileResource.uri}
+                />
+              )}
               <ImageAutocomplete
                 activeLanguage={activeLanguage}
                 apiContextPath={apiContextPath}

--- a/dc-cudami-editor/src/components/modals/utils.js
+++ b/dc-cudami-editor/src/components/modals/utils.js
@@ -1,4 +1,12 @@
-export const mimeExtensionMapping = {
-  gif: 'gif',
-  png: 'png',
+export function getImageUrl(image, width = 'full') {
+  const mimeExtensionMapping = {
+    gif: 'gif',
+    png: 'png',
+  }
+  const subMimeType = image.mimeType.split('/')[1]
+  return image.iiifBaseUrl
+    ? `${image.iiifBaseUrl}/full/${width}/0/default.${
+        mimeExtensionMapping[subMimeType] ?? 'jpg'
+      }`
+    : image.uri
 }


### PR DESCRIPTION
This PR adds an image preview (with the filename), after an image was uploaded
![Bildschirmfoto_2020-06-03_17-06-27](https://user-images.githubusercontent.com/19190936/83653940-b4901e80-a5bc-11ea-912e-38f005423dd4.png)
or selected from the autocomplete
![Bildschirmfoto_2020-06-03_17-07-01](https://user-images.githubusercontent.com/19190936/83653960-bb1e9600-a5bc-11ea-83e9-ebfc94c78e06.png)