### PR TITLE
test: temporarily disable cudami.server.ApplicationTest

### DIFF
--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageHtmlControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageHtmlControllerTest.java
@@ -20,6 +20,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,7 @@ public class WebpageHtmlControllerTest {
 
   @MockBean private WebpageService webpageService;
 
+  @Disabled("Disable until issue #578 got fixed")
   @Test
   public void shouldReturnValidHtml() throws Exception {
     prepareWebpageMock();


### PR DESCRIPTION
This PR temporarily disables the `cudami.server.ApplicationTest` due to a strange bug on OpenJDK >= 11.0.8 (see #578).
