### PR TITLE
Sort webpages

### DIFF
--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
@@ -598,6 +598,21 @@ public class CudamiBaseClient<T extends Object> {
     }
   }
 
+  protected String doPutRequestForString(String requestUrl, Object object) throws HttpException {
+    try {
+      HttpRequest req = createPutRequest(requestUrl, object);
+      HttpResponse<String> response = http.send(req, HttpResponse.BodyHandlers.ofString());
+      Integer statusCode = response.statusCode();
+      if (statusCode >= 400) {
+        throw CudamiRestErrorDecoder.decode("PUT " + requestUrl, statusCode);
+      }
+      final String body = response.body();
+      return body;
+    } catch (IOException | InterruptedException e) {
+      throw new HttpException("Failed to retrieve response due to connection error", e);
+    }
+  }
+
   /**
    * Converts the given list of filter criterias to a request string
    *

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiBaseClient.java
@@ -527,7 +527,7 @@ public class CudamiBaseClient<T extends Object> {
       HttpResponse<String> response = http.send(req, HttpResponse.BodyHandlers.ofString());
       Integer statusCode = response.statusCode();
       if (statusCode >= 400) {
-        throw CudamiRestErrorDecoder.decode("PATCH " + requestUrl, statusCode);
+        throw CudamiRestErrorDecoder.decode("POST " + requestUrl, statusCode);
       }
       final String body = response.body();
       return body;

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebpagesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebpagesClient.java
@@ -123,4 +123,11 @@ public class CudamiWebpagesClient extends CudamiBaseClient<WebpageImpl> {
   public Webpage update(UUID uuid, Webpage webpage) throws HttpException {
     return doPutRequestForObject(String.format("/latest/webpages/%s", uuid), (WebpageImpl) webpage);
   }
+
+  public boolean updateChildrenOrder(UUID webpageUuid, List<Webpage> children)
+      throws HttpException {
+    return Boolean.parseBoolean(
+        doPutRequestForString(
+            String.format("/latest/webpages/%s/children", webpageUuid), children));
+  }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebsitesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiWebsitesClient.java
@@ -9,6 +9,7 @@ import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.impl.identifiable.entity.WebsiteImpl;
 import de.digitalcollections.model.impl.identifiable.entity.parts.WebpageImpl;
 import java.net.http.HttpClient;
+import java.util.List;
 import java.util.UUID;
 
 public class CudamiWebsitesClient extends CudamiBaseClient<WebsiteImpl> {
@@ -54,5 +55,12 @@ public class CudamiWebsitesClient extends CudamiBaseClient<WebsiteImpl> {
 
   public Website update(UUID uuid, Website website) throws HttpException {
     return doPutRequestForObject(String.format("/latest/websites/%s", uuid), (WebsiteImpl) website);
+  }
+
+  public boolean updateRootPagesOrder(UUID websiteUuid, List<Webpage> rootpages)
+      throws HttpException {
+    return Boolean.parseBoolean(
+        doPutRequestForString(
+            String.format("/latest/websites/%s/rootpages", websiteUuid), rootpages));
   }
 }

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/WebsiteRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/WebsiteRepository.java
@@ -15,4 +15,13 @@ public interface WebsiteRepository extends EntityRepository<Website> {
   List<Webpage> getRootPages(UUID uuid);
 
   PageResponse<Webpage> getRootPages(UUID uuid, PageRequest pageRequest);
+
+  default boolean updateRootPagesOrder(Website website, List<Webpage> rootPages) {
+    if (website == null || rootPages == null) {
+      return false;
+    }
+    return updateRootPagesOrder(website.getUuid(), rootPages);
+  }
+
+  boolean updateRootPagesOrder(UUID website, List<Webpage> rootPages);
 }

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/parts/WebpageRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/parts/WebpageRepository.java
@@ -5,6 +5,7 @@ import de.digitalcollections.model.api.filter.Filtering;
 import de.digitalcollections.model.api.identifiable.entity.Entity;
 import de.digitalcollections.model.api.identifiable.entity.Website;
 import de.digitalcollections.model.api.identifiable.entity.parts.Webpage;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -36,4 +37,13 @@ public interface WebpageRepository<E extends Entity>
    * @return the website the given root-webpage belongs to (webpage is top level webpage)
    */
   Website getWebsite(UUID rootWebpageUuid);
+
+  default boolean updateChildrenOrder(Webpage webpage, List<Webpage> children) {
+    if (webpage == null || children == null) {
+      return false;
+    }
+    return updateChildrenOrder(webpage.getUuid(), children);
+  }
+
+  boolean updateChildrenOrder(UUID parentUuid, List<Webpage> children);
 }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
@@ -350,8 +350,8 @@ public class WebsiteRepositoryImpl extends EntityRepositoryImpl<Website>
                         .values()));
     String sql =
         "SELECT count(*) FROM webpages as w"
-            + " INNER JOIN webpage_webpages ww ON w.uuid = ww.child_webpage_uuid"
-            + " WHERE ww.parent_webpage_uuid = :uuid";
+            + " INNER JOIN website_webpages ww ON w.uuid = ww.webpage_uuid"
+            + " WHERE ww.website_uuid = :uuid";
     long total =
         dbi.withHandle(
             h -> h.createQuery(sql).bind("uuid", uuid).mapTo(Long.class).findOne().get());

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
@@ -41,8 +41,7 @@ public class WebsiteRepositoryImpl extends EntityRepositoryImpl<Website>
           + " file.uuid f_uuid, file.filename f_filename, file.mimetype f_mimeType, file.size_in_bytes f_sizeInBytes, file.uri f_uri, file.http_base_url f_httpBaseUrl"
           + " FROM webpages as w INNER JOIN website_webpages ww ON w.uuid = ww.webpage_uuid"
           + " LEFT JOIN fileresources_image as file on w.previewfileresource = file.uuid"
