### PR TITLE
Fix memory leak: each client created a HttpClient

### DIFF
--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigBackend.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigBackend.java
@@ -2,6 +2,8 @@ package de.digitalcollections.cudami.admin.config;
 
 import de.digitalcollections.cudami.client.CudamiClient;
 import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +16,11 @@ public class SpringConfigBackend {
 
   @Bean
   public CudamiClient cudamiClient() {
-    return new CudamiClient(serverUrl, new DigitalCollectionsObjectMapper());
+    final HttpClient http =
+        HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+    return new CudamiClient(http, serverUrl, new DigitalCollectionsObjectMapper());
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiArticlesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiArticlesClient.java
@@ -7,14 +7,15 @@ import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.impl.identifiable.entity.ArticleImpl;
 import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
 public class CudamiArticlesClient extends CudamiBaseClient<ArticleImpl> {
 
-  public CudamiArticlesClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, ArticleImpl.class, mapper);
+  public CudamiArticlesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, ArticleImpl.class, mapper);
   }
 
   public Article create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
@@ -129,7 +129,7 @@ public class CudamiBaseClient<T extends Object> {
     HttpRequest req =
         HttpRequest.newBuilder()
             .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(bodyObject)))
-            .uri(createFullUri(requestUrl))
+            .uri(url)
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             // TODO add creation of a request id if needed

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
@@ -167,11 +167,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       final String body = response.thenApply(HttpResponse::body).get();
       return body;
