### PR TITLE
Remove description from search for collections and digital objects

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
@@ -220,9 +220,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
                 + " FROM collections AS c"
                 + " LEFT JOIN fileresources_image AS file ON c.previewfileresource = file.uuid"
                 + " LEFT JOIN LATERAL jsonb_object_keys(c.label) l(keys) ON c.label IS NOT null"
-                + " LEFT JOIN LATERAL jsonb_object_keys(c.description) n(keys) ON c.description IS NOT null"
-                + " WHERE (c.label->>l.keys ILIKE '%' || :searchTerm || '%'"
-                + " OR c.description->>n.keys ILIKE '%' || :searchTerm || '%')");
+                + " WHERE (c.label->>l.keys ILIKE '%' || :searchTerm || '%')");
     // handle optional filtering params
     String filterClauses = getFilterClauses(searchPageRequest.getFiltering());
     if (!filterClauses.isEmpty()) {

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -134,9 +134,7 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
                 + " FROM digitalobjects as d"
                 + " LEFT JOIN fileresources_image as file on d.previewfileresource = file.uuid"
                 + " LEFT JOIN LATERAL jsonb_object_keys(d.label) l(keys) on d.label is not null"
-                + " LEFT JOIN LATERAL jsonb_object_keys(d.description) n(keys) on d.description is not null"
-                + " WHERE (d.label->>l.keys ilike '%' || :searchTerm || '%'"
-                + " OR d.description->>n.keys ilike '%' || :searchTerm || '%')");
+                + " WHERE (d.label->>l.keys ILIKE '%' || :searchTerm || '%')");
     addPageRequestParams(searchPageRequest, query);
 
     List<DigitalObject> result =


### PR DESCRIPTION
This PR removes the field `description` from the search for collections and digital objects, because it isn't displayed anywhere and could be confusing.