-          + " WHERE ww.website_uuid = :uuid"
-          + " ORDER BY ww.sortIndex ASC";
+          + " WHERE ww.website_uuid = :uuid";
 
   // select all details shown/needed in single object details page
   private static final String FIND_ONE_BASE_SQL =
@@ -320,6 +319,9 @@ public class WebsiteRepositoryImpl extends EntityRepositoryImpl<Website>
   public PageResponse<Webpage> getRootPages(UUID uuid, PageRequest pageRequest) {
     // minimal data required (= identifiable fields) for creating text links/teasers in a list
     StringBuilder query = new StringBuilder(BASE_ROOTPAGES_QUERY);
+    if (pageRequest.getSorting() == null) {
+      query.append(" ORDER BY ww.sortIndex ASC");
+    }
     addPageRequestParams(pageRequest, query);
     List<Webpage> result =
         new ArrayList(

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/WebsiteService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/WebsiteService.java
@@ -15,4 +15,6 @@ public interface WebsiteService extends EntityService<Website> {
   List<Webpage> getRootPages(UUID uuid);
 
   PageResponse<Webpage> getRootPages(UUID uuid, PageRequest pageRequest);
+
+  boolean updateRootPagesOrder(Website website, List<Webpage> rootPages);
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/parts/WebpageService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/parts/WebpageService.java
@@ -34,4 +34,6 @@ public interface WebpageService<E extends Entity>
 
   Webpage saveWithParentWebpage(Webpage webpage, UUID parentWebpageUuid)
       throws IdentifiableServiceException;
+
+  boolean updateChildrenOrder(Webpage webpage, List<Webpage> children);
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/WebsiteServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/WebsiteServiceImpl.java
@@ -39,4 +39,9 @@ public class WebsiteServiceImpl extends EntityServiceImpl<Website> implements We
   public PageResponse<Webpage> getRootPages(UUID uuid, PageRequest pageRequest) {
     return ((WebsiteRepository) repository).getRootPages(uuid, pageRequest);
   }
+
+  @Override
+  public boolean updateRootPagesOrder(Website website, List<Webpage> rootPages) {
+    return ((WebsiteRepository) repository).updateRootPagesOrder(website, rootPages);
+  }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/parts/WebpageServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/parts/WebpageServiceImpl.java
@@ -150,4 +150,9 @@ public class WebpageServiceImpl<E extends Entity> extends EntityPartServiceImpl<
       throw new IdentifiableServiceException(e.getMessage());
     }
   }
+
+  @Override
+  public boolean updateChildrenOrder(Webpage webpage, List<Webpage> children) {
+    return ((WebpageRepository) repository).updateChildrenOrder(webpage, children);
+  }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
@@ -9,9 +9,11 @@ import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
 import de.digitalcollections.model.api.paging.enums.Direction;
 import de.digitalcollections.model.api.paging.enums.NullHandling;
+import de.digitalcollections.model.impl.identifiable.entity.WebsiteImpl;
 import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.jsondoc.core.annotation.Api;
@@ -19,7 +21,9 @@ import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
 import org.jsondoc.core.annotation.ApiResponseObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -121,5 +125,24 @@ public class WebsiteController {
     }
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return service.getRootPages(uuid, pageRequest);
+  }
+
+  @ApiMethod(description = "Update the order of a website's rootpages")
+  @PutMapping(
+      value = {"/latest/websites/{uuid}/rootpages", "/v3/websites/{uuid}/rootpages"},
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @ApiResponseObject
+  public ResponseEntity updateRootPagesOrder(
+      @ApiPathParam(description = "UUID of the website") @PathVariable("uuid") UUID uuid,
+      @ApiPathParam(description = "List of the rootpages") @RequestBody List<Webpage> rootPages) {
+    Website website = new WebsiteImpl();
+    website.setUuid(uuid);
+
+    boolean successful = service.updateRootPagesOrder(website, rootPages);
+
+    if (successful) {
+      return new ResponseEntity<>(successful, HttpStatus.OK);
+    }
+    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageController.java
@@ -15,6 +15,7 @@ import de.digitalcollections.model.api.paging.Sorting;
 import de.digitalcollections.model.api.paging.enums.Direction;
 import de.digitalcollections.model.api.paging.enums.NullHandling;
 import de.digitalcollections.model.api.view.BreadcrumbNavigation;
+import de.digitalcollections.model.impl.identifiable.entity.parts.WebpageImpl;
 import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
@@ -306,5 +307,24 @@ public class WebpageController {
     }
 
     return new ResponseEntity<>(breadcrumbNavigation, HttpStatus.OK);
+  }
+
+  @ApiMethod(description = "Update the order of a webpage's children")
+  @PutMapping(
+      value = {"/latest/webpages/{uuid}/children", "/v3/webpages/{uuid}/children"},
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @ApiResponseObject
+  public ResponseEntity updateChildrenOrder(
+      @ApiPathParam(description = "UUID of the webpage") @PathVariable("uuid") UUID uuid,
+      @ApiPathParam(description = "List of the children") @RequestBody List<Webpage> rootPages) {
+    Webpage webpage = new WebpageImpl();
+    webpage.setUuid(uuid);
+
+    boolean successful = webpageService.updateChildrenOrder(webpage, rootPages);
+
+    if (successful) {
+      return new ResponseEntity<>(successful, HttpStatus.OK);
+    }
+    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
   }
 }


### PR DESCRIPTION
This PR adds endpoints to change the order of (sub) webpages - i.e. updating the `sortindex` column - with client methods.