### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           check-latest: true
-          distribution: adopt
+          distribution: zulu
           java-version: ${{ matrix.java }}
       - name: Set up cache
         uses: actions/cache@v2
@@ -42,7 +42,7 @@ jobs:
         run: mvn -B -U clean verify -Pproduction
     strategy:
       matrix:
-        java: [11, 14]
+        java: [11, 11.0.3, 14]
   coverage:
     needs: build
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           check-latest: true
-          distribution: adopt
+          distribution: zulu
           java-version: 11
           server-id: ossrh-snapshots
           server-password: MAVEN_PASSWORD
@@ -108,7 +108,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           check-latest: true
-          distribution: adopt
+          distribution: zulu
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           java-version: 11


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Added a fixed release to LTS versions of the JDK as best practices.