### PR TITLE
Add possibility to define links

### DIFF
--- a/dc-cudami-editor/src/components/modals/LinkAdderModal.jsx
+++ b/dc-cudami-editor/src/components/modals/LinkAdderModal.jsx
@@ -86,7 +86,7 @@ class LinkAdderModal extends Component {
                 label="URL"
                 name="link-url"
                 onChange={(value) => this.setAttribute('href', value.trim())}
-                pattern="^(https?://|/).*$"
+                pattern="^(https?://|/|mailto:).*$"
                 required
                 value={attributes.href}
               />


### PR DESCRIPTION
This PR adds functionality to add links with `mailto:` prefix