### PR TITLE
Fix duplicate table name

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
@@ -328,20 +328,20 @@ public class IdentifiableRepositoryImpl<I extends Identifiable> extends JdbiRepo
             + tableAlias
             + " LEFT JOIN LATERAL jsonb_object_keys("
             + tableAlias
-            + ".label) l(keys) ON "
+            + ".label) lbl(keys) ON "
             + tableAlias
             + ".label IS NOT NULL"
             + " LEFT JOIN LATERAL jsonb_object_keys("
             + tableAlias
-            + ".description) d(keys) ON "
+            + ".description) dsc(keys) ON "
             + tableAlias
             + ".description IS NOT NULL"
             + " WHERE ("
             + tableAlias
-            + ".label->>l.keys ILIKE '%' || :searchTerm || '%'"
+            + ".label->>lbl.keys ILIKE '%' || :searchTerm || '%'"
             + " OR "
             + tableAlias
-            + ".description->>d.keys ILIKE '%' || :searchTerm || '%')";
+            + ".description->>dsc.keys ILIKE '%' || :searchTerm || '%')";
     return find(searchPageRequest, commonSql, Map.of("searchTerm", searchPageRequest.getQuery()));
   }
 


### PR DESCRIPTION
This PR fixes a bug that caused the search for digital objects to fail.