### PR TITLE
Add a notification when removing the preview image

### DIFF
--- a/dc-cudami-editor/src/components/PreviewImage.jsx
+++ b/dc-cudami-editor/src/components/PreviewImage.jsx
@@ -1,6 +1,13 @@
 import {publish, subscribe, unsubscribe} from 'pubsub-js'
-import React from 'react'
-import {Button, ButtonGroup, Card, CardBody} from 'reactstrap'
+import React, {useState} from 'react'
+import {
+  Alert,
+  Button,
+  ButtonGroup,
+  Card,
+  CardBody,
+  CardFooter,
+} from 'reactstrap'
 import {useTranslation} from 'react-i18next'
 import {FaEdit, FaPlus, FaTrashAlt} from 'react-icons/fa'
 
@@ -85,6 +92,7 @@ const PreviewImage = ({
   previewImage,
   previewImageRenderingHints = {},
 }) => {
+  const [showRemoveNotification, setShowRemoveNotification] = useState(false)
   const {t} = useTranslation()
   if (!previewImage) {
     return (
@@ -107,6 +115,13 @@ const PreviewImage = ({
             <FaPlus />
           </Button>
         </CardBody>
+        {showRemoveNotification && (
+          <CardFooter className="p-0">
+            <Alert className="mb-0" color="info">
+              {t('removePreviewImageAfterSaveNotification')}
+            </Alert>
+          </CardFooter>
+        )}
       </Card>
     )
   }
@@ -140,12 +155,14 @@ const PreviewImage = ({
           </Button>
           <Button
             color="light"
-            onClick={() =>
+            onClick={() => {
+              setShowRemoveNotification(true)
+              setTimeout(() => setShowRemoveNotification(false), 3000)
               onUpdate({
                 previewImage: undefined,
                 previewImageRenderingHints: undefined,
               })
-            }
+            }}
             size="sm"
           >
             <FaTrashAlt />

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -86,6 +86,7 @@
     "numberOfRows": "Anzahl an Zeilen",
     "openLinkNewTab": "in einem neuen Tab öffnen",
     "openLinkSameTab": "im selben Tab öffnen",
+    "removePreviewImageAfterSaveNotification": "Klicken Sie auf \"$t(save)\", um die Löschung zu bestätigen.",
     "sameTab": "in gleichem Tab",
     "save": "Speichern",
     "selectImage": {

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -85,6 +85,7 @@
     "numberOfRows": "Number of rows",
     "openLinkNewTab": "open in a new tab",
     "openLinkSameTab": "open in the same tab",
+    "removePreviewImageAfterSaveNotification": "Click \"$t(save)\" to confirm the deletion",
     "save": "Save",
     "selectImage": {
       "moreElementsFound": "{{ maxElements }} out of {{ totalElements }} results, please refine your search.",


### PR DESCRIPTION
This PR adds a notification that removing the preview image only has effect after saving:
![Peek 2020-07-03 10-58](https://user-images.githubusercontent.com/19190936/86453103-8c135580-bd1d-11ea-9721-25115b9272e3.gif)