### PR TITLE
Add missing column name mapping

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -687,6 +687,10 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
         return "d.created";
       case "lastModified":
         return "d.last_modified";
+      case "publicationEnd":
+        return "c.publication_end";
+      case "publicationStart":
+        return "c.publication_start";
       case "refId":
         return "d.refid";
       default:


### PR DESCRIPTION
These missing mappings caused the filtering for active collections of a digital object to fail.