### PR TITLE
Add floating label instead of placeholder

### DIFF
--- a/dc-cudami-editor/src/components/IdentifiableForm.jsx
+++ b/dc-cudami-editor/src/components/IdentifiableForm.jsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react'
 import {Label} from 'reactstrap'
 import {withTranslation} from 'react-i18next'
 
+import './common.css'
 import './IdentifiableForm.css'
 import ArticleForm from './ArticleForm'
 import CollectionForm from './CollectionForm'

--- a/dc-cudami-editor/src/components/common.css
+++ b/dc-cudami-editor/src/components/common.css
@@ -1,0 +1,17 @@
+.floating-label {
+  color: #666;
+  left: 14px;
+  pointer-events: none;
+  position: absolute;
+  top: 7px;
+  transition: 0.2s ease all;
+}
+
+input:focus ~ .floating-label,
+input:not([value=""]) ~ .floating-label {
+  background: white;
+  font-size: 14px;
+  padding: 0 5px;
+  top: -11px;
+  z-index: 5;
+}

--- a/dc-cudami-editor/src/components/modals/imageAdder/ImageMetadataForm.jsx
+++ b/dc-cudami-editor/src/components/modals/imageAdder/ImageMetadataForm.jsx
@@ -49,10 +49,10 @@ const ImageMetadataForm = ({
               <Input
                 name="caption"
                 onChange={(evt) => onChange('caption', evt.target.value)}
-                placeholder={t('caption')}
                 type="text"
                 value={caption}
               />
+              <span className="floating-label">{t('caption')}</span>
               <InputGroupAddon addonType="append">
                 <InputGroupText>
                   <FaQuestionCircle
@@ -74,10 +74,10 @@ const ImageMetadataForm = ({
               <Input
                 name="title"
                 onChange={(evt) => onChange('title', evt.target.value)}
-                placeholder={t('tooltip')}
                 type="text"
                 value={title}
               />
+              <span className="floating-label">{t('tooltip')}</span>
               <InputGroupAddon addonType="append">
                 <InputGroupText>
                   <FaQuestionCircle
@@ -99,10 +99,10 @@ const ImageMetadataForm = ({
               <Input
                 name="altText"
                 onChange={(evt) => onChange('altText', evt.target.value)}
-                placeholder={t('altText')}
                 type="text"
                 value={altText}
               />
+              <span className="floating-label">{t('altText')}</span>
               <InputGroupAddon addonType="append">
                 <InputGroupText>
                   <FaQuestionCircle


### PR DESCRIPTION
This PR adds floating labels instead of placeholders for some input fields, so that the label is still visible when the is content in the field:

![Peek 2020-09-02 15-33](https://user-images.githubusercontent.com/19190936/91990211-c0ad8880-ed31-11ea-8f1b-597836d822ba.gif)