### PR TITLE
Fixed fetch and save corporations

### DIFF
--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CorporationServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CorporationServiceImpl.java
@@ -34,16 +34,22 @@ public class CorporationServiceImpl extends EntityServiceImpl<Corporation>
   @Override
   public Corporation fetchAndSaveByGndId(String gndId) {
     Corporation corporation = externalRepository.getByGndId(gndId);
-    try {
-      ImageFileResource previewImage =
-          (ImageFileResource) fileResourceMetadataService.save(corporation.getPreviewImage());
-      corporation.setPreviewImage(previewImage);
-    } catch (IdentifiableServiceException ex) {
-      LOGGER.warn(
-          "Can not save previewImage of corporation: "
-              + corporation.getLabel().getText()
-              + ", gndId: "
-              + gndId);
+    if (corporation == null) {
+      return null;
+    }
+
+    if (corporation.getPreviewImage() != null) {
+      try {
+        ImageFileResource previewImage =
+            (ImageFileResource) fileResourceMetadataService.save(corporation.getPreviewImage());
+        corporation.setPreviewImage(previewImage);
+      } catch (IdentifiableServiceException ex) {
+        LOGGER.warn(
+            "Can not save previewImage of corporation: "
+                + corporation.getLabel().getText()
+                + ", gndId: "
+                + gndId);
+      }
     }
     return repository.save(corporation);
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CorporationServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CorporationServiceImplTest.java
@@ -1,0 +1,76 @@
+package de.digitalcollections.cudami.server.business.impl.service.identifiable.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.CorporationRepository;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.ExternalCorporationRepository;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.FileResourceMetadataService;
+import de.digitalcollections.model.api.identifiable.entity.Corporation;
+import de.digitalcollections.model.api.identifiable.resource.FileResource;
+import de.digitalcollections.model.api.identifiable.resource.ImageFileResource;
+import de.digitalcollections.model.impl.identifiable.entity.CorporationImpl;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The corporation service")
+class CorporationServiceImplTest {
+
+  private CorporationServiceImpl corporationService;
+  private CorporationRepository corporationRepository;
+  private ExternalCorporationRepository externalCorporationRepository;
+  private FileResourceMetadataService fileResourceMetadataService;
+
+  @BeforeEach
+  void setUp() throws IdentifiableServiceException {
+    corporationRepository = mock(CorporationRepository.class);
+    when(corporationRepository.save(any(Corporation.class))).thenReturn(new CorporationImpl());
+    when(corporationRepository.save(eq(null))).thenThrow(new NullPointerException());
+
+    externalCorporationRepository = mock(ExternalCorporationRepository.class);
+    fileResourceMetadataService = mock(FileResourceMetadataService.class);
+    when(fileResourceMetadataService.save(eq(null))).thenThrow(new NullPointerException());
+
+    corporationService =
+        new CorporationServiceImpl(
+            corporationRepository, externalCorporationRepository, fileResourceMetadataService);
+  }
+
+  @Test
+  @DisplayName("persists preview image for saved and retrieved corporation")
+  void savePreviewImage() throws MalformedURLException, IdentifiableServiceException {
+    Corporation corporation = mock(Corporation.class);
+    ImageFileResource previewImageFileResource = mock(ImageFileResource.class);
+    when(previewImageFileResource.getIiifBaseUrl()).thenReturn(new URL("file:///tmp/foo"));
+    when(corporation.getPreviewImage()).thenReturn(previewImageFileResource);
+    when(externalCorporationRepository.getByGndId(any(String.class))).thenReturn(corporation);
+
+    assertThat(corporationService.fetchAndSaveByGndId("12345")).isNotNull();
+    verify(fileResourceMetadataService, times(1)).save(any(FileResource.class));
+  }
+
+  @Test
+  @DisplayName("can retrieve and save corporations without preview image")
+  void saveWithoutPreviewImage() {
+    Corporation corporationWithoutPreviewImage = new CorporationImpl();
+    when(externalCorporationRepository.getByGndId(any(String.class)))
+        .thenReturn(corporationWithoutPreviewImage);
+    assertThat(corporationService.fetchAndSaveByGndId("12345")).isNotNull();
+  }
+
+  @Test
+  @DisplayName("returns null when no corporation was found")
+  void returnsNullForNullCorporation() {
+    when(externalCorporationRepository.getByGndId(any(String.class))).thenReturn(null);
+    assertThat(corporationService.fetchAndSaveByGndId("12345")).isNull();
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CorporationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CorporationController.java
@@ -37,7 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Api(description = "The corporation controller", name = "Corporation controller")
 public class CorporationController {
 
-  private static final Pattern GNDID_PATTERN = Pattern.compile("\\d+-\\d");
+  private static final Pattern GNDID_PATTERN = Pattern.compile("\\d+(-.)?");
 
   private final CorporationService corporationService;
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CorporationControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CorporationControllerTest.java
@@ -1,0 +1,38 @@
+package de.digitalcollections.cudami.server.controller.identifiable.entity;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.CorporationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("The corporation controller")
+class CorporationControllerTest {
+
+  private CorporationController corporationController;
+  private CorporationService corporationService;
+
+  @BeforeEach
+  void setUp() {
+    corporationService = mock(CorporationService.class);
+    corporationController = new CorporationController(corporationService);
+  }
+
+  @ParameterizedTest(
+      name =
+          "shall accept proper and refuse invalid GND IDs when fetching and retrieving institutions by GND ID")
+  @CsvSource(
+      value = {"1234-5, true", "12345, true", "1234-X, true", "abcde, false", "abcd-e, false"})
+  void gndIdVerification(String gndId, boolean isValue) throws IdentifiableServiceException {
+    if (isValue) {
+      corporationController.fetchAndSaveByGndId(gndId);
+    } else {
+      assertThrows(
+          IllegalArgumentException.class, () -> corporationController.fetchAndSaveByGndId(gndId));
+    }
+  }
+}


### PR DESCRIPTION
This PR allows a broader range of valid GND Ids and no longer throws an error, when there's no image in the externally retrieved corporation.