### PR TITLE
Fix alt text of preview image

### DIFF
--- a/dc-cudami-editor/src/components/PreviewImage.jsx
+++ b/dc-cudami-editor/src/components/PreviewImage.jsx
@@ -1,4 +1,5 @@
 import {useContext} from 'react'
+import {useTranslation} from 'react-i18next'
 
 import AppContext from './AppContext'
 import {getImageUrl} from './utils'
@@ -11,6 +12,7 @@ const PreviewImage = ({
   showCaption = false,
   width,
 }) => {
+  const {t} = useTranslation()
   const {apiContextPath, defaultLanguage} = useContext(AppContext)
   if (!language) {
     language = defaultLanguage
@@ -19,7 +21,9 @@ const PreviewImage = ({
   return (
     <figure className={className} style={{maxWidth: `${width}px`}}>
       <img
-        alt={altText?.[language] ?? ''}
+        alt={
+          image ? altText?.[language] ?? image.filename : t('noPreviewImage')
+        }
         className="img-fluid mw-100"
         src={
           image

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -197,6 +197,7 @@
     "next": "Weiter",
     "no": "Nein",
     "noAlignment": "ohne Textumlauf",
+    "noPreviewImage": "kein Vorschaubild",
     "numberOfColumns": "Anzahl an Spalten",
     "numberOfRows": "Anzahl an Zeilen",
     "openLinkNewTab": "in einem neuen Tab öffnen",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -197,6 +197,7 @@
     "next": "Next",
     "no": "No",
     "noAlignment": "without text wrapping",
+    "noPreviewImage": "no preview image",
     "numberOfColumns": "Number of columns",
     "numberOfRows": "Number of rows",
     "openLinkNewTab": "open in a new tab",


### PR DESCRIPTION
This PR fixes the alt text used in the editor for preview images to be consistent with the client rendering.