-      //      HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("doDeleteRequestForString", resp.statusCode());
-      //      }
-      //      return resp.body();
     } catch (InterruptedException | ExecutionException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
@@ -193,11 +188,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("doGetRequestForObject", resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -226,11 +216,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("doGetRequestForObjectList", resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -270,11 +255,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("GET " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -310,11 +290,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("GET " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -355,11 +330,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("GET " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null) {
         return null;
       }
@@ -381,11 +351,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       final String body = response.thenApply(HttpResponse::body).get();
       return body;
-      //      HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("GET " + requestUrl, resp.statusCode());
-      //      }
-      //      return resp.body();
     } catch (InterruptedException | ExecutionException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
@@ -402,11 +367,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       final String body = response.thenApply(HttpResponse::body).get();
       return body;
-      //      HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("PATCH " + requestUrl, resp.statusCode());
-      //      }
-      //      return resp.body();
     } catch (InterruptedException | ExecutionException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
@@ -423,11 +383,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       final String body = response.thenApply(HttpResponse::body).get();
       return body;
-      //      HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("PATCH " + requestUrl, resp.statusCode());
-      //      }
-      //      return resp.body();
     } catch (IOException | InterruptedException | ExecutionException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
@@ -444,11 +399,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("POST " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -471,11 +421,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("POST " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null) {
         return null;
       }
@@ -498,11 +443,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("POST " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -530,11 +470,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("POST " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -556,11 +491,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("PUT " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null || body.length == 0) {
         return null;
       }
@@ -583,11 +513,6 @@ public class CudamiBaseClient<T extends Object> {
       }
       // This is the most performant approach for Jackson
       final byte[] body = response.thenApply(HttpResponse::body).get();
-      //      HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-      //      if (resp.statusCode() != 200) {
-      //        throw CudamiRestErrorDecoder.decode("PUT " + requestUrl, resp.statusCode());
-      //      }
-      //      final byte[] body = resp.body();
       if (body == null) {
         return null;
       }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
@@ -22,8 +22,6 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,15 +157,14 @@ public class CudamiBaseClient<T extends Object> {
   protected String doDeleteRequestForString(String requestUrl) throws HttpException {
     HttpRequest req = createDeleteRequest(requestUrl);
     try {
-      CompletableFuture<HttpResponse<String>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofString());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<String> response = http.send(req, HttpResponse.BodyHandlers.ofString());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("DELETE " + requestUrl, statusCode);
       }
-      final String body = response.thenApply(HttpResponse::body).get();
+      final String body = response.body();
       return body;
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (InterruptedException | IOException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -180,20 +177,19 @@ public class CudamiBaseClient<T extends Object> {
       throws HttpException {
     HttpRequest req = createGetRequest(requestUrl);
     try {
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("GET " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       T result = mapper.readerFor(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -208,20 +204,19 @@ public class CudamiBaseClient<T extends Object> {
     // TODO add creation of a request id if needed
     //            .header("X-Request-Id", request.getRequestId())
     try {
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("GET " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       List result = mapper.readerForListOf(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -247,20 +242,19 @@ public class CudamiBaseClient<T extends Object> {
                 findParams.getNullHandling());
     HttpRequest req = createGetRequest(requestUrl);
     try {
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("GET " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       PageResponse<T> result = mapper.readerFor(PageResponse.class).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -282,21 +276,20 @@ public class CudamiBaseClient<T extends Object> {
                 URLEncoder.encode(searchTerm, StandardCharsets.UTF_8));
     HttpRequest req = createGetRequest(requestUrl);
     try {
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("GET " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       SearchPageResponse<T> result = mapper.readerFor(SearchPageResponse.class).readValue(body);
       result.setQuery(searchTerm);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -322,20 +315,19 @@ public class CudamiBaseClient<T extends Object> {
                 findParams.getNullHandling());
     HttpRequest req = createGetRequest(requestUrl);
     try {
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("GET " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null) {
         return null;
       }
       PageResponse result = mapper.readerFor(PageResponse.class).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -343,15 +335,14 @@ public class CudamiBaseClient<T extends Object> {
   protected String doGetRequestForString(String requestUrl) throws HttpException {
     HttpRequest req = createGetRequest(requestUrl);
     try {
-      CompletableFuture<HttpResponse<String>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofString());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<String> response = http.send(req, HttpResponse.BodyHandlers.ofString());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("GET " + requestUrl, statusCode);
       }
-      final String body = response.thenApply(HttpResponse::body).get();
+      final String body = response.body();
       return body;
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -359,15 +350,14 @@ public class CudamiBaseClient<T extends Object> {
   protected String doPatchRequestForString(String requestUrl) throws HttpException {
     HttpRequest req = createPatchRequest(requestUrl);
     try {
-      CompletableFuture<HttpResponse<String>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofString());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<String> response = http.send(req, HttpResponse.BodyHandlers.ofString());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("PATCH " + requestUrl, statusCode);
       }
-      final String body = response.thenApply(HttpResponse::body).get();
+      final String body = response.body();
       return body;
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (InterruptedException | IOException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -375,15 +365,14 @@ public class CudamiBaseClient<T extends Object> {
   protected String doPatchRequestForString(String requestUrl, Object object) throws HttpException {
     try {
       HttpRequest req = createPatchRequest(requestUrl, object);
-      CompletableFuture<HttpResponse<String>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofString());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<String> response = http.send(req, HttpResponse.BodyHandlers.ofString());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("PATCH " + requestUrl, statusCode);
       }
-      final String body = response.thenApply(HttpResponse::body).get();
+      final String body = response.body();
       return body;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -391,20 +380,19 @@ public class CudamiBaseClient<T extends Object> {
   protected T doPostRequestForObject(String requestUrl, T object) throws HttpException {
     try {
       HttpRequest req = createPostRequest(requestUrl, object);
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("POST " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       T result = mapper.readerFor(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to error", e);
     }
   }
@@ -413,20 +401,19 @@ public class CudamiBaseClient<T extends Object> {
       throws HttpException {
     try {
       HttpRequest req = createPostRequest(requestUrl, bodyObject);
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("POST " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null) {
         return null;
       }
       Object result = mapper.readerFor(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to error", e);
     }
   }
@@ -435,20 +422,19 @@ public class CudamiBaseClient<T extends Object> {
       throws HttpException {
     try {
       HttpRequest req = createPostRequest(requestUrl);
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("POST " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       Object result = mapper.readerFor(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to error", e);
     }
   }
@@ -462,20 +448,19 @@ public class CudamiBaseClient<T extends Object> {
       String requestUrl, List<Class<?>> list, Class<?> targetType) throws HttpException {
     try {
       HttpRequest req = createPostRequest(requestUrl, list);
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("POST " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       List<Class<?>> result = mapper.readerForListOf(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to error", e);
     }
   }
@@ -483,20 +468,19 @@ public class CudamiBaseClient<T extends Object> {
   protected T doPutRequestForObject(String requestUrl, T object) throws HttpException {
     try {
       HttpRequest req = createPutRequest(requestUrl, object);
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("PUT " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null || body.length == 0) {
         return null;
       }
       T result = mapper.readerFor(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to connection error", e);
     }
   }
@@ -505,20 +489,19 @@ public class CudamiBaseClient<T extends Object> {
       throws HttpException {
     try {
       HttpRequest req = createPutRequest(requestUrl, bodyObject);
-      CompletableFuture<HttpResponse<byte[]>> response =
-          http.sendAsync(req, HttpResponse.BodyHandlers.ofByteArray());
-      Integer statusCode = response.thenApply(HttpResponse::statusCode).get();
+      HttpResponse<byte[]> response = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+      Integer statusCode = response.statusCode();
       if (statusCode != 200) {
         throw CudamiRestErrorDecoder.decode("PUT " + requestUrl, statusCode);
       }
       // This is the most performant approach for Jackson
-      final byte[] body = response.thenApply(HttpResponse::body).get();
+      final byte[] body = response.body();
       if (body == null) {
         return null;
       }
       Object result = mapper.readerFor(targetType).readValue(body);
       return result;
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | InterruptedException e) {
       throw new HttpException("Failed to retrieve response due to error", e);
     }
   }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
@@ -1,9 +1,12 @@
 package de.digitalcollections.cudami.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpClient;
+import java.time.Duration;
 
 public class CudamiClient {
 
+  protected final HttpClient http;
   private final CudamiArticlesClient cudamiArticlesClient;
   private final CudamiCollectionsClient cudamiCollectionsClient;
   private final CudamiCorporationsClient cudamiCorporationsClient;
@@ -23,25 +26,37 @@ public class CudamiClient {
   private final CudamiWebsitesClient cudamiWebsitesClient;
 
   public CudamiClient(String cudamiServerUrl, ObjectMapper mapper) {
-    this.cudamiArticlesClient = new CudamiArticlesClient(cudamiServerUrl, mapper);
-    this.cudamiCollectionsClient = new CudamiCollectionsClient(cudamiServerUrl, mapper);
-    this.cudamiCorporationsClient = new CudamiCorporationsClient(cudamiServerUrl, mapper);
-    this.cudamiDigitalObjectsClient = new CudamiDigitalObjectsClient(cudamiServerUrl, mapper);
-    this.cudamiEntitiesClient = new CudamiEntitiesClient(cudamiServerUrl, mapper);
-    this.cudamiEntityPartsClient = new CudamiEntityPartsClient(cudamiServerUrl, mapper);
+    this(
+        HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build(),
+        cudamiServerUrl,
+        mapper);
+  }
+
+  public CudamiClient(HttpClient http, String cudamiServerUrl, ObjectMapper mapper) {
+    this.http = http;
+    this.cudamiArticlesClient = new CudamiArticlesClient(http, cudamiServerUrl, mapper);
+    this.cudamiCollectionsClient = new CudamiCollectionsClient(http, cudamiServerUrl, mapper);
+    this.cudamiCorporationsClient = new CudamiCorporationsClient(http, cudamiServerUrl, mapper);
+    this.cudamiDigitalObjectsClient = new CudamiDigitalObjectsClient(http, cudamiServerUrl, mapper);
+    this.cudamiEntitiesClient = new CudamiEntitiesClient(http, cudamiServerUrl, mapper);
+    this.cudamiEntityPartsClient = new CudamiEntityPartsClient(http, cudamiServerUrl, mapper);
     this.cudamiFileResourcesBinaryClient =
         new CudamiFileResourcesBinaryClient(cudamiServerUrl, mapper);
     this.cudamiFileResourcesMetadataClient =
-        new CudamiFileResourcesMetadataClient(cudamiServerUrl, mapper);
-    this.cudamiIdentifiablesClient = new CudamiIdentifiablesClient(cudamiServerUrl, mapper);
-    this.cudamiIdentifierTypesClient = new CudamiIdentifierTypesClient(cudamiServerUrl, mapper);
-    this.cudamiLocalesClient = new CudamiLocalesClient(cudamiServerUrl, mapper);
-    this.cudamiProjectsClient = new CudamiProjectsClient(cudamiServerUrl, mapper);
-    this.cudamiSubtopicsClient = new CudamiSubtopicsClient(cudamiServerUrl, mapper);
-    this.cudamiTopicsClient = new CudamiTopicsClient(cudamiServerUrl, mapper);
-    this.cudamiUsersClient = new CudamiUsersClient(cudamiServerUrl, mapper);
-    this.cudamiWebpagesClient = new CudamiWebpagesClient(cudamiServerUrl, mapper);
-    this.cudamiWebsitesClient = new CudamiWebsitesClient(cudamiServerUrl, mapper);
+        new CudamiFileResourcesMetadataClient(http, cudamiServerUrl, mapper);
+    this.cudamiIdentifiablesClient = new CudamiIdentifiablesClient(http, cudamiServerUrl, mapper);
+    this.cudamiIdentifierTypesClient =
+        new CudamiIdentifierTypesClient(http, cudamiServerUrl, mapper);
+    this.cudamiLocalesClient = new CudamiLocalesClient(http, cudamiServerUrl, mapper);
+    this.cudamiProjectsClient = new CudamiProjectsClient(http, cudamiServerUrl, mapper);
+    this.cudamiSubtopicsClient = new CudamiSubtopicsClient(http, cudamiServerUrl, mapper);
+    this.cudamiTopicsClient = new CudamiTopicsClient(http, cudamiServerUrl, mapper);
+    this.cudamiUsersClient = new CudamiUsersClient(http, cudamiServerUrl, mapper);
+    this.cudamiWebpagesClient = new CudamiWebpagesClient(http, cudamiServerUrl, mapper);
+    this.cudamiWebsitesClient = new CudamiWebsitesClient(http, cudamiServerUrl, mapper);
   }
 
   public CudamiArticlesClient forArticles() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiCollectionsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiCollectionsClient.java
@@ -10,14 +10,15 @@ import de.digitalcollections.model.api.view.BreadcrumbNavigation;
 import de.digitalcollections.model.impl.identifiable.entity.CollectionImpl;
 import de.digitalcollections.model.impl.identifiable.entity.DigitalObjectImpl;
 import de.digitalcollections.model.impl.view.BreadcrumbNavigationImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
 public class CudamiCollectionsClient extends CudamiBaseClient<CollectionImpl> {
 
-  public CudamiCollectionsClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, CollectionImpl.class, mapper);
+  public CudamiCollectionsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, CollectionImpl.class, mapper);
   }
 
   public boolean addDigitalObject(UUID collectionUuid, UUID digitalObjectUuid)

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiCorporationsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiCorporationsClient.java
@@ -6,12 +6,13 @@ import de.digitalcollections.model.api.identifiable.entity.Corporation;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.impl.identifiable.entity.CorporationImpl;
+import java.net.http.HttpClient;
 import java.util.UUID;
 
 public class CudamiCorporationsClient extends CudamiBaseClient<CorporationImpl> {
 
-  public CudamiCorporationsClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, CorporationImpl.class, mapper);
+  public CudamiCorporationsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, CorporationImpl.class, mapper);
   }
 
   public Corporation create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiDigitalObjectsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiDigitalObjectsClient.java
@@ -17,13 +17,14 @@ import de.digitalcollections.model.impl.identifiable.entity.ProjectImpl;
 import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
 import de.digitalcollections.model.impl.identifiable.resource.ImageFileResourceImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
 public class CudamiDigitalObjectsClient extends CudamiBaseClient<DigitalObjectImpl> {
 
-  public CudamiDigitalObjectsClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, DigitalObjectImpl.class, mapper);
+  public CudamiDigitalObjectsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, DigitalObjectImpl.class, mapper);
   }
 
   public DigitalObject create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiEntitiesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiEntitiesClient.java
@@ -13,14 +13,15 @@ import de.digitalcollections.model.impl.identifiable.entity.EntityImpl;
 import de.digitalcollections.model.impl.identifiable.entity.EntityRelationImpl;
 import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
 public class CudamiEntitiesClient extends CudamiBaseClient<EntityImpl> {
 
-  public CudamiEntitiesClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, EntityImpl.class, mapper);
+  public CudamiEntitiesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, EntityImpl.class, mapper);
   }
 
   public Entity create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiEntityPartsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiEntityPartsClient.java
@@ -3,11 +3,12 @@ package de.digitalcollections.cudami.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.api.identifiable.entity.parts.EntityPart;
 import de.digitalcollections.model.impl.identifiable.entity.parts.EntityPartImpl;
+import java.net.http.HttpClient;
 
 public class CudamiEntityPartsClient extends CudamiBaseClient<EntityPartImpl> {
 
-  public CudamiEntityPartsClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, EntityPartImpl.class, mapper);
+  public CudamiEntityPartsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, EntityPartImpl.class, mapper);
   }
 
   public EntityPart create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiFileResourcesBinaryClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiFileResourcesBinaryClient.java
@@ -7,6 +7,7 @@ import de.digitalcollections.model.api.identifiable.resource.exceptions.Resource
 import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpEntity;
@@ -18,10 +19,14 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.HttpClientBuilder;
 
-public class CudamiFileResourcesBinaryClient extends CudamiBaseClient<FileResourceImpl> {
+public class CudamiFileResourcesBinaryClient {
+
+  protected final ObjectMapper mapper;
+  protected final URI serverUri;
 
   public CudamiFileResourcesBinaryClient(String serverUrl, ObjectMapper mapper) {
-    super(null, serverUrl, FileResourceImpl.class, mapper);
+    this.mapper = mapper;
+    this.serverUri = URI.create(serverUrl);
   }
 
   public FileResource create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiFileResourcesBinaryClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiFileResourcesBinaryClient.java
@@ -21,7 +21,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 public class CudamiFileResourcesBinaryClient extends CudamiBaseClient<FileResourceImpl> {
 
   public CudamiFileResourcesBinaryClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, FileResourceImpl.class, mapper);
+    super(null, serverUrl, FileResourceImpl.class, mapper);
   }
 
   public FileResource create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiFileResourcesMetadataClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiFileResourcesMetadataClient.java
@@ -9,13 +9,14 @@ import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
 public class CudamiFileResourcesMetadataClient extends CudamiBaseClient<FileResourceImpl> {
 
-  public CudamiFileResourcesMetadataClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, FileResourceImpl.class, mapper);
+  public CudamiFileResourcesMetadataClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, FileResourceImpl.class, mapper);
   }
 
   public FileResource create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiIdentifiablesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiIdentifiablesClient.java
@@ -9,14 +9,15 @@ import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.impl.identifiable.IdentifiableImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
 public class CudamiIdentifiablesClient extends CudamiBaseClient<IdentifiableImpl> {
 
-  public CudamiIdentifiablesClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, IdentifiableImpl.class, mapper);
+  public CudamiIdentifiablesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, IdentifiableImpl.class, mapper);
   }
 
   public Identifiable create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiIdentifierTypesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiIdentifierTypesClient.java
@@ -9,13 +9,14 @@ import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.impl.identifiable.IdentifierTypeImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
 public class CudamiIdentifierTypesClient extends CudamiBaseClient<IdentifierTypeImpl> {
 
-  public CudamiIdentifierTypesClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, IdentifierTypeImpl.class, mapper);
+  public CudamiIdentifierTypesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, IdentifierTypeImpl.class, mapper);
   }
 
   public IdentifierType create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiLocalesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiLocalesClient.java
@@ -2,13 +2,14 @@ package de.digitalcollections.cudami.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.exceptions.HttpException;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 
 public class CudamiLocalesClient extends CudamiBaseClient<Locale> {
 
-  public CudamiLocalesClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, Locale.class, mapper);
+  public CudamiLocalesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, Locale.class, mapper);
   }
 
   public List<String> findAllLanguages() throws HttpException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiProjectsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiProjectsClient.java
@@ -8,13 +8,14 @@ import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.impl.identifiable.entity.DigitalObjectImpl;
 import de.digitalcollections.model.impl.identifiable.entity.ProjectImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
 public class CudamiProjectsClient extends CudamiBaseClient<ProjectImpl> {
 
-  public CudamiProjectsClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, ProjectImpl.class, mapper);
+  public CudamiProjectsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, ProjectImpl.class, mapper);
   }
 
   public boolean addDigitalObject(UUID projectUuid, UUID digitalObjectUuid) throws HttpException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiSubtopicsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiSubtopicsClient.java
@@ -14,14 +14,15 @@ import de.digitalcollections.model.impl.identifiable.entity.TopicImpl;
 import de.digitalcollections.model.impl.identifiable.entity.parts.SubtopicImpl;
 import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
 import de.digitalcollections.model.impl.view.BreadcrumbNavigationImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
 public class CudamiSubtopicsClient extends CudamiBaseClient<SubtopicImpl> {
 
-  public CudamiSubtopicsClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, SubtopicImpl.class, mapper);
+  public CudamiSubtopicsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, SubtopicImpl.class, mapper);
   }
 
   public Subtopic create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiTopicsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiTopicsClient.java
@@ -8,13 +8,14 @@ import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.impl.identifiable.entity.TopicImpl;
 import de.digitalcollections.model.impl.identifiable.entity.parts.SubtopicImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
 public class CudamiTopicsClient extends CudamiBaseClient<TopicImpl> {
 
-  public CudamiTopicsClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, TopicImpl.class, mapper);
+  public CudamiTopicsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, TopicImpl.class, mapper);
   }
 
   public Topic create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiUsersClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiUsersClient.java
@@ -6,13 +6,14 @@ import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.security.User;
 import de.digitalcollections.model.impl.security.UserImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
 public class CudamiUsersClient extends CudamiBaseClient<UserImpl> {
 
-  public CudamiUsersClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, UserImpl.class, mapper);
+  public CudamiUsersClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, UserImpl.class, mapper);
   }
 
   public User create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebpagesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebpagesClient.java
@@ -11,14 +11,15 @@ import de.digitalcollections.model.impl.identifiable.entity.WebsiteImpl;
 import de.digitalcollections.model.impl.identifiable.entity.parts.WebpageImpl;
 import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
 import de.digitalcollections.model.impl.view.BreadcrumbNavigationImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
 public class CudamiWebpagesClient extends CudamiBaseClient<WebpageImpl> {
 
-  public CudamiWebpagesClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, WebpageImpl.class, mapper);
+  public CudamiWebpagesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, WebpageImpl.class, mapper);
   }
 
   public Webpage create() {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebsitesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebsitesClient.java
@@ -8,13 +8,14 @@ import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.impl.identifiable.entity.WebsiteImpl;
 import de.digitalcollections.model.impl.identifiable.entity.parts.WebpageImpl;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
 public class CudamiWebsitesClient extends CudamiBaseClient<WebsiteImpl> {
 
-  public CudamiWebsitesClient(String serverUrl, ObjectMapper mapper) {
-    super(serverUrl, WebsiteImpl.class, mapper);
+  public CudamiWebsitesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
+    super(http, serverUrl, WebsiteImpl.class, mapper);
   }
 
   public Website create() {

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/CudamiBaseClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/CudamiBaseClientTest.java
@@ -14,7 +14,8 @@ public class CudamiBaseClientTest {
     String serverUrl = "http://localhost:1234";
     String requestUrl = "/foo/bar";
     CudamiBaseClient base =
-        new CudamiBaseClient(serverUrl, Identifiable.class, new DigitalCollectionsObjectMapper());
+        new CudamiBaseClient(
+            null, serverUrl, Identifiable.class, new DigitalCollectionsObjectMapper());
     URI result = base.createFullUri(requestUrl);
     URI expectedResult = URI.create(serverUrl + requestUrl);
     assertThat(result).isEqualTo(expectedResult);
@@ -25,7 +26,8 @@ public class CudamiBaseClientTest {
     String serverUrl = "http://localhost:1234/cudami";
     String requestUrl = "/foo/bar";
     CudamiBaseClient base =
-        new CudamiBaseClient(serverUrl, Identifiable.class, new DigitalCollectionsObjectMapper());
+        new CudamiBaseClient(
+            null, serverUrl, Identifiable.class, new DigitalCollectionsObjectMapper());
     URI result = base.createFullUri(requestUrl);
     URI expectedResult = URI.create(serverUrl + requestUrl);
     assertThat(result).isEqualTo(expectedResult);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
@@ -240,7 +240,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
   public PageResponse<DigitalObject> getDigitalObjects(
       UUID collectionUuid, PageRequest pageRequest) {
     final String baseQuery =
-        "SELECT d.uuid d_uuid, d.label d_label,"
+        "SELECT d.uuid d_uuid, d.label d_label, d.refid d_refId,"
             + " d.created d_created, d.last_modified d_lastModified,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
             + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
@@ -200,7 +200,8 @@ public class DigitalObjectController {
       produces = "application/json")
   @ApiResponseObject
   public List<FileResource> saveFileResources(
-      @PathVariable UUID uuid, @RequestBody List<FileResource> fileResources) {
+      @ApiPathParam(description = "UUID of the digital object") @PathVariable("uuid") UUID uuid,
+      @RequestBody List<FileResource> fileResources) {
     return service.saveFileResources(uuid, fileResources);
   }
 
@@ -210,7 +211,9 @@ public class DigitalObjectController {
       produces = "application/json")
   @ApiResponseObject
   public DigitalObject update(
-      @PathVariable UUID uuid, @RequestBody DigitalObject digitalObject, BindingResult errors)
+      @ApiPathParam(description = "UUID of the digital object") @PathVariable("uuid") UUID uuid,
+      @RequestBody DigitalObject digitalObject,
+      BindingResult errors)
       throws IdentifiableServiceException {
     assert Objects.equals(uuid, digitalObject.getUuid());
     return service.update(digitalObject);

--- a/dc-cudami-templates/template-website-springboot/src/main/java/de/digitalcollections/cudami/template/website/springboot/config/SpringConfigBackend.java
+++ b/dc-cudami-templates/template-website-springboot/src/main/java/de/digitalcollections/cudami/template/website/springboot/config/SpringConfigBackend.java
@@ -1,6 +1,7 @@
 package de.digitalcollections.cudami.template.website.springboot.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.digitalcollections.cudami.client.CudamiClient;
 import de.digitalcollections.cudami.client.CudamiLocalesClient;
 import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +23,7 @@ public class SpringConfigBackend {
 
   @Bean
   public CudamiLocalesClient cudamiLocalesClient(ObjectMapper objectMapper) {
-    return new CudamiLocalesClient(serverUrl, objectMapper);
+    CudamiClient cudamiClient = new CudamiClient(serverUrl, objectMapper);
+    return cudamiClient.forLocales();
   }
 }

--- a/dc-cudami-templates/template-website-springboot/src/test/java/de/digitalcollections/cudami/template/website/springboot/TestConfig.java
+++ b/dc-cudami-templates/template-website-springboot/src/test/java/de/digitalcollections/cudami/template/website/springboot/TestConfig.java
@@ -33,7 +33,7 @@ public class TestConfig {
   public class TestCudamiLocalesClient extends CudamiLocalesClient {
 
     public TestCudamiLocalesClient(String serverUrl, ObjectMapper objectMapper) {
-      super(serverUrl, objectMapper);
+      super(null, serverUrl, objectMapper);
     }
 
     @Override


### PR DESCRIPTION
Fix OutOfMemory Error (unable to create native threads)
Cause was creating one HttpClient for every Cudami Repository Client (CudamiArticlesClient, CudamiCollectionsClient, ....).
Now creating one HttpClient for all, handing it over to all clients.