### PR TITLE
Fix display of empty language

### DIFF
--- a/dc-cudami-editor/src/components/LanguageTab.jsx
+++ b/dc-cudami-editor/src/components/LanguageTab.jsx
@@ -16,7 +16,7 @@ const LanguageTab = ({activeLanguage, enableRemove, language, toggle}) => {
           }
         }}
       >
-        {t(`languageNames:${language}`)}
+        {language ? t(`languageNames:${language}`) : `(${t('notSpecified')})`}
         {enableRemove && (
           <Button
             className="ml-2 p-0"

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -196,6 +196,7 @@
     "new": "Neu",
     "next": "Weiter",
     "no": "Nein",
+    "notSpecified": "nicht spezifiziert",
     "noAlignment": "ohne Textumlauf",
     "numberOfColumns": "Anzahl an Spalten",
     "numberOfRows": "Anzahl an Zeilen",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -196,6 +196,7 @@
     "new": "New",
     "next": "Next",
     "no": "No",
+    "notSpecified": "not specified",
     "noAlignment": "without text wrapping",
     "numberOfColumns": "Number of columns",
     "numberOfRows": "Number of rows",


### PR DESCRIPTION
This PR adds a text to display on the language tab, when the language is empty.