### PR TITLE
Add more security restriction

### DIFF
--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigSecurityWebapp.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/config/SpringConfigSecurityWebapp.java
@@ -52,7 +52,7 @@ public class SpringConfigSecurityWebapp extends WebSecurityConfigurerAdapter {
 
     http.authorizeRequests()
         .antMatchers("/users/updatePassword")
-        .permitAll()
+        .hasAnyAuthority(Role.ADMIN.getAuthority(), Role.CONTENT_MANAGER.getAuthority())
         .antMatchers("/users/**")
         .hasAnyAuthority(Role.ADMIN.getAuthority())
         .anyRequest()


### PR DESCRIPTION
This PR adds more restrictions for the admin endpoint `/users/updatePassword`, that only users with specific roles can access it - everyone else gets redirected to the login form.