### PR TITLE
Increase memory for PostgreSQL docker container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_USER: "cudami"
       POSTGRES_PASSWORD: "somepassword"
       POSTGRES_DB: "cudami"
+    # see https://docs.docker.com/compose/compose-file/compose-file-v2/#shm_size for documentation
+    shm_size: "1g"
   iiif:
     build:
       args:


### PR DESCRIPTION
Die standardmäßigen 64M shared memory reichen gerade bei umfangreicherem Datenbestand und umfrangreicheren Aktionen nicht mehr aus, es kommt zu einer entsprechenden Fehlermeldung.

Mit 1GB sind wir auf der sicherern Seite.