### PR TITLE
Add information about successfully moving subcollections

### DIFF
--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -115,6 +115,7 @@
     },
     "startPublicationDate": "Start-Publikationsdatum",
     "subcollections": "Untergeordnete Sammlungen",
+    "subcollectionSuccessfullyMoved": "Die untergeordnete Sammlung wurde erfolgreich in die gewählte Sammlung verschoben.",
     "text": "Langtext",
     "title": "Titel",
     "tooltip": "Tooltip",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -115,6 +115,7 @@
     },
     "startPublicationDate": "Start of publication",
     "subcollections": "Sub collections",
+    "subcollectionSuccessfullyMoved": "The subcollection has been moved successfully to the selected collection.",
     "text": "Long text",
     "title": "Title",
     "tooltip": "Tooltip",


### PR DESCRIPTION
This PR adds
- an information about successfully moving subcollections
- an update of the current page