### PR TITLE
Add legend for publication status

### DIFF
--- a/dc-cudami-admin/src/main/resources/messages.properties
+++ b/dc-cudami-admin/src/main/resources/messages.properties
@@ -143,10 +143,27 @@ title_login=Please log in
 title_warning=Warning
 to=to
 tooltip_activate_user=activate user
+tooltip_currently_published=currently published
 tooltip_deactivate_user=deactivate user
 tooltip_edit=edit
 tooltip_enabled.false=deactivated
 tooltip_enabled.true=activated
+tooltip_no_longer_published=no longer published
+tooltip_not_yet_published=not yet published
+tooltip_publication_status=<ul class="list-group">\
+<li class="align-items-center d-flex list-group-item">\
+<span class="badge badge-danger badge-pill mr-3">&nbsp;</span>\
+no longer published (end date is in the past)\
+</li>\
+<li class="align-items-center d-flex list-group-item">\
+<span class="badge badge-pill badge-warning mr-3">&nbsp;</span>\
+not yet published (start date is empty or lies in the future)\
+</li>\
+<li class="align-items-center d-flex list-group-item">\
+<span class="badge badge-pill badge-success mr-3">&nbsp;</span>\
+currently published (start date is in the past/present and end date is empty or in the future)\
+</li>\
+</ul>
 tooltip_remove_digitalobject_from_collection=remove digital object from collection
 tooltip_remove_digitalobject_from_project=remove digital object from project
 tooltip_username=Please pay attention to upper and lower case

--- a/dc-cudami-admin/src/main/resources/messages_de.properties
+++ b/dc-cudami-admin/src/main/resources/messages_de.properties
@@ -142,10 +142,27 @@ title_login=Bitte einloggen
 title_warning=Warnung
 to=bis
 tooltip_activate_user=Benutzer aktivieren
+tooltip_currently_published=aktuell ver\u00f6ffentlicht
 tooltip_deactivate_user=Benutzer deaktivieren
 tooltip_edit=bearbeiten
 tooltip_enabled.false=deaktiviert
 tooltip_enabled.true=aktiviert
+tooltip_no_longer_published=nicht mehr ver\u00f6ffentlicht
+tooltip_not_yet_published=noch nicht ver\u00f6ffentlicht
+tooltip_publication_status=<ul class="list-group">\
+<li class="align-items-center d-flex list-group-item">\
+<span class="badge badge-danger badge-pill mr-3">&nbsp;</span>\
+nicht mehr ver\u00f6ffentlicht (Enddatum liegt in der Vergangenheit)\
+</li>\
+<li class="align-items-center d-flex list-group-item">\
+<span class="badge badge-pill badge-warning mr-3">&nbsp;</span>\
+noch nicht ver\u00f6ffentlicht (Startdatum ist leer oder liegt in der Zukunft)\
+</li>\
+<li class="align-items-center d-flex list-group-item">\
+<span class="badge badge-pill badge-success mr-3">&nbsp;</span>\
+aktuell ver\u00f6ffentlicht (Startdatum liegt in der Vergangenheit/Gegenwart und Enddatum ist leer oder liegt in der Zukunft)\
+</li>\
+</ul>
 tooltip_remove_digitalobject_from_collection=Digitalisat (Digitales Objekt) aus Sammlung entfernen
 tooltip_remove_digitalobject_from_project=Digitalisat (Digitales Objekt) aus Projekt entfernen
 tooltip_username=Bitte achten Sie auf Gro\u00df- und Kleinschreibung

--- a/dc-cudami-admin/src/main/resources/templates/webpages/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/webpages/view.html
@@ -52,7 +52,12 @@
               <div class="col-md-9"><span th:text="*{uuid}">b7a245fe-da46-4d7d-a8e4-a7ee8f24f840</span></div>
             </div>
             <div class="row">
