### PR TITLE
Fix deletion for empty identifier lists

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifierRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifierRepositoryImpl.java
@@ -40,7 +40,7 @@ public class IdentifierRepositoryImpl extends JdbiRepositoryImpl implements Iden
 
   @Override
   public void delete(List<UUID> uuids) {
-    if (uuids==null || uuids.isEmpty()) {
+    if (uuids == null || uuids.isEmpty()) {
       return;
     }
     dbi.withHandle(

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifierRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifierRepositoryImpl.java
@@ -40,6 +40,9 @@ public class IdentifierRepositoryImpl extends JdbiRepositoryImpl implements Iden
 
   @Override
   public void delete(List<UUID> uuids) {
+    if (uuids==null || uuids.isEmpty()) {
+      return;
+    }
     dbi.withHandle(
         h ->
             h.createUpdate("DELETE FROM " + tableName + " WHERE uuid in (<uuids>)")


### PR DESCRIPTION
If the given list of `uuids` is empty, e.g. when you have a `DigitalObject`, which contains no identifiers at all, the deletion failed. This fix now ignores the deletion request, when the list of `uuids` is null or empty.