### PR TITLE
Fix check if label should be rendered

### DIFF
--- a/dc-cudami-client/src/main/resources/templates/cudami/fragments/webpage-to-html.html
+++ b/dc-cudami-client/src/main/resources/templates/cudami/fragments/webpage-to-html.html
@@ -5,7 +5,7 @@
 
   <th:block th:fragment="renderWebpage(webpage, locale)">
     <div class="webpage">
-      <th:block th:if="${renderLabel}">
+      <th:block th:if="${#objects.nullSafe(renderLabel, true)}">
         <!-- label of webpage: -->
         <div class="webpage-label">
           <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(${webpage.label}, ${locale})"></th:block>
@@ -28,5 +28,5 @@
     </div>
   </th:block>
 
-</body>
+  </body>
 </html>


### PR DESCRIPTION
This PR fixes the former default behaviour that the label will be rendered, if `renderLabel` is not defined.