-              <div class="col-md-3"><label class="font-weight-bold" th:text="#{publicationStatus}">Publication status</label></div>
+              <div class="col-md-3">
+                <label class="font-weight-bold" th:text="#{publicationStatus}">Publication status</label>
+                <button class="btn btn-link" data-html="true" data-placement="bottom" data-toggle="popover" data-trigger="focus" th:attr="data-content=#{tooltip_publication_status}" id="publication_status_tooltip" type="button">
+                  <i class="fas fa-question-circle"></i>
+                </button>
+              </div>
               <div class="col-md-9" th:with="now=${T(java.time.LocalDate).now()}">
                 <th:block th:if="${webpage.publicationStart}  == null OR  ${webpage.publicationStart.compareTo(now)} > 0"><span class="badge badge-pill badge-warning">&nbsp;</span></th:block>
                 <th:block th:if="(${webpage.publicationStart} != null AND ${webpage.publicationStart.compareTo(now)} <= 0) AND (${webpage.publicationEnd} == null OR ${webpage.publicationEnd.compareTo(now)} >= 0)"><span class="badge badge-pill badge-success">&nbsp;</span></th:block>
@@ -121,9 +126,9 @@
               <tr th:each="subpage, stats : *{children}">
                 <td class="text-right" th:text="${stats.index + 1}">1</td>
                 <td class="center" th:with="now=${T(java.time.LocalDate).now()}">
-                  <th:block th:if="${subpage.publicationStart}  == null OR  ${subpage.publicationStart.compareTo(now)} > 0"><span class="badge badge-pill badge-warning">&nbsp;</span></th:block>
-                  <th:block th:if="(${subpage.publicationStart} != null AND ${subpage.publicationStart.compareTo(now)} <= 0) AND (${subpage.publicationEnd} == null OR ${subpage.publicationEnd.compareTo(now)} >= 0)"><span class="badge badge-pill badge-success">&nbsp;</span></th:block>
-                  <th:block th:if="(${subpage.publicationStart} != null AND ${subpage.publicationStart.compareTo(now)} <= 0) AND (${subpage.publicationEnd} != null AND ${subpage.publicationEnd.compareTo(now)} < 0)"><span class="badge badge-pill badge-danger">&nbsp;</span></th:block>
+                  <th:block th:if="${subpage.publicationStart}  == null OR  ${subpage.publicationStart.compareTo(now)} > 0"><span class="badge badge-pill badge-warning" th:title="#{tooltip_not_yet_published}">&nbsp;</span></th:block>
+                  <th:block th:if="(${subpage.publicationStart} != null AND ${subpage.publicationStart.compareTo(now)} <= 0) AND (${subpage.publicationEnd} == null OR ${subpage.publicationEnd.compareTo(now)} >= 0)"><span class="badge badge-pill badge-success" th:title="#{tooltip_currently_published}">&nbsp;</span></th:block>
+                  <th:block th:if="(${subpage.publicationStart} != null AND ${subpage.publicationStart.compareTo(now)} <= 0) AND (${subpage.publicationEnd} != null AND ${subpage.publicationEnd.compareTo(now)} < 0)"><span class="badge badge-pill badge-danger" th:title="#{tooltip_no_longer_published}">&nbsp;</span></th:block>
                 </td>
                 <td class="center">
                   <th:block th:insert="cudami/fragments/previewimage-to-html::renderImage(${subpage.previewImage}, ${subpage.previewImageRenderingHints}, ${#locale}, 50)"></th:block>
@@ -149,6 +154,9 @@
 
   <th:block layout:fragment="beforeBodyEnds">
     <div th:replace="fragments/modals :: selectItemDialog"></div>
+    <script type="text/javascript" th:inline="javascript">
+      $('#publication_status_tooltip').popover();
+    </script>
   </th:block>
 </body>
 </html>


### PR DESCRIPTION
This PR adds a legend for the publication status:
![screenshot-localhost_9898-2020 08 13-10_56_07](https://user-images.githubusercontent.com/19190936/90114908-acd6be00-dd53-11ea-84ab-5ad4c07e27f4.png)