### PR TITLE
Add language tabs for lists

### DIFF
--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
@@ -25,10 +25,8 @@ import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -286,17 +284,16 @@ public class CollectionsController extends AbstractController {
     Collection collection = service.findOne(uuid);
     List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, collection.getLabel().getLocales());
-    Set<Locale> existingSubcollectionLanguages =
+    List<Locale> existingSubcollectionLanguages =
         collection.getChildren().stream()
             .map(child -> child.getLabel().getLocales())
             .flatMap(l -> l.stream())
-            .collect(Collectors.toSet());
-    existingSubcollectionLanguages =
-        new HashSet<>(
-            languageSortingHelper.sortLanguages(displayLocale, existingSubcollectionLanguages));
+            .collect(Collectors.toList());
 
     model.addAttribute("existingLanguages", existingLanguages);
-    model.addAttribute("existingSubcollectionLanguages", existingSubcollectionLanguages);
+    model.addAttribute(
+        "existingSubcollectionLanguages",
+        languageSortingHelper.sortLanguages(displayLocale, existingSubcollectionLanguages));
     model.addAttribute("collection", collection);
 
     BreadcrumbNavigation breadcrumbNavigation = service.getBreadcrumbNavigation(uuid);

--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/identifiable/entity/CollectionsController.java
@@ -25,9 +25,12 @@ import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -283,8 +286,17 @@ public class CollectionsController extends AbstractController {
     Collection collection = service.findOne(uuid);
     List<Locale> existingLanguages =
         languageSortingHelper.sortLanguages(displayLocale, collection.getLabel().getLocales());
+    Set<Locale> existingSubcollectionLanguages =
+        collection.getChildren().stream()
+            .map(child -> child.getLabel().getLocales())
+            .flatMap(l -> l.stream())
+            .collect(Collectors.toSet());
+    existingSubcollectionLanguages =
+        new HashSet<>(
+            languageSortingHelper.sortLanguages(displayLocale, existingSubcollectionLanguages));
 
     model.addAttribute("existingLanguages", existingLanguages);
+    model.addAttribute("existingSubcollectionLanguages", existingSubcollectionLanguages);
     model.addAttribute("collection", collection);
 
     BreadcrumbNavigation breadcrumbNavigation = service.getBreadcrumbNavigation(uuid);

--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/util/LanguageSortingHelper.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/util/LanguageSortingHelper.java
@@ -21,6 +21,7 @@ public class LanguageSortingHelper {
     languagesToSort.stream()
         .filter(l -> !prioritisedSortedLanguages.contains(l))
         .sorted(Comparator.comparing(l -> l.getDisplayLanguage(displayLocale)))
+        .distinct()
         .forEach(sortedLanguages::add);
     return sortedLanguages;
   }

--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/util/LanguageSortingHelper.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/util/LanguageSortingHelper.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.admin.util;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -12,7 +13,7 @@ public class LanguageSortingHelper {
     this.prioritisedSortedLanguages = prioritisedSortedLanguages;
   }
 
-  public List<Locale> sortLanguages(Locale displayLocale, List<Locale> languagesToSort) {
+  public List<Locale> sortLanguages(Locale displayLocale, Collection<Locale> languagesToSort) {
     List<Locale> sortedLanguages =
         prioritisedSortedLanguages.stream()
             .filter(languagesToSort::contains)

--- a/dc-cudami-admin/src/main/resources/templates/collections/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/collections/view.html
@@ -100,6 +100,7 @@
           enableAdd: true,
           enableMove: true,
           enableRemove: true,
+          existingLanguages: /*[[${existingSubcollectionLanguages}]]*/,
           id: "subcollection-list",
           parentType: "collection",
           parentUuid: /*[[*{uuid}]]*/,

--- a/dc-cudami-editor/src/components/IdentifiableListItem.jsx
+++ b/dc-cudami-editor/src/components/IdentifiableListItem.jsx
@@ -36,9 +36,7 @@ const IdentifiableListItem = ({
           width={30}
         />
       </td>
-      <td>
-        <a href={viewUrl}>{label}</a>
-      </td>
+      <td>{label && <a href={viewUrl}>{label}</a>}</td>
       <td>
         <ul className="list-inline mb-0">
           {identifiers.map(({id, namespace}) => (

--- a/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
+++ b/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
@@ -1,14 +1,16 @@
 import uniqBy from 'lodash/uniqBy'
 import React, {Component} from 'react'
-import {Alert, Button, Col, Row, Table} from 'reactstrap'
+import {Alert, Button, Card, CardBody, Col, Nav, Row, Table} from 'reactstrap'
 import {withTranslation} from 'react-i18next'
 import {FaHashtag, FaImage} from 'react-icons/fa'
 import ReactPaginate from 'react-paginate'
 
+import './common.css'
 import AppContext from './AppContext'
+import IdentifiableListItem from './IdentifiableListItem'
+import LanguageTab from './LanguageTab'
 import AddAttachedIdentifiablesModal from './modals/AddAttachedIdentifiablesModal'
 import RemoveAttachedIdentifiableModal from './modals/RemoveAttachedIdentifiableModal'
-import IdentifiableListItem from './IdentifiableListItem'
 import {
   addAttachedIdentifiable,
   addAttachedIdentifiables,
@@ -24,7 +26,10 @@ class PagedIdentifiableList extends Component {
 
   constructor(props) {
     super(props)
+    const {existingLanguages} = this.props
     this.state = {
+      activeLanguage: existingLanguages ? existingLanguages[0] : '',
+      existingLanguages: existingLanguages ?? [],
       identifiables: [],
       identifierTypes: [],
       modalsOpen: {
@@ -158,6 +163,12 @@ class PagedIdentifiableList extends Component {
     return successful
   }
 
+  toggleLanguage = (activeLanguage) => {
+    this.setState({
+      activeLanguage,
+    })
+  }
+
   toggleModal = (name) => {
     this.setState({
       modalsOpen: {
@@ -195,7 +206,9 @@ class PagedIdentifiableList extends Component {
       uiLocale,
     } = this.props
     const {
+      activeLanguage,
       defaultLanguage,
+      existingLanguages,
       identifiables,
       identifierTypes,
       modalsOpen,
@@ -232,106 +245,118 @@ class PagedIdentifiableList extends Component {
             {t(`${type}SuccessfullyMoved`)}
           </Alert>
         )}
-        {this.state.identifiables.length > 0 && (
-          <ReactPaginate
-            activeClassName="active"
-            breakClassName="page-item"
-            breakLabel="&hellip;"
-            breakLinkClassName="page-link"
-            containerClassName="d-inline-flex mb-2 pagination"
-            disabledClassName="disabled"
-            forcePage={this.state.pageNumber}
-            marginPagesDisplayed={1}
-            nextClassName="page-item"
-            nextLabel="&raquo;"
-            nextLinkClassName="page-link"
-            onPageChange={this.updatePage}
-            pageClassName="page-item"
-            pageCount={this.state.numberOfPages}
-            pageLinkClassName="page-link"
-            pageRangeDisplayed={5}
-            previousClassName="page-item"
-            previousLabel="&laquo;"
-            previousLinkClassName="page-link"
-          />
-        )}
-        <span className="ml-2">
-          {t(`totalElements.${type}s`, {count: this.state.totalElements})}
-        </span>
-        <Table bordered className="mb-0" hover responsive size="sm" striped>
-          <thead>
-            <tr>
-              <th className="text-right">
-                <FaHashtag />
-              </th>
-              <th className="text-center">
-                <FaImage />
-              </th>
-              <th>{t('label')}</th>
-              <th>{t('identifiers')}</th>
-              <th className="text-center">{t('lastModified')}</th>
-              <th className="text-center">{t('actions')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {identifiables.map((identifiable, index) => (
-              <IdentifiableListItem
-                apiContextPath={apiContextPath}
-                enableMove={enableMove}
-                enableRemove={enableRemove}
-                identifiers={identifiable.identifiers}
-                identifierTypes={identifierTypes}
-                index={index + 1 + pageNumber * this.pageSize}
-                key={identifiable.uuid}
-                label={
-                  identifiable.label[defaultLanguage] ??
-                  Object.values(identifiable.label)[0]
-                }
-                lastModified={identifiable.lastModified}
-                onMove={() => {
-                  this.toggleModal('moveAttachedIdentifiable')
-                  this.setState({moveIndex: index})
-                }}
-                onRemove={() => {
-                  this.toggleModal('removeAttachedIdentifiable')
-                  this.setState({removeIndex: index})
-                }}
-                parentType={parentType}
-                previewImage={identifiable.previewImage}
-                previewImageRenderingHints={
-                  identifiable.previewImageRenderingHints
-                }
-                showEdit={showEdit}
-                type={type}
-                uiLocale={uiLocale}
-                uuid={identifiable.uuid}
+        <Nav tabs>
+          {existingLanguages.length > 1 &&
+            existingLanguages.map((language) => (
+              <LanguageTab
+                activeLanguage={activeLanguage}
+                key={language}
+                language={language}
+                toggle={this.toggleLanguage}
               />
             ))}
-          </tbody>
-        </Table>
-        {identifiables.length > 0 && (
-          <ReactPaginate
-            activeClassName="active"
-            breakClassName="page-item"
-            breakLabel="&hellip;"
-            breakLinkClassName="page-link"
-            containerClassName="mt-2 pagination"
-            disabledClassName="disabled"
-            forcePage={pageNumber}
-            marginPagesDisplayed={1}
-            nextClassName="page-item"
-            nextLabel="&raquo;"
-            nextLinkClassName="page-link"
-            onPageChange={this.updatePage}
-            pageClassName="page-item"
-            pageCount={numberOfPages}
-            pageLinkClassName="page-link"
-            pageRangeDisplayed={5}
-            previousClassName="page-item"
-            previousLabel="&laquo;"
-            previousLinkClassName="page-link"
-          />
-        )}
+        </Nav>
+        <Card className="border-top-0">
+          <CardBody>
+            {this.state.identifiables.length > 0 && (
+              <ReactPaginate
+                activeClassName="active"
+                breakClassName="page-item"
+                breakLabel="&hellip;"
+                breakLinkClassName="page-link"
+                containerClassName="d-inline-flex mb-2 pagination"
+                disabledClassName="disabled"
+                forcePage={this.state.pageNumber}
+                marginPagesDisplayed={1}
+                nextClassName="page-item"
+                nextLabel="&raquo;"
+                nextLinkClassName="page-link"
+                onPageChange={this.updatePage}
+                pageClassName="page-item"
+                pageCount={this.state.numberOfPages}
+                pageLinkClassName="page-link"
+                pageRangeDisplayed={5}
+                previousClassName="page-item"
+                previousLabel="&laquo;"
+                previousLinkClassName="page-link"
+              />
+            )}
+            <span className="ml-2">
+              {t(`totalElements.${type}s`, {count: this.state.totalElements})}
+            </span>
+            <Table bordered className="mb-0" hover responsive size="sm" striped>
+              <thead>
+                <tr>
+                  <th className="text-right">
+                    <FaHashtag />
+                  </th>
+                  <th className="text-center">
+                    <FaImage />
+                  </th>
+                  <th>{t('label')}</th>
+                  <th>{t('identifiers')}</th>
+                  <th className="text-center">{t('lastModified')}</th>
+                  <th className="text-center">{t('actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {identifiables.map((identifiable, index) => (
+                  <IdentifiableListItem
+                    apiContextPath={apiContextPath}
+                    enableMove={enableMove}
+                    enableRemove={enableRemove}
+                    identifiers={identifiable.identifiers}
+                    identifierTypes={identifierTypes}
+                    index={index + 1 + pageNumber * this.pageSize}
+                    key={identifiable.uuid}
+                    label={identifiable.label[activeLanguage]}
+                    lastModified={identifiable.lastModified}
+                    onMove={() => {
+                      this.toggleModal('moveAttachedIdentifiable')
+                      this.setState({moveIndex: index})
+                    }}
+                    onRemove={() => {
+                      this.toggleModal('removeAttachedIdentifiable')
+                      this.setState({removeIndex: index})
+                    }}
+                    parentType={parentType}
+                    previewImage={identifiable.previewImage}
+                    previewImageRenderingHints={
+                      identifiable.previewImageRenderingHints
+                    }
+                    showEdit={showEdit}
+                    type={type}
+                    uiLocale={uiLocale}
+                    uuid={identifiable.uuid}
+                  />
+                ))}
+              </tbody>
+            </Table>
+            {identifiables.length > 0 && (
+              <ReactPaginate
+                activeClassName="active"
+                breakClassName="page-item"
+                breakLabel="&hellip;"
+                breakLinkClassName="page-link"
+                containerClassName="mb-0 mt-2 pagination"
+                disabledClassName="disabled"
+                forcePage={pageNumber}
+                marginPagesDisplayed={1}
+                nextClassName="page-item"
+                nextLabel="&raquo;"
+                nextLinkClassName="page-link"
+                onPageChange={this.updatePage}
+                pageClassName="page-item"
+                pageCount={numberOfPages}
+                pageLinkClassName="page-link"
+                pageRangeDisplayed={5}
+                previousClassName="page-item"
+                previousLabel="&laquo;"
+                previousLinkClassName="page-link"
+              />
+            )}
+          </CardBody>
+        </Card>
         {enableAdd && (
           <AddAttachedIdentifiablesModal
             action="add"

--- a/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
+++ b/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
@@ -163,12 +163,6 @@ class PagedIdentifiableList extends Component {
     return successful
   }
 
-  toggleLanguage = (activeLanguage) => {
-    this.setState({
-      activeLanguage,
-    })
-  }
-
   toggleModal = (name) => {
     this.setState({
       modalsOpen: {
@@ -252,7 +246,7 @@ class PagedIdentifiableList extends Component {
                 activeLanguage={activeLanguage}
                 key={language}
                 language={language}
-                toggle={this.toggleLanguage}
+                toggle={(activeLanguage) => this.setState({activeLanguage})}
               />
             ))}
         </Nav>

--- a/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
+++ b/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import uniqBy from 'lodash/uniqBy'
 import React, {Component} from 'react'
 import {Alert, Button, Card, CardBody, Col, Nav, Row, Table} from 'reactstrap'
@@ -209,7 +210,37 @@ class PagedIdentifiableList extends Component {
       numberOfPages,
       pageNumber,
       showSuccessfullyMoved,
+      totalElements,
     } = this.state
+    const TablePagination = ({position}) => (
+      <ReactPaginate
+        activeClassName="active"
+        breakClassName="page-item"
+        breakLabel="&hellip;"
+        breakLinkClassName="page-link"
+        containerClassName={classNames({
+          'd-inline-flex': true,
+          pagination: true,
+          'mb-0': position === 'under',
+          'mb-2': position === 'above',
+          'mt-2': position === 'under',
+        })}
+        disabledClassName="disabled"
+        forcePage={pageNumber}
+        marginPagesDisplayed={1}
+        nextClassName="page-item"
+        nextLabel="&raquo;"
+        nextLinkClassName="page-link"
+        onPageChange={this.updatePage}
+        pageClassName="page-item"
+        pageCount={numberOfPages}
+        pageLinkClassName="page-link"
+        pageRangeDisplayed={5}
+        previousClassName="page-item"
+        previousLabel="&laquo;"
+        previousLinkClassName="page-link"
+      />
+    )
     return (
       <AppContext.Provider value={{apiContextPath, defaultLanguage, mockApi}}>
         <Row>
@@ -252,31 +283,9 @@ class PagedIdentifiableList extends Component {
         </Nav>
         <Card className="border-top-0">
           <CardBody>
-            {this.state.identifiables.length > 0 && (
-              <ReactPaginate
-                activeClassName="active"
-                breakClassName="page-item"
-                breakLabel="&hellip;"
-                breakLinkClassName="page-link"
-                containerClassName="d-inline-flex mb-2 pagination"
-                disabledClassName="disabled"
-                forcePage={this.state.pageNumber}
-                marginPagesDisplayed={1}
-                nextClassName="page-item"
-                nextLabel="&raquo;"
-                nextLinkClassName="page-link"
-                onPageChange={this.updatePage}
-                pageClassName="page-item"
-                pageCount={this.state.numberOfPages}
-                pageLinkClassName="page-link"
-                pageRangeDisplayed={5}
-                previousClassName="page-item"
-                previousLabel="&laquo;"
-                previousLinkClassName="page-link"
-              />
-            )}
+            {identifiables.length > 0 && <TablePagination position="above" />}
             <span className="ml-2">
-              {t(`totalElements.${type}s`, {count: this.state.totalElements})}
+              {t(`totalElements.${type}s`, {count: totalElements})}
             </span>
             <Table bordered className="mb-0" hover responsive size="sm" striped>
               <thead>
@@ -326,29 +335,7 @@ class PagedIdentifiableList extends Component {
                 ))}
               </tbody>
             </Table>
-            {identifiables.length > 0 && (
-              <ReactPaginate
-                activeClassName="active"
-                breakClassName="page-item"
-                breakLabel="&hellip;"
-                breakLinkClassName="page-link"
-                containerClassName="mb-0 mt-2 pagination"
-                disabledClassName="disabled"
-                forcePage={pageNumber}
-                marginPagesDisplayed={1}
-                nextClassName="page-item"
-                nextLabel="&raquo;"
-                nextLinkClassName="page-link"
-                onPageChange={this.updatePage}
-                pageClassName="page-item"
-                pageCount={numberOfPages}
-                pageLinkClassName="page-link"
-                pageRangeDisplayed={5}
-                previousClassName="page-item"
-                previousLabel="&laquo;"
-                previousLinkClassName="page-link"
-              />
-            )}
+            {identifiables.length > 0 && <TablePagination position="under" />}
           </CardBody>
         </Card>
         {enableAdd && (

--- a/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
+++ b/dc-cudami-editor/src/components/PagedIdentifiableList.jsx
@@ -28,7 +28,7 @@ class PagedIdentifiableList extends Component {
     super(props)
     const {existingLanguages} = this.props
     this.state = {
-      activeLanguage: existingLanguages ? existingLanguages[0] : '',
+      activeLanguage: existingLanguages?.[0] ?? '',
       existingLanguages: existingLanguages ?? [],
       identifiables: [],
       identifierTypes: [],

--- a/dc-cudami-editor/src/lib/IdentifiableList.jsx
+++ b/dc-cudami-editor/src/lib/IdentifiableList.jsx
@@ -12,6 +12,7 @@ export default function (config) {
       enableAdd={config.enableAdd}
       enableMove={config.enableMove}
       enableRemove={config.enableRemove}
+      existingLanguages={config.existingLanguages}
       parentType={config.parentType}
       parentUuid={config.parentUuid}
       showEdit={config.showEdit}


### PR DESCRIPTION
This PR adds language tabs for paged list of identifiables:
![screenshot-localhost_9898-2020 09 04-09_59_38](https://user-images.githubusercontent.com/19190936/92215698-76451c80-ee95-11ea-9f13-a686cc625688.png)