### PR TITLE
Add delete button and highlighting to search button

### DIFF
--- a/dc-cudami-editor/src/components/IdentifiableSearch.css
+++ b/dc-cudami-editor/src/components/IdentifiableSearch.css
@@ -1,5 +1,3 @@
-@charset "UTF-8";
-
 .position-centered {
   top: 0px;
   bottom: 0px;

--- a/dc-cudami-editor/src/components/IdentifiableSearch.css
+++ b/dc-cudami-editor/src/components/IdentifiableSearch.css
@@ -1,0 +1,11 @@
+@charset "UTF-8";
+
+.position-centered {
+  top: 0px;
+  bottom: 0px;
+  right: 0px;
+}
+
+.border-width-3 {
+  border-width: 3px !important;
+}

--- a/dc-cudami-editor/src/components/IdentifiableSearch.jsx
+++ b/dc-cudami-editor/src/components/IdentifiableSearch.jsx
@@ -1,9 +1,12 @@
+import './IdentifiableSearch.css'
+
 import React from 'react'
 import {useTranslation} from 'react-i18next'
-import {FaSearch} from 'react-icons/fa'
+import {FaSearch, FaTimes} from 'react-icons/fa'
 import {Button, Form, Input, InputGroup, InputGroupAddon} from 'reactstrap'
+import classNames from 'classnames'
 
-const IdentifiableSearch = ({onChange, onSubmit, value}) => {
+const IdentifiableSearch = ({onChange, onSubmit, value, isHighlighted}) => {
   const {t} = useTranslation()
   return (
     <Form
@@ -12,13 +15,33 @@ const IdentifiableSearch = ({onChange, onSubmit, value}) => {
         onSubmit()
       }}
     >
-      <InputGroup>
-        <Input
-          onChange={(evt) => onChange(evt.target.value)}
-          placeholder={t('searchTerm')}
-          type="text"
-          value={value}
-        />
+      <InputGroup className="flex-nowrap">
+        <div className="position-relative">
+          <Input
+            className={classNames(
+              'pr-5',
+              isHighlighted && ['border', 'border-danger', 'border-width-3']
+            )}
+            onChange={(evt) => onChange(evt.target.value)}
+            placeholder={t('searchTerm')}
+            type="text"
+            value={value}
+          />
+          <Button
+            className={classNames(
+              'position-absolute',
+              'position-centered',
+              'mr-0',
+              'bg-transparent',
+              'border-0',
+              !value && 'd-none'
+            )}
+            type="button"
+            onClick={() => onChange('')}
+          >
+            <FaTimes color="gray" />
+          </Button>
+        </div>
         <InputGroupAddon addonType="append">
           <Button color="primary" type="submit">
             <FaSearch />

--- a/dc-cudami-editor/src/components/IdentifiableSearch.jsx
+++ b/dc-cudami-editor/src/components/IdentifiableSearch.jsx
@@ -1,10 +1,10 @@
 import './IdentifiableSearch.css'
 
+import classNames from 'classnames'
 import React from 'react'
 import {useTranslation} from 'react-i18next'
 import {FaSearch, FaTimes} from 'react-icons/fa'
 import {Button, Form, Input, InputGroup, InputGroupAddon} from 'reactstrap'
-import classNames from 'classnames'
 
 const IdentifiableSearch = ({onChange, onSubmit, value, isHighlighted}) => {
   const {t} = useTranslation()

--- a/dc-cudami-editor/src/components/Pagination.jsx
+++ b/dc-cudami-editor/src/components/Pagination.jsx
@@ -14,7 +14,7 @@ const Pagination = ({
 }) => {
   const {t} = useTranslation()
   if (totalElements === 0) {
-    return null
+    return <div />
   }
   return (
     <div className="justify-content-start">

--- a/dc-cudami-editor/src/components/lists/PagedIdentifiableList.jsx
+++ b/dc-cudami-editor/src/components/lists/PagedIdentifiableList.jsx
@@ -453,7 +453,7 @@ class PagedIdentifiableList extends Component {
                   onChange={(value) => this.setState({searchTerm: value})}
                   onSubmit={this.executeSearch}
                   value={searchTerm}
-                  isHighlighted={totalElements === 1}
+                  isHighlighted={totalElements === 0}
                 />
               )}
             </div>

--- a/dc-cudami-editor/src/components/lists/PagedIdentifiableList.jsx
+++ b/dc-cudami-editor/src/components/lists/PagedIdentifiableList.jsx
@@ -56,6 +56,7 @@ class PagedIdentifiableList extends Component {
       pageNumber: 0,
       totalElements: 0,
       searchTerm: '',
+      showSearch: true,
     }
   }
 
@@ -69,6 +70,7 @@ class PagedIdentifiableList extends Component {
       identifierTypes,
       numberOfPages: Math.ceil(totalElements / pageSize),
       totalElements,
+      showSearch: totalElements > 0,
     })
   }
 
@@ -373,6 +375,7 @@ class PagedIdentifiableList extends Component {
       pageNumber,
       searchTerm,
       totalElements,
+      showSearch,
     } = this.state
     const showChangeOfOrder =
       enableChangeOfOrder && !changeOfOrderActive && totalElements > 1
@@ -445,11 +448,12 @@ class PagedIdentifiableList extends Component {
                   {t('save')}
                 </Button>
               )}
-              {enableSearch && totalElements > 0 && (
+              {enableSearch && showSearch && (
                 <IdentifiableSearch
                   onChange={(value) => this.setState({searchTerm: value})}
                   onSubmit={this.executeSearch}
                   value={searchTerm}
+                  isHighlighted={totalElements < 1}
                 />
               )}
             </div>

--- a/dc-cudami-editor/src/components/lists/PagedIdentifiableList.jsx
+++ b/dc-cudami-editor/src/components/lists/PagedIdentifiableList.jsx
@@ -453,7 +453,7 @@ class PagedIdentifiableList extends Component {
                   onChange={(value) => this.setState({searchTerm: value})}
                   onSubmit={this.executeSearch}
                   value={searchTerm}
-                  isHighlighted={totalElements < 1}
+                  isHighlighted={totalElements === 1}
                 />
               )}
             </div>


### PR DESCRIPTION
This PR adds a button to delete the search input field and a highlighting for searches with empty resultset to `IdentifiableSearch` button.

See also `cudami/webapp/-/issues/50`.
