### PR TITLE
Fix term search in description and label

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
@@ -373,10 +373,19 @@ public class IdentifiableRepositoryImpl<I extends Identifiable> extends JdbiRepo
       return find(searchPageRequest, commonSql, Collections.EMPTY_MAP);
     }
 
+    // FYI: [JSON Path
+    // Functions](https://www.postgresql.org/docs/12/functions-json.html#FUNCTIONS-SQLJSON-PATH)
+    // and [Data type](https://www.postgresql.org/docs/12/datatype-json.html#DATATYPE-JSONPATH)
     commonSql +=
         " WHERE ("
             + "jsonb_path_exists("
             + tableAlias
+            // To insert `:searchTerm` into the `jsonpath` we must split it up;
+            // the cast is necessary otherwise Postgres does not recognise it as `jsonpath` (that is
+            // just a string practically).
+            // Finds (case insensitively) labels that contain the search term, see `like_regex`
+            // example in
+            // https://www.postgresql.org/docs/12/functions-json.html#FUNCTIONS-SQLJSON-PATH
             + ".label, ('$.* ? (@ like_regex \"' || :searchTerm || '\" flag \"iq\")')::jsonpath)"
             + " OR "
             + "jsonb_path_exists("

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
@@ -366,16 +366,6 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
             + tableName
             + " AS "
             + tableAlias
-            + " LEFT JOIN LATERAL jsonb_object_keys("
-            + tableAlias
-            + ".label) lbl(keys) ON "
-            + tableAlias
-            + ".label IS NOT NULL"
-            + " LEFT JOIN LATERAL jsonb_object_keys("
-            + tableAlias
-            + ".description) dsc(keys) ON "
-            + tableAlias
-            + ".description IS NOT NULL"
             + " WHERE ("
             + " NOT EXISTS (SELECT FROM topic_topics WHERE child_topic_uuid = "
             + tableAlias
@@ -388,11 +378,13 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
 
     commonSql +=
         " AND ("
+            + "jsonb_path_exists("
             + tableAlias
-            + ".label->>lbl.keys ILIKE '%' || :searchTerm || '%'"
+            + ".label, ('$.* ? (@ like_regex \"' || :searchTerm || '\" flag \"iq\")')::jsonpath)"
             + " OR "
+            + "jsonb_path_exists("
             + tableAlias
-            + ".description->>dsc.keys ILIKE '%' || :searchTerm || '%')";
+            + ".description, ('$.* ? (@ like_regex \"' || :searchTerm || '\" flag \"iq\")')::jsonpath))";
     return find(searchPageRequest, commonSql, Map.of("searchTerm", searchTerm));
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
@@ -156,31 +156,19 @@ public class FileResourceMetadataRepositoryImpl<F extends FileResource>
 
   public String getCommonFileResourceSearchSql(
       String tableName, String tableAlias, String searchTerm) {
-    String commonSql =
-        " FROM "
-            + tableName
-            + " AS "
-            + tableAlias
-            + " LEFT JOIN LATERAL jsonb_object_keys("
-            + tableAlias
-            + ".label) l(keys) ON "
-            + tableAlias
-            + ".label IS NOT NULL"
-            + " LEFT JOIN LATERAL jsonb_object_keys("
-            + tableAlias
-            + ".description) d(keys) ON "
-            + tableAlias
-            + ".description IS NOT NULL";
+    String commonSql = " FROM " + tableName + " AS " + tableAlias;
     if (!StringUtils.hasText(searchTerm)) {
       return commonSql;
     }
     return commonSql
         + " WHERE ("
+        + "jsonb_path_exists("
         + tableAlias
-        + ".label->>l.keys ILIKE '%' || :searchTerm || '%'"
+        + ".label, ('$.* ? (@ like_regex \"' || :searchTerm || '\" flag \"iq\")')::jsonpath)"
         + " OR "
+        + "jsonb_path_exists("
         + tableAlias
-        + ".description->>d.keys ILIKE '%' || :searchTerm || '%'"
+        + ".description, ('$.* ? (@ like_regex \"' || :searchTerm || '\" flag \"iq\")')::jsonpath)"
         + " OR "
         + tableAlias
         + ".filename ILIKE '%' || :searchTerm || '%')";


### PR DESCRIPTION
This PR fixes some issues with duplicate rows in the SQL resultset due to using `left join` and `group by` to extract JSONs. 

Ticket: cudami/webapp/-/issues/52
