### PR TITLE
Refactor to new sorting param syntax

### DIFF
--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -152,9 +152,7 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
   protected void setDefaultSorting(PageRequest pageRequest) {
     // business logic: default sorting if no other sorting given: german label ascending
     // TODO or make dependend from language the user has chosen...?
-    if (pageRequest.getSorting() == null
-        || pageRequest.getSorting().getOrders() == null
-        || pageRequest.getSorting().getOrders().isEmpty()) {
+    if (!pageRequest.hasSorting()) {
       // TODO: discuss default sorting (what if only english label exists? or german and english?)
       String defaultLanguage = localeService.getDefaultLanguage();
       final OrderImpl labelOrder1 = new OrderImpl(Direction.ASC, "label");

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifierTypeServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifierTypeServiceImpl.java
@@ -59,9 +59,7 @@ public class IdentifierTypeServiceImpl implements IdentifierTypeService {
   }
 
   private void setDefaultSorting(PageRequest pageRequest) {
-    if (pageRequest.getSorting() == null
-        || pageRequest.getSorting().getOrders() == null
-        || pageRequest.getSorting().getOrders().isEmpty()) {
+    if (!pageRequest.hasSorting()) {
       Sorting sorting = new SortingImpl(Direction.ASC, "namespace");
       pageRequest.setSorting(sorting);
     }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifierTypeServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifierTypeServiceImpl.java
@@ -5,6 +5,9 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.Ide
 import de.digitalcollections.model.api.identifiable.IdentifierType;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
+import de.digitalcollections.model.api.paging.Sorting;
+import de.digitalcollections.model.api.paging.enums.Direction;
+import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -36,6 +39,7 @@ public class IdentifierTypeServiceImpl implements IdentifierTypeService {
 
   @Override
   public PageResponse<IdentifierType> find(PageRequest pageRequest) {
+    setDefaultSorting(pageRequest);
     return repository.find(pageRequest);
   }
 
@@ -52,6 +56,15 @@ public class IdentifierTypeServiceImpl implements IdentifierTypeService {
   @Override
   public IdentifierType save(IdentifierType identifierType) {
     return repository.save(identifierType);
+  }
+
+  private void setDefaultSorting(PageRequest pageRequest) {
+    if (pageRequest.getSorting() == null
+        || pageRequest.getSorting().getOrders() == null
+        || pageRequest.getSorting().getOrders().isEmpty()) {
+      Sorting sorting = new SortingImpl(Direction.ASC, "namespace");
+      pageRequest.setSorting(sorting);
+    }
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
@@ -45,7 +45,6 @@ public class CollectionServiceImpl extends EntityServiceImpl<Collection>
 
   @Override
   public PageResponse<Collection> findActive(PageRequest pageRequest) {
-    setDefaultSorting(pageRequest);
     Filtering filtering = filteringForActive();
     pageRequest.add(filtering);
     return find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/security/UserServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/security/UserServiceImpl.java
@@ -115,9 +115,7 @@ public class UserServiceImpl implements UserService<User> {
   }
 
   private void setDefaultSorting(PageRequest pageRequest) {
-    if (pageRequest.getSorting() == null
-        || pageRequest.getSorting().getOrders() == null
-        || pageRequest.getSorting().getOrders().isEmpty()) {
+    if (!pageRequest.hasSorting()) {
       Sorting sorting = new SortingImpl(Direction.ASC, "email");
       pageRequest.setSorting(sorting);
     }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/security/UserServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/security/UserServiceImpl.java
@@ -4,8 +4,11 @@ import de.digitalcollections.cudami.server.backend.api.repository.security.UserR
 import de.digitalcollections.cudami.server.business.api.service.security.UserService;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
+import de.digitalcollections.model.api.paging.Sorting;
+import de.digitalcollections.model.api.paging.enums.Direction;
 import de.digitalcollections.model.api.security.User;
 import de.digitalcollections.model.api.security.enums.Role;
+import de.digitalcollections.model.impl.paging.SortingImpl;
 import de.digitalcollections.model.impl.security.UserImpl;
 import java.util.List;
 import java.util.UUID;
@@ -38,6 +41,7 @@ public class UserServiceImpl implements UserService<User> {
 
   @Override
   public PageResponse<User> find(PageRequest pageRequest) {
+    setDefaultSorting(pageRequest);
     return userRepository.find(pageRequest);
   }
 
@@ -108,5 +112,14 @@ public class UserServiceImpl implements UserService<User> {
   //  @Transactional(readOnly = true)
   public List<User> findActiveAdminUsers() {
     return userRepository.findActiveAdminUsers();
+  }
+
+  private void setDefaultSorting(PageRequest pageRequest) {
+    if (pageRequest.getSorting() == null
+        || pageRequest.getSorting().getOrders() == null
+        || pageRequest.getSorting().getOrders().isEmpty()) {
+      Sorting sorting = new SortingImpl(Direction.ASC, "email");
+      pageRequest.setSorting(sorting);
+    }
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/view/RenderingTemplateServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/view/RenderingTemplateServiceImpl.java
@@ -4,6 +4,9 @@ import de.digitalcollections.cudami.server.backend.api.repository.view.Rendering
 import de.digitalcollections.cudami.server.business.api.service.view.RenderingTemplateService;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
+import de.digitalcollections.model.api.paging.Sorting;
+import de.digitalcollections.model.api.paging.enums.Direction;
+import de.digitalcollections.model.impl.paging.SortingImpl;
 import de.digitalcollections.model.impl.view.RenderingTemplate;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ public class RenderingTemplateServiceImpl implements RenderingTemplateService {
 
   @Override
   public PageResponse<RenderingTemplate> find(PageRequest pageRequest) {
+    setDefaultSorting(pageRequest);
     return repository.find(pageRequest);
   }
 
@@ -29,6 +33,15 @@ public class RenderingTemplateServiceImpl implements RenderingTemplateService {
   @Override
   public RenderingTemplate save(RenderingTemplate template) {
     return repository.save(template);
+  }
+
+  private void setDefaultSorting(PageRequest pageRequest) {
+    if (pageRequest.getSorting() == null
+        || pageRequest.getSorting().getOrders() == null
+        || pageRequest.getSorting().getOrders().isEmpty()) {
+      Sorting sorting = new SortingImpl(Direction.ASC, "name");
+      pageRequest.setSorting(sorting);
+    }
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/view/RenderingTemplateServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/view/RenderingTemplateServiceImpl.java
@@ -36,9 +36,7 @@ public class RenderingTemplateServiceImpl implements RenderingTemplateService {
   }
 
   private void setDefaultSorting(PageRequest pageRequest) {
-    if (pageRequest.getSorting() == null
-        || pageRequest.getSorting().getOrders() == null
-        || pageRequest.getSorting().getOrders().isEmpty()) {
+    if (!pageRequest.hasSorting()) {
       Sorting sorting = new SortingImpl(Direction.ASC, "name");
       pageRequest.setSorting(sorting);
     }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
@@ -10,9 +10,7 @@ import de.digitalcollections.model.api.paging.Sorting;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -48,8 +46,7 @@ public class IdentifiableController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
     SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
@@ -3,16 +3,16 @@ package de.digitalcollections.cudami.server.controller.identifiable;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.IdentifiableService;
 import de.digitalcollections.model.api.identifiable.Identifiable;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -44,18 +44,14 @@ public class IdentifiableController {
   public SearchPageResponse<Identifiable> find(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    SearchPageRequest pageRequest =
-        new SearchPageRequestImpl(searchTerm, pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifierTypeController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifierTypeController.java
@@ -2,16 +2,16 @@ package de.digitalcollections.cudami.server.controller.identifiable;
 
 import de.digitalcollections.cudami.server.business.api.service.identifiable.IdentifierTypeService;
 import de.digitalcollections.model.api.identifiable.IdentifierType;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -40,15 +40,13 @@ public class IdentifierTypeController {
   public PageResponse<IdentifierType> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false, defaultValue = "namespace")
-          String sortField,
-      @RequestParam(name = "sortDirection", required = false, defaultValue = "ASC")
-          Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-    Sorting sorting = new SortingImpl(order);
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
+    }
     return service.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifierTypeController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifierTypeController.java
@@ -11,7 +11,6 @@ import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -43,8 +42,7 @@ public class IdentifierTypeController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ArticleController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ArticleController.java
@@ -3,17 +3,17 @@ package de.digitalcollections.cudami.server.controller.identifiable.entity;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ArticleService;
 import de.digitalcollections.model.api.identifiable.entity.Article;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -46,16 +46,13 @@ public class ArticleController {
   public PageResponse<Article> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return articleService.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ArticleController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ArticleController.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -49,8 +48,7 @@ public class ArticleController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return articleService.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -182,8 +181,7 @@ public class CollectionController {
       @RequestParam(name = "active", required = false) String active) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (active != null) {
@@ -203,8 +201,7 @@ public class CollectionController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return collectionService.getRootNodes(pageRequest);
@@ -281,8 +278,7 @@ public class CollectionController {
       @RequestParam(name = "active", required = false) String active) {
     SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (active != null) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
@@ -14,12 +14,9 @@ import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
 import de.digitalcollections.model.api.view.BreadcrumbNavigation;
 import de.digitalcollections.model.impl.identifiable.entity.CollectionImpl;
 import de.digitalcollections.model.impl.identifiable.entity.DigitalObjectImpl;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
@@ -182,22 +179,13 @@ public class CollectionController {
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false) NullHandling nullHandling,
       @RequestParam(name = "active", required = false) String active) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
-    }
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      LOGGER.warn(
-          "Endpoint '/latest/collections' was called with the old AND the new sorting syntax (sortBy).");
-      sorting =
+      Sorting sorting =
           new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     if (active != null) {
       return collectionService.findActive(pageRequest);
     }
@@ -212,16 +200,13 @@ public class CollectionController {
   public PageResponse<Collection> findAllTop(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return collectionService.getRootNodes(pageRequest);
   }
 
@@ -292,25 +277,14 @@ public class CollectionController {
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
       @RequestParam(name = "searchTerm", required = false) String searchTerm,
       @RequestParam(name = "active", required = false) String active) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
-    }
+    SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
-      LOGGER.warn(
-          "Endpoint '/latest/collections/search' was called with the old AND the new sorting syntax (sortBy).");
-      sorting =
+      Sorting sorting =
           new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    SearchPageRequest pageRequest =
-        new SearchPageRequestImpl(searchTerm, pageNumber, pageSize, sorting);
     if (active != null) {
       return collectionService.findActive(pageRequest);
     }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
@@ -21,7 +21,6 @@ import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -81,8 +80,7 @@ public class DigitalObjectController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);
@@ -144,8 +142,7 @@ public class DigitalObjectController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
     SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
@@ -8,21 +8,20 @@ import de.digitalcollections.model.api.identifiable.entity.Project;
 import de.digitalcollections.model.api.identifiable.entity.work.Item;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
 import de.digitalcollections.model.api.identifiable.resource.ImageFileResource;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
 import de.digitalcollections.model.impl.identifiable.entity.DigitalObjectImpl;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -79,16 +78,13 @@ public class DigitalObjectController {
   public PageResponse<DigitalObject> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 
@@ -144,18 +140,14 @@ public class DigitalObjectController {
   public SearchPageResponse<DigitalObject> findDigitalObjects(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    SearchPageRequest pageRequest =
-        new SearchPageRequestImpl(searchTerm, pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
@@ -6,19 +6,19 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.ent
 import de.digitalcollections.model.api.identifiable.entity.Entity;
 import de.digitalcollections.model.api.identifiable.entity.relation.EntityRelation;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -57,16 +57,13 @@ public class EntityController<E extends Entity> {
   public PageResponse<Entity> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 
@@ -79,18 +76,14 @@ public class EntityController<E extends Entity> {
   public SearchPageResponse<Entity> find(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    SearchPageRequest pageRequest =
-        new SearchPageRequestImpl(searchTerm, pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
@@ -16,9 +16,7 @@ import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -60,8 +58,7 @@ public class EntityController<E extends Entity> {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);
@@ -80,8 +77,7 @@ public class EntityController<E extends Entity> {
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
     SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -118,8 +117,7 @@ public class ProjectController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return projectService.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
@@ -4,20 +4,19 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Ident
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ProjectService;
 import de.digitalcollections.model.api.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.api.identifiable.entity.Project;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
 import de.digitalcollections.model.impl.identifiable.entity.DigitalObjectImpl;
 import de.digitalcollections.model.impl.identifiable.entity.ProjectImpl;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -116,16 +115,13 @@ public class ProjectController {
   public PageResponse<Project> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return projectService.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
@@ -4,17 +4,16 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Ident
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.TopicService;
 import de.digitalcollections.model.api.identifiable.entity.Topic;
 import de.digitalcollections.model.api.identifiable.entity.parts.Subtopic;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -43,16 +42,13 @@ public class TopicController {
   public PageResponse<Topic> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
@@ -13,7 +13,6 @@ import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -45,8 +44,7 @@ public class TopicController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -59,8 +58,7 @@ public class WebsiteController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);
@@ -101,8 +99,7 @@ public class WebsiteController {
       throws IdentifiableServiceException {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.getRootPages(uuid, pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
@@ -4,19 +4,18 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Ident
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.WebsiteService;
 import de.digitalcollections.model.api.identifiable.entity.Website;
 import de.digitalcollections.model.api.identifiable.entity.parts.Webpage;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
 import de.digitalcollections.model.impl.identifiable.entity.WebsiteImpl;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -25,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,16 +56,13 @@ public class WebsiteController {
   public PageResponse<Website> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 
@@ -102,18 +97,14 @@ public class WebsiteController {
           UUID uuid,
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false, defaultValue = "DESC")
-          Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling)
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy)
       throws IdentifiableServiceException {
-    Sorting sorting = null;
-    if (StringUtils.hasText(sortField)) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return service.getRootPages(uuid, pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
@@ -3,18 +3,18 @@ package de.digitalcollections.cudami.server.controller.identifiable.entity.agent
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.CorporateBodyService;
 import de.digitalcollections.model.api.identifiable.entity.agent.CorporateBody;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -70,16 +70,13 @@ public class CorporateBodyController {
   public PageResponse<CorporateBody> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return corporateBodyService.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
@@ -14,7 +14,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -73,8 +72,7 @@ public class CorporateBodyController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return corporateBodyService.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
@@ -17,7 +17,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -69,8 +68,7 @@ public class PersonController {
       @RequestParam(name = "initial", required = false) String initial) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (initial == null) {
@@ -95,8 +93,7 @@ public class PersonController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return personService.findByLocationOfBirth(pageRequest, uuid);
@@ -118,8 +115,7 @@ public class PersonController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return personService.findByLocationOfDeath(pageRequest, uuid);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
@@ -6,18 +6,18 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.ent
 import de.digitalcollections.model.api.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.api.identifiable.entity.agent.Person;
 import de.digitalcollections.model.api.identifiable.entity.work.Work;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -64,18 +64,15 @@ public class PersonController {
   public PageResponse<Person> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "language", required = false, defaultValue = "de") String language,
       @RequestParam(name = "initial", required = false) String initial) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     if (initial == null) {
       return personService.find(pageRequest);
     }
@@ -95,16 +92,13 @@ public class PersonController {
           UUID uuid,
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return personService.findByLocationOfBirth(pageRequest, uuid);
   }
 
@@ -121,16 +115,13 @@ public class PersonController {
           UUID uuid,
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return personService.findByLocationOfDeath(pageRequest, uuid);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/GeoLocationController.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -66,8 +65,7 @@ public class GeoLocationController {
       @RequestParam(name = "initial", required = false) String initial) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (language == null && initial == null) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/GeoLocationController.java
@@ -3,17 +3,17 @@ package de.digitalcollections.cudami.server.controller.identifiable.entity.geo;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.geo.GeoLocationService;
 import de.digitalcollections.model.api.identifiable.entity.geo.GeoLocation;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -61,18 +61,15 @@ public class GeoLocationController {
       Pageable pageable,
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "language", required = false) String language,
       @RequestParam(name = "initial", required = false) String initial) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     if (language == null && initial == null) {
       return geoLocationService.find(pageRequest);
     }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/HumanSettlementController.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -57,8 +56,7 @@ public class HumanSettlementController {
       @RequestParam(name = "initial", required = false) String initial) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (initial == null) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/HumanSettlementController.java
@@ -3,17 +3,17 @@ package de.digitalcollections.cudami.server.controller.identifiable.entity.geo;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.geo.HumanSettlementService;
 import de.digitalcollections.model.api.identifiable.entity.geo.HumanSettlement;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -52,18 +52,15 @@ public class HumanSettlementController {
       Pageable pageable,
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "language", required = false, defaultValue = "de") String language,
       @RequestParam(name = "initial", required = false) String initial) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     if (initial == null) {
       return humanSettlementService.find(pageRequest);
     }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/SubtopicController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/SubtopicController.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -102,8 +101,7 @@ public class SubtopicController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/SubtopicController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/SubtopicController.java
@@ -7,19 +7,18 @@ import de.digitalcollections.model.api.identifiable.entity.Entity;
 import de.digitalcollections.model.api.identifiable.entity.Topic;
 import de.digitalcollections.model.api.identifiable.entity.parts.Subtopic;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
 import de.digitalcollections.model.api.view.BreadcrumbNavigation;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -100,16 +99,13 @@ public class SubtopicController {
   public PageResponse<Subtopic> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return service.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/parts/WebpageController.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -75,8 +74,7 @@ public class WebpageController {
           FilterCriterion<LocalDate> publicationEnd) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     Filtering filtering =
@@ -195,8 +193,7 @@ public class WebpageController {
       throws IdentifiableServiceException {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (active != null) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
@@ -6,17 +6,18 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.ent
 import de.digitalcollections.model.api.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.api.identifiable.entity.work.Item;
 import de.digitalcollections.model.api.identifiable.entity.work.Work;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -64,18 +65,15 @@ public class ItemController {
   public PageResponse<Item> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "language", required = false, defaultValue = "de") String language,
       @RequestParam(name = "initial", required = false) String initial) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     if (initial == null) {
       return service.find(pageRequest);
     }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
@@ -14,10 +14,8 @@ import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -70,8 +68,7 @@ public class ItemController {
       @RequestParam(name = "initial", required = false) String initial) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (initial == null) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
@@ -6,17 +6,17 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.ent
 import de.digitalcollections.model.api.identifiable.entity.agent.Agent;
 import de.digitalcollections.model.api.identifiable.entity.work.Item;
 import de.digitalcollections.model.api.identifiable.entity.work.Work;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -64,18 +64,15 @@ public class WorkController {
   public PageResponse<Work> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "language", required = false, defaultValue = "de") String language,
       @RequestParam(name = "initial", required = false) String initial) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     if (initial == null) {
       return service.find(pageRequest);
     }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
@@ -14,9 +14,7 @@ import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -69,8 +67,7 @@ public class WorkController {
       @RequestParam(name = "initial", required = false) String initial) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     if (initial == null) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -64,8 +63,7 @@ public class FileResourceMetadataController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return fileResourceService.find(pageRequest);
@@ -88,8 +86,7 @@ public class FileResourceMetadataController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
     SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
@@ -5,20 +5,20 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Ident
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.FileResourceMetadataService;
 import de.digitalcollections.model.api.filter.Filtering;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.SearchPageRequest;
 import de.digitalcollections.model.api.paging.SearchPageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SearchPageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
@@ -61,16 +61,13 @@ public class FileResourceMetadataController {
   public PageResponse<FileResource> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
     return fileResourceService.find(pageRequest);
   }
 
@@ -87,18 +84,14 @@ public class FileResourceMetadataController {
           String type,
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "5") int pageSize,
-      @RequestParam(name = "sortField", required = false) String sortField,
-      @RequestParam(name = "sortDirection", required = false) Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm) {
-    Sorting sorting = null;
-    if (sortField != null && sortDirection != null) {
-      OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-      sorting = new SortingImpl(order);
+    SearchPageRequest pageRequest = new SearchPageRequestImpl(searchTerm, pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
     }
-    SearchPageRequest pageRequest =
-        new SearchPageRequestImpl(searchTerm, pageNumber, pageSize, sorting);
 
     String prefix;
     switch (type) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/security/UserController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/security/UserController.java
@@ -12,7 +12,6 @@ import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -55,8 +54,7 @@ public class UserController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/security/UserController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/security/UserController.java
@@ -1,19 +1,18 @@
 package de.digitalcollections.cudami.server.controller.security;
 
 import de.digitalcollections.cudami.server.business.api.service.security.UserService;
+import de.digitalcollections.model.api.paging.Order;
 import de.digitalcollections.model.api.paging.PageRequest;
 import de.digitalcollections.model.api.paging.PageResponse;
 import de.digitalcollections.model.api.paging.Sorting;
-import de.digitalcollections.model.api.paging.enums.Direction;
-import de.digitalcollections.model.api.paging.enums.NullHandling;
 import de.digitalcollections.model.api.security.User;
 import de.digitalcollections.model.api.security.enums.Role;
-import de.digitalcollections.model.impl.paging.OrderImpl;
 import de.digitalcollections.model.impl.paging.PageRequestImpl;
 import de.digitalcollections.model.impl.paging.SortingImpl;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiResponseObject;
@@ -53,14 +52,13 @@ public class UserController {
   public PageResponse<User> findAll(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
-      @RequestParam(name = "sortField", required = false, defaultValue = "email") String sortField,
-      @RequestParam(name = "sortDirection", required = false, defaultValue = "ASC")
-          Direction sortDirection,
-      @RequestParam(name = "nullHandling", required = false, defaultValue = "NATIVE")
-          NullHandling nullHandling) {
-    OrderImpl order = new OrderImpl(sortDirection, sortField, nullHandling);
-    Sorting sorting = new SortingImpl(order);
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, sorting);
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting =
+          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      pageRequest.setSorting(sorting);
+    }
     return service.find(pageRequest);
   }
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/view/RenderingTemplateController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/view/RenderingTemplateController.java
@@ -38,7 +38,7 @@ public class RenderingTemplateController {
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
-    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize, null);
+    PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting =
           new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/view/RenderingTemplateController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/view/RenderingTemplateController.java
@@ -11,7 +11,6 @@ import de.digitalcollections.model.impl.view.RenderingTemplate;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,8 +39,7 @@ public class RenderingTemplateController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy) {
     PageRequest pageRequest = new PageRequestImpl(pageNumber, pageSize);
     if (sortBy != null) {
-      Sorting sorting =
-          new SortingImpl(sortBy.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+      Sorting sorting = new SortingImpl(sortBy);
       pageRequest.setSorting(sorting);
     }
     return service.find(pageRequest);


### PR DESCRIPTION
This PR refactors the old syntax for sorting params (one sort field) to the new one (`sortBy`).