### PR TITLE
Refactor iiifBaseUrl to httpBaseUrl

### DIFF
--- a/dc-cudami-client/src/main/resources/templates/cudami/fragments/previewimage-to-html.html
+++ b/dc-cudami-client/src/main/resources/templates/cudami/fragments/previewimage-to-html.html
@@ -9,13 +9,13 @@
         <th:block th:if="${hints != null && hints.targetLink != null}">
           <a th:href="${hints.targetLink}" th:target="${hints.openLinkInNewWindow}? '_blank'">
         </th:block>
-        <th:block th:if="${previewImage.iiifBaseUrl}">
-          <img th:src="|${previewImage.iiifBaseUrl}/full/${width},/0/default.${#strings.equals(previewImage.mimeType.subType, 'png')?'png':'jpg'}|"
+        <th:block th:if="${previewImage.httpBaseUrl}">
+          <img th:src="|${previewImage.httpBaseUrl}/full/${width},/0/default.${#strings.equals(previewImage.mimeType.subType, 'png')?'png':'jpg'}|"
                th:alt="${hints != null && hints.altText != null}? ${hints.altText.getText(language)} : ${previewImage.filename}"
                th:title="${hints != null && hints.title != null}? ${hints.title.getText(language)}"
                />
         </th:block>
-        <th:block th:unless="${previewImage.iiifBaseUrl}">
+        <th:block th:unless="${previewImage.httpBaseUrl}">
           <img th:src="${previewImage.uri}"
                th:alt="${hints != null && hints.altText != null}? ${hints.altText.getText(language)} : ${previewImage.filename}"
                th:title="${hints != null && hints.title != null}? ${hints.title.getText(language)}"

