### PR TITLE
Fix SQL jsonpath error on main

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
@@ -338,6 +338,33 @@ public class IdentifiableRepositoryImpl<I extends Identifiable> extends JdbiRepo
     return true;
   }
 
+  /**
+   * Escape characters that must not appear in jsonpath inner strings.
+   *
+   * <p>This method should always be used to clean up strings, e.g. search terms, that are intended
+   * to appear in an jsonpath inner string, i.e. between double quotes. If the inserted term
+   * contains double quotes then the jsonpath breaks. Hence we remove double quotes at start and end
+   * of the provided string (they do not have any meaning for the search at all) and escape the
+   * remaining ones with a backslash.
+   *
+   * @param term, can be null
+   * @return term with forbidden characters removed or escaped
+   */
+  protected String escapeTermForJsonpath(String term) {
+    if (term == null) {
+      return null;
+    }
+    if (term.startsWith("\"") && term.endsWith("\"")) {
+      // 1st step: remove useless surrounding quotes
+      term = term.replaceAll("^\"(.+)\"$", "$1");
+    }
+    if (term.contains("\"")) {
+      // 2nd step: escape remaining double quotes; yes, looks ugly...
+      term = term.replaceAll("\"", "\\\\\"");
+    }
+    return term;
+  }
+
   @Override
   public PageResponse<I> find(PageRequest pageRequest) {
     return find(pageRequest, null, null);
@@ -374,7 +401,8 @@ public class IdentifiableRepositoryImpl<I extends Identifiable> extends JdbiRepo
     }
 
     commonSql += " WHERE " + getCommonSearchSql(tableAlias);
-    return find(searchPageRequest, commonSql, Map.of("searchTerm", searchTerm));
+    return find(
+        searchPageRequest, commonSql, Map.of("searchTerm", this.escapeTermForJsonpath(searchTerm)));
   }
 
   protected SearchPageResponse<I> find(

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
@@ -173,7 +173,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
     String searchTerm = searchPageRequest.getQuery();
     if (StringUtils.hasText(searchTerm)) {
       commonSql += " AND " + getCommonSearchSql(tableAlias);
-      argumentMappings.put("searchTerm", searchTerm);
+      argumentMappings.put("searchTerm", this.escapeTermForJsonpath(searchTerm));
     }
 
     StringBuilder innerQuery = new StringBuilder("SELECT cc.sortindex AS idx, *" + commonSql);
@@ -360,7 +360,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
     String searchTerm = searchPageRequest.getQuery();
     if (StringUtils.hasText(searchTerm)) {
       commonSql += " AND " + getCommonSearchSql(doTableAlias);
-      argumentMappings.put("searchTerm", searchTerm);
+      argumentMappings.put("searchTerm", this.escapeTermForJsonpath(searchTerm));
     }
 
     StringBuilder innerQuery = new StringBuilder("SELECT cd.sortindex AS idx, *" + commonSql);
@@ -529,7 +529,8 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
     }
 
     commonSql += " AND " + getCommonSearchSql(tableAlias);
-    return find(searchPageRequest, commonSql, Map.of("searchTerm", searchTerm));
+    return find(
+        searchPageRequest, commonSql, Map.of("searchTerm", this.escapeTermForJsonpath(searchTerm)));
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
@@ -133,7 +133,7 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
     String searchTerm = searchPageRequest.getQuery();
     if (StringUtils.hasText(searchTerm)) {
       commonSql += " AND " + getCommonSearchSql(tableAlias);
-      argumentMappings.put("searchTerm", searchTerm);
+      argumentMappings.put("searchTerm", this.escapeTermForJsonpath(searchTerm));
     }
 
     StringBuilder innerQuery = new StringBuilder("SELECT cc.sortindex AS idx, *" + commonSql);
@@ -486,7 +486,8 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
     }
 
     commonSql += " AND " + getCommonSearchSql(tableAlias);
-    return find(searchPageRequest, commonSql, Map.of("searchTerm", searchTerm));
+    return find(
+        searchPageRequest, commonSql, Map.of("searchTerm", this.escapeTermForJsonpath(searchTerm)));
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImpl.java
@@ -125,7 +125,7 @@ public class WebsiteRepositoryImpl extends EntityRepositoryImpl<Website>
     String searchTerm = searchPageRequest.getQuery();
     if (StringUtils.hasText(searchTerm)) {
       commonSql += " AND " + getCommonSearchSql(wpTableAlias);
-      argumentMappings.put("searchTerm", searchTerm);
+      argumentMappings.put("searchTerm", this.escapeTermForJsonpath(searchTerm));
     }
 
     StringBuilder innerQuery = new StringBuilder("SELECT ww.sortindex AS idx, *" + commonSql);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
@@ -124,7 +124,8 @@ public class FileResourceMetadataRepositoryImpl<F extends FileResource>
     if (!StringUtils.hasText(searchTerm)) {
       return find(searchPageRequest, commonSql, Collections.EMPTY_MAP);
     }
-    return find(searchPageRequest, commonSql, Map.of("searchTerm", searchTerm));
+    return find(
+        searchPageRequest, commonSql, Map.of("searchTerm", this.escapeTermForJsonpath(searchTerm)));
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/web/WebpageRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/web/WebpageRepositoryImpl.java
@@ -142,7 +142,7 @@ public class WebpageRepositoryImpl extends IdentifiableRepositoryImpl<Webpage>
     String searchTerm = searchPageRequest.getQuery();
     if (StringUtils.hasText(searchTerm)) {
       commonSql += " AND " + getCommonSearchSql(tableAlias);
-      argumentMappings.put("searchTerm", searchTerm);
+      argumentMappings.put("searchTerm", this.escapeTermForJsonpath(searchTerm));
     }
 
     StringBuilder innerQuery = new StringBuilder("SELECT cc.sortindex AS idx, *" + commonSql);
@@ -374,7 +374,8 @@ public class WebpageRepositoryImpl extends IdentifiableRepositoryImpl<Webpage>
     }
 
     commonSql += " AND " + getCommonSearchSql(tableAlias);
-    return find(searchPageRequest, commonSql, Map.of("searchTerm", searchTerm));
+    return find(
+        searchPageRequest, commonSql, Map.of("searchTerm", this.escapeTermForJsonpath(searchTerm)));
   }
 
   @Override


### PR DESCRIPTION
This PR fixes an error that happens when a `searchTerm` is inserted into a jsonpath `like_regex` search that contains double quotes. Since double quotes are special characters for "inner strings" those will break the syntax. Surrounding double quotes are not necessary and will be removed now. Those within the `searchTerm` string will be escaped by backslashes.

Ticket: /cudami/webapp/-/issues/116