### PR TITLE
Upgrade spring boot

### DIFF
--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigWeb.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigWeb.java
@@ -25,7 +25,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -114,11 +113,6 @@ public class SpringConfigWeb implements WebMvcConfigurer {
   @Bean
   public CreateAdminUserInterceptor createAdminUserInterceptor() {
     return new CreateAdminUserInterceptor();
-  }
-
-  @Override
-  public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {
-    configurer.enable();
   }
 
   @Bean

--- a/dc-cudami-admin/src/main/resources/application.yml
+++ b/dc-cudami-admin/src/main/resources/application.yml
@@ -79,6 +79,8 @@ webjars:
 ---
 
 spring:
-  profiles: PROD
+  config:
+    activate:
+      on-profile: PROD
   thymeleaf:
     cache: true

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/resources/application.yml
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/resources/application.yml
@@ -97,7 +97,9 @@ custom:
     port: 5432
 
 spring:
-  profiles: PROD
+  config:
+    activate:
+      on-profile: PROD
   thymeleaf:
     cache: true
 
@@ -111,8 +113,10 @@ spring:
       - org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesAutoConfiguration
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
       - org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration
+  config:
+    activate:
+      on-profile: TEST
   flyway:
     enabled: false
   main:
     allow-bean-definition-overriding: true
-  profiles: TEST

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.6.RELEASE</version>
+    <version>2.4.1</version>
   </parent>
 
   <groupId>de.digitalcollections.cudami</groupId>


### PR DESCRIPTION
This PR upgrades `spring-boot-starter-parent` to `2.4.1` and
* fixes invalid syntax in `application.yml`
* removes configuration that broke the unit tests (see https://stackoverflow.com/questions/64822250/illegalstateexception-after-upgrading-web-app-to-spring-boot-2-4)