--- a/dc-cudami-editor/src/components/utils.js
+++ b/dc-cudami-editor/src/components/utils.js
@@ -1,5 +1,5 @@
 export function getImageUrl(image, width = 'full') {
-  if (!image.iiifBaseUrl || !image.mimeType) {
+  if (!image.httpBaseUrl || !image.mimeType) {
     return image.uri
   }
   const mimeExtensionMapping = {
@@ -7,7 +7,7 @@ export function getImageUrl(image, width = 'full') {
     png: 'png',
   }
   const subMimeType = image.mimeType.split('/')[1]
-  return `${image.iiifBaseUrl}/full/${width}/0/default.${
+  return `${image.httpBaseUrl}/full/${width}/0/default.${
     mimeExtensionMapping[subMimeType] ?? 'jpg'
   }`
 }

--- a/dc-cudami-server/dc-cudami-server-backend-file/src/main/java/de/digitalcollections/cudami/server/backend/impl/file/identifiable/resource/FileResourceBinaryRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-file/src/main/java/de/digitalcollections/cudami/server/backend/impl/file/identifiable/resource/FileResourceBinaryRepositoryImpl.java
@@ -362,10 +362,10 @@ public class FileResourceBinaryRepositoryImpl implements FileResourceBinaryRepos
           iiifUrl += "/";
         }
         iiifUrl += getIiifIdentifier(imageFileResource);
-        imageFileResource.setIiifBaseUrl(URI.create(iiifUrl).toURL());
+        imageFileResource.setHttpBaseUrl(URI.create(iiifUrl).toURL());
       } catch (MalformedURLException ex) {
         throw new IllegalStateException(
-            "creating a valid iiif url failed! check configuration!", ex);
+            "Creating a valid iiif url failed! Check configuration!", ex);
       }
     }
   }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
@@ -45,7 +45,7 @@ public class IdentifiableRepositoryImpl<I extends Identifiable>
           + " i.created i_created, i.last_modified i_last_modified,"
           + " i.preview_hints i_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM identifiables as i"
           + " LEFT JOIN identifiers as id on i.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on i.previewfileresource = file.uuid";
@@ -56,7 +56,7 @@ public class IdentifiableRepositoryImpl<I extends Identifiable>
           + " i.identifiable_type i_type,"
           + " i.created i_created, i.last_modified i_lastModified,"
           + " i.preview_hints i_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.uri f_uri, file.filename f_filename, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.uri f_uri, file.filename f_filename, file.http_base_url f_httpBaseUrl"
           + " FROM identifiables as i"
           + " LEFT JOIN fileresources_image as file on i.previewfileresource = file.uuid";
 
@@ -130,7 +130,7 @@ public class IdentifiableRepositoryImpl<I extends Identifiable>
         new StringBuilder(
             "SELECT i.uuid i_uuid, i.label i_label, i.description i_description,"
                 + " i.identifiable_type i_identifiableType,"
-                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
                 + " FROM identifiables as i"
                 + " LEFT JOIN fileresources_image as file on i.previewfileresource = file.uuid"
                 + " LEFT JOIN LATERAL jsonb_object_keys(i.label) l(keys) on i.label is not null"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/ArticleRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/ArticleRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ArticleRepositoryImpl extends EntityRepositoryImpl<Article>
           + " a.created a_created, a.last_modified a_lastModified,"
           + " a.text a_text, a.preview_hints a_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM articles as a"
           + " LEFT JOIN identifiers as id on a.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on a.previewfileresource = file.uuid";
@@ -48,7 +48,7 @@ public class ArticleRepositoryImpl extends EntityRepositoryImpl<Article>
           + " a.identifiable_type a_type, a.entity_type a_entityType,"
           + " a.created a_created, a.last_modified a_lastModified,"
           + " a.preview_hints a_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM articles as a"
           + " LEFT JOIN fileresources_image as file on a.previewfileresource = file.uuid";
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
@@ -48,7 +48,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
           + " c.created c_created, c.last_modified c_lastModified,"
           + " c.text c_text, c.preview_hints c_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM collections as c"
           + " LEFT JOIN identifiers as id on c.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on c.previewfileresource = file.uuid";
@@ -60,7 +60,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
           + " c.identifiable_type c_type, c.entity_type c_entityType,"
           + " c.created c_created, c.last_modified c_lastModified,"
           + " c.preview_hints c_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM collections as c"
           + " LEFT JOIN fileresources_image as file on c.previewfileresource = file.uuid";
 
@@ -196,7 +196,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
         new StringBuilder(
             "SELECT c.uuid c_uuid, c.refid c_refId, c.label c_label, c.description c_description,"
                 + " c.entity_type c_entityType,"
-                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
                 + " FROM collections as c"
                 + " LEFT JOIN fileresources_image as file on c.previewfileresource = file.uuid"
                 + " LEFT JOIN LATERAL jsonb_object_keys(c.label) l(keys) on c.label is not null"
@@ -351,7 +351,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
         "SELECT d.uuid d_uuid, d.label d_label, d.refid d_refId,"
             + " d.created d_created, d.last_modified d_lastModified,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM digitalobjects as d"
             + " LEFT JOIN identifiers as id on d.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on d.previewfileresource = file.uuid"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CorporationRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CorporationRepositoryImpl.java
@@ -37,7 +37,7 @@ public class CorporationRepositoryImpl extends EntityRepositoryImpl<Corporation>
           + " c.created c_created, c.last_modified c_lastModified,"
           + " c.text c_text, c.homepage_url c_homepageUrl, c.preview_hints c_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM corporations as c"
           + " LEFT JOIN identifiers as id on c.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on c.previewfileresource = file.uuid";
@@ -48,7 +48,7 @@ public class CorporationRepositoryImpl extends EntityRepositoryImpl<Corporation>
           + " c.identifiable_type c_type, c.entity_type c_entityType,"
           + " c.created c_created, c.last_modified c_lastModified,"
           + " c.preview_hints c_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM corporations as c"
           + " LEFT JOIN fileresources_image as file on c.previewfileresource = file.uuid";
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -51,7 +51,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
           + " d.preview_hints d_previewImageRenderingHints,"
           // TODO: add d.license d_license, d.version d_version, when features added
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl,"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl,"
           // related file resources
           + " fr.uuid fr_uuid, fr.filename fr_filename, fr.mimetype fr_mimetype, fr.size_in_bytes fr_sizeInBytes, fr.uri fr_uri"
           + " FROM digitalobjects as d"
@@ -66,7 +66,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
           + " d.identifiable_type d_type, d.entity_type d_entityType,"
           + " d.created d_created, d.last_modified d_lastModified,"
           + " d.preview_hints d_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM digitalobjects as d"
           + " LEFT JOIN fileresources_image as file on d.previewfileresource = file.uuid";
 
@@ -129,7 +129,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
         new StringBuilder(
             "SELECT d.uuid d_uuid, d.refid d_refId, d.label d_label, d.description d_description,"
                 + " d.entity_type d_entityType,"
-                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
                 + " FROM digitalobjects as d"
                 + " LEFT JOIN fileresources_image as file on d.previewfileresource = file.uuid"
                 + " LEFT JOIN LATERAL jsonb_object_keys(d.label) l(keys) on d.label is not null"
@@ -296,7 +296,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
         "SELECT c.uuid c_uuid, c.label c_label,"
             + " c.created c_created, c.last_modified c_lastModified,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM collections as c"
             + " LEFT JOIN identifiers as id on c.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on c.previewfileresource = file.uuid"
@@ -367,7 +367,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
             + " f.created f_created, f.last_modified f_lastModified,"
             + " f.filename f_filename, f.mimetype f_mimeType, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -420,7 +420,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
             + " f.filename f_filename, f.mimetype f_mimeType, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
             + " f.height f_height, f.width f_width,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources_image as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -473,7 +473,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
         "SELECT p.uuid p_uuid, p.label p_label,"
             + " p.created p_created, p.last_modified p_lastModified,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM projects as p"
             + " LEFT JOIN identifiers as id on p.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on p.previewfileresource = file.uuid"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/EntityRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/EntityRepositoryImpl.java
@@ -45,7 +45,7 @@ public class EntityRepositoryImpl<E extends Entity> extends IdentifiableReposito
           + " e.created e_created, e.last_modified e_last_modified,"
           + " e.preview_hints e_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM entities as e"
           + " LEFT JOIN identifiers as id on e.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on e.previewfileresource = file.uuid";
@@ -56,7 +56,7 @@ public class EntityRepositoryImpl<E extends Entity> extends IdentifiableReposito
           + " e.identifiable_type e_type, e.entity_type e_entityType,"
           + " e.created e_created, e.last_modified e_lastModified,"
           + " e.preview_hints e_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM entities as e"
           + " LEFT JOIN fileresources_image as file on e.previewfileresource = file.uuid";
 
@@ -159,7 +159,7 @@ public class EntityRepositoryImpl<E extends Entity> extends IdentifiableReposito
         new StringBuilder(
             "SELECT e.uuid e_uuid, e.refid e_refId, e.label e_label, e.description e_description,"
                 + " e.entity_type e_entityType,"
-                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+                + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
                 + " FROM entities as e"
                 + " LEFT JOIN fileresources_image as file on e.previewfileresource = file.uuid"
                 + " LEFT JOIN LATERAL jsonb_object_keys(e.label) l(keys) on e.label is not null"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/ProjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/ProjectRepositoryImpl.java
@@ -42,7 +42,7 @@ public class ProjectRepositoryImpl extends EntityRepositoryImpl<Project>
           + " p.text p_text, p.start_date p_startDate, p.end_date p_endDate,"
           + " p.preview_hints p_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM projects as p"
           + " LEFT JOIN identifiers as id on p.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on p.previewfileresource = file.uuid";
@@ -54,7 +54,7 @@ public class ProjectRepositoryImpl extends EntityRepositoryImpl<Project>
           + " p.created p_created, p.last_modified p_lastModified,"
           + " p.start_date p_startDate, p.end_date p_endDate,"
           + " p.preview_hints p_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM projects as p"
           + " LEFT JOIN fileresources_image as file on p.previewfileresource = file.uuid";
 
@@ -241,7 +241,7 @@ public class ProjectRepositoryImpl extends EntityRepositoryImpl<Project>
         "SELECT d.uuid d_uuid, d.label d_label,"
             + " d.created d_created, d.last_modified d_lastModified,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM digitalobjects as d"
             + " LEFT JOIN identifiers as id on d.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on d.previewfileresource = file.uuid"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
@@ -38,7 +38,7 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
           + " t.created t_created, t.last_modified t_lastModified,"
           + " t.preview_hints t_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM topics as t"
           + " LEFT JOIN identifiers as id on t.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on t.previewfileresource = file.uuid";
@@ -49,7 +49,7 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
           + " t.identifiable_type t_type, t.entity_type t_entityType,"
           + " t.created t_created, t.last_modified t_lastModified,"
           + " t.preview_hints t_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM topics as t"
           + " LEFT JOIN fileresources_image as file on t.previewfileresource = file.uuid";
 
@@ -207,7 +207,7 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
         "SELECT st.uuid st_uuid, st.label st_label, st.description st_description,"
             + " st.identifiable_type st_type,"
             + " st.created st_created, st.last_modified st_lastModified,"
-            + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+            + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
             + " FROM subtopics as st INNER JOIN topic_subtopics ts ON st.uuid = ts.subtopic_uuid"
             + " LEFT JOIN fileresources_image as file on st.previewfileresource = file.uuid"
             + " WHERE ts.topic_uuid = :uuid"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
@@ -41,7 +41,7 @@ public class WebsiteRepositoryImpl extends EntityRepositoryImpl<Website>
           + " w.url w_url, w.registration_date w_registrationDate,"
           + " w.preview_hints w_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM websites as w"
           + " LEFT JOIN identifiers as id on w.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on w.previewfileresource = file.uuid";
@@ -53,7 +53,7 @@ public class WebsiteRepositoryImpl extends EntityRepositoryImpl<Website>
           + " w.created w_created, w.last_modified w_lastModified,"
           + " w.url w_url, w.registration_date w_registrationDate,"
           + " w.preview_hints w_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM websites as w"
           + " LEFT JOIN fileresources_image as file on w.previewfileresource = file.uuid";
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/PersonRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/PersonRepositoryImpl.java
@@ -710,7 +710,7 @@ public class PersonRepositoryImpl extends IdentifiableRepositoryImpl<Person>
   public Set<DigitalObject> getDigitalObjects(UUID uuidPerson) {
     String query =
         "SELECT d.uuid d_uuid, d.label d_label, d.refid d_refId,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimetype, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimetype, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM digitalobjects as d"
             + " LEFT JOIN item_digitalobjects as itdi on d.uuid = itdi.digitalobject_uuid"
             + " LEFT JOIN item_works as itwo on itdi.item_uuid = itwo.item_uuid"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/parts/SubtopicRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/parts/SubtopicRepositoryImpl.java
@@ -49,7 +49,7 @@ public class SubtopicRepositoryImpl extends EntityPartRepositoryImpl<Subtopic, E
           + " s.created s_created, s.last_modified s_lastModified,"
           + " s.preview_hints s_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM subtopics as s"
           + " LEFT JOIN identifiers as id on s.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on s.previewfileresource = file.uuid";
@@ -60,7 +60,7 @@ public class SubtopicRepositoryImpl extends EntityPartRepositoryImpl<Subtopic, E
           + " s.identifiable_type s_type,"
           + " s.created s_created, s.last_modified s_lastModified,"
           + " s.preview_hints s_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM subtopics as s"
           + " LEFT JOIN fileresources_image as file on s.previewfileresource = file.uuid";
 
@@ -69,7 +69,7 @@ public class SubtopicRepositoryImpl extends EntityPartRepositoryImpl<Subtopic, E
           + " s.identifiable_type s_type,"
           + " s.created s_created, s.last_modified s_lastModified,"
           + " s.preview_hints s_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM subtopics as s INNER JOIN subtopic_subtopics ss ON s.uuid = ss.child_subtopic_uuid"
           + " LEFT JOIN fileresources_image as file on s.previewfileresource = file.uuid"
           + " WHERE ss.parent_subtopic_uuid = :uuid";
@@ -332,7 +332,7 @@ public class SubtopicRepositoryImpl extends EntityPartRepositoryImpl<Subtopic, E
             + " e.identifiable_type e_type, e.entity_type e_entityType,"
             + " e.created e_created, e.last_modified e_lastModified,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+            + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
             + " FROM entities as e INNER JOIN subtopic_entities se ON e.uuid = se.entity_uuid"
             + " LEFT JOIN fileresources_image as file on e.previewfileresource = file.uuid"
             + " LEFT JOIN identifiers as id on e.uuid = id.identifiable"
@@ -384,7 +384,7 @@ public class SubtopicRepositoryImpl extends EntityPartRepositoryImpl<Subtopic, E
             + " f.identifiable_type f_type,"
             + " f.created f_created, f.last_modified f_lastModified,"
             + " f.filename f_filename, f.mimetype f_mimeType,"
-            + " pf.uuid pf_uuid, pf.filename pf_filename, pf.mimetype pf_mimeType, pf.size_in_bytes pf_sizeInBytes, pf.uri pf_uri, pf.iiif_base_url pf_iiifBaseUrl"
+            + " pf.uuid pf_uuid, pf.filename pf_filename, pf.mimetype pf_mimeType, pf.size_in_bytes pf_sizeInBytes, pf.uri pf_uri, pf.http_base_url pf_httpBaseUrl"
             + " FROM fileresources as f INNER JOIN subtopic_fileresources sf ON f.uuid = sf.fileresource_uuid"
             + " LEFT JOIN fileresources_image as pf on f.previewfileresource = pf.uuid"
             + " WHERE sf.subtopic_uuid = :uuid"

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/parts/WebpageRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/parts/WebpageRepositoryImpl.java
@@ -49,7 +49,7 @@ public class WebpageRepositoryImpl<E extends Entity, C extends Comparable<C>>
           + " w.text w_text, w.publication_start w_publicationStart, w.publication_end w_publicationEnd,"
           + " w.preview_hints w_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM webpages as w"
           + " LEFT JOIN identifiers as id on w.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on w.previewfileresource = file.uuid";
@@ -61,7 +61,7 @@ public class WebpageRepositoryImpl<E extends Entity, C extends Comparable<C>>
           + " w.created w_created, w.last_modified w_lastModified,"
           + " w.publication_start w_publicationStart, w.publication_end w_publicationEnd,"
           + " w.preview_hints w_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM webpages as w"
           + " LEFT JOIN fileresources_image as file on w.previewfileresource = file.uuid";
 
@@ -71,7 +71,7 @@ public class WebpageRepositoryImpl<E extends Entity, C extends Comparable<C>>
           + " w.created w_created, w.last_modified w_lastModified,"
           + " w.publication_start w_publicationStart, w.publication_end w_publicationEnd,"
           + " w.preview_hints w_previewImageRenderingHints,"
-          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.iiif_base_url f_iiifBaseUrl"
+          + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM webpages as w INNER JOIN webpage_webpages ww ON w.uuid = ww.child_webpage_uuid"
           + " LEFT JOIN fileresources_image as file on w.previewfileresource = file.uuid"
           + " WHERE ww.parent_webpage_uuid = :uuid";

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
@@ -56,9 +56,10 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
           + " f.identifiable_type f_type,"
           + " f.created f_created, f.last_modified f_lastModified,"
           + " f.filename f_filename, f.mimetype f_mimetype, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
+          + " f.http_base_url f_httpBaseUrl,"
           + " f.preview_hints f_previewImageRenderingHints,"
           + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-          + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+          + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
           + " FROM fileresources as f"
           + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
           + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid";
@@ -69,8 +70,9 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
           + " f.identifiable_type f_type,"
           + " f.created f_created, f.last_modified f_lastModified,"
           + " f.filename f_filename, f.mimetype f_mimetype, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
+          + " f.http_base_url f_httpBaseUrl,"
           + " f.preview_hints f_previewImageRenderingHints,"
-          + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+          + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
           + " FROM fileresources as f"
           + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid";
 
@@ -301,7 +303,7 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
             + " f.created f_created, f.last_modified f_lastModified,"
             + " f.filename f_filename, f.mimetype f_mimetype, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources_application as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -349,7 +351,7 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
             + " f.filename f_filename, f.mimetype f_mimetype, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
             + " f.duration f_duration," // file resource type specific fields
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources_audio as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -396,9 +398,9 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
             + " f.created f_created, f.last_modified f_lastModified,"
             + " f.filename f_filename, f.mimetype f_mimetype, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
             // file resource type specific fields:
-            + " f.height f_height, f.width f_width, f.iiif_base_url f_iiifBaseUrl,"
+            + " f.height f_height, f.width f_width, f.http_base_url f_httpBaseUrl,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources_image as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -451,7 +453,7 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
             + " f.context f_context, f.object_type f_objectType," // file resource type specific
             // fields
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources_linkeddata as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -498,7 +500,7 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
             + " f.created f_created, f.last_modified f_lastModified,"
             + " f.filename f_filename, f.mimetype f_mimetype, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources_text as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -545,7 +547,7 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
             + " f.filename f_filename, f.mimetype f_mimetype, f.size_in_bytes f_sizeInBytes, f.uri f_uri,"
             + " f.duration f_duration," // file resource type specific fields
             + " id.uuid id_uuid, id.identifiable id_identifiable, id.namespace id_namespace, id.identifier id_id,"
-            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.iiif_base_url pf_iiifBaseUrl"
+            + " file.uuid pf_uuid, file.filename pf_filename, file.mimetype pf_mimeType, file.size_in_bytes pf_sizeInBytes, file.uri pf_uri, file.http_base_url pf_httpBaseUrl"
             + " FROM fileresources_video as f"
             + " LEFT JOIN identifiers as id on f.uuid = id.identifiable"
             + " LEFT JOIN fileresources_image as file on f.previewfileresource = file.uuid"
@@ -595,9 +597,9 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
         fileResource.getPreviewImage() == null ? null : fileResource.getPreviewImage().getUuid();
 
     final String baseColumnsSql =
-        "uuid, label, description, previewfileresource, preview_hints, identifiable_type, created, last_modified, filename, mimetype, size_in_bytes, uri";
+        "uuid, label, description, previewfileresource, preview_hints, identifiable_type, created, last_modified, filename, mimetype, size_in_bytes, uri, http_base_url";
     final String basePropertiesSql =
-        ":uuid, :label::JSONB, :description::JSONB, :previewFileResource, :previewImageRenderingHints::JSONB, :type, :created, :lastModified, :filename, :mimeType, :sizeInBytes, :uri";
+        ":uuid, :label::JSONB, :description::JSONB, :previewFileResource, :previewImageRenderingHints::JSONB, :type, :created, :lastModified, :filename, :mimeType, :sizeInBytes, :uri, :httpBaseUrl";
 
     if (fileResource instanceof ApplicationFileResource) {
       // no special columns
@@ -631,9 +633,9 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
               h.createUpdate(
                       "INSERT INTO fileresources_image("
                           + baseColumnsSql
-                          + ", width, height, iiif_base_url) VALUES ("
+                          + ", width, height) VALUES ("
                           + basePropertiesSql
-                          + ", :width, :height, :iiifBaseUrl)")
+                          + ", :width, :height)")
                   .bind("previewFileResource", previewUuid)
                   .bindBean(fileResource)
                   .execute());
@@ -698,7 +700,7 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
     final String baseColumnsSql =
         "label=:label::JSONB, description=:description::JSONB,"
             + " previewfileresource=:previewFileResource, preview_hints=:previewImageRenderingHints::JSONB,"
-            + " last_modified=:lastModified";
+            + " last_modified=:lastModified, http_base_url=:httpBaseUrl";
 
     if (fileResource instanceof ApplicationFileResource) {
       // no special columns
@@ -725,7 +727,7 @@ public class FileResourceMetadataRepositoryImpl extends IdentifiableRepositoryIm
       String query =
           "UPDATE fileresources_image SET "
               + baseColumnsSql
-              + ", width=:width, height=:height, iiif_base_url=:iiifBaseUrl WHERE uuid=:uuid";
+              + ", width=:width, height=:height WHERE uuid=:uuid";
       dbi.withHandle(
           h ->
               h.createUpdate(query)

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V2_1_0__DDL_Add_httpBaseUrl_to_Fileresource.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V2_1_0__DDL_Add_httpBaseUrl_to_Fileresource.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fileresources ADD COLUMN http_base_url VARCHAR;

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V2_1_1__DML_Migrate_iiifBaseUrl_to_httpBaseUrl.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V2_1_1__DML_Migrate_iiifBaseUrl_to_httpBaseUrl.sql
@@ -1,0 +1,1 @@
+UPDATE fileresources SET http_base_url = (SELECT iiif_base_url FROM fileresources_image WHERE fileresources.uuid = fileresources_image.uuid);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V2_1_2__DML_Remove_iiifBaseUrl_from_ImageFileresource.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V2_1_2__DML_Remove_iiifBaseUrl_from_ImageFileresource.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fileresources_image DROP COLUMN iiif_base_url;

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CorporationServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CorporationServiceImplTest.java
@@ -50,7 +50,7 @@ class CorporationServiceImplTest {
   void savePreviewImage() throws MalformedURLException, IdentifiableServiceException {
     Corporation corporation = mock(Corporation.class);
     ImageFileResource previewImageFileResource = mock(ImageFileResource.class);
-    when(previewImageFileResource.getIiifBaseUrl()).thenReturn(new URL("file:///tmp/foo"));
+    when(previewImageFileResource.getHttpBaseUrl()).thenReturn(new URL("file:///tmp/foo"));
     when(corporation.getPreviewImage()).thenReturn(previewImageFileResource);
     when(externalCorporationRepository.getByGndId(any(String.class))).thenReturn(corporation);
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <version.commons-dbcp2>2.7.0</version.commons-dbcp2>
     <version.commons-lang3>3.11</version.commons-lang3>
-    <version.dc-model>6.3.0-SNAPSHOT</version.dc-model>
+    <version.dc-model>7.0.0-SNAPSHOT</version.dc-model>
     <version.flyway>6.5.6</version.flyway>
     <version.javax.servlet-api>4.0.1</version.javax.servlet-api>
     <version.json>20200518</version.json>


### PR DESCRIPTION
This PR refactors the `iiifBaseUrl` that was only set for `ImageFileResource` to a more generic `httpBaseUrl` that can be set for all `FileResource` types.