### PR TITLE
Remove checkbox to activate remember-me functionality

### DIFF
--- a/dc-cudami-admin/src/main/resources/templates/login.html
+++ b/dc-cudami-admin/src/main/resources/templates/login.html
@@ -45,10 +45,11 @@
             </div>
             <div class="row">
               <div class="col-8">
-                <div class="icheck-primary">
+                <!-- FIXME: this is not working at the moment, should come back later -->
+                <!--<div class="icheck-primary">
                   <input type="checkbox" id="remember-me" name="remember-me">
                   <label for="remember-me" th:text="#{lbl_stay_logged_in}">Remember me</label>
-                </div>
+                </div>-->
               </div>
               <!-- /.col -->
               <div class="col-4">


### PR DESCRIPTION
This PR removes the checkbox to activate remember-me functionality, because it is not working properly at the moment.