### PR TITLE
Identifiable assert

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
@@ -14,6 +14,7 @@
   <packaging>jar</packaging>
 
   <properties>
+    <version.assertj-assertions-generator-maven-plugin>2.1.0</version.assertj-assertions-generator-maven-plugin>
     <version.dc-commons-jdbi>4.2.1-SNAPSHOT</version.dc-commons-jdbi>
     <version.jdbi>3.20.1</version.jdbi>
     <version.testcontainers>1.16.0</version.testcontainers>
@@ -127,4 +128,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
+        <version>${version.assertj-assertions-generator-maven-plugin}</version>
+        <configuration>
+          <classes>
+            <param>de.digitalcollections.cudami.server.backend.impl.asserts.IdentifiableAssert</param>
+          </classes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
@@ -14,7 +14,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.assertj-assertions-generator-maven-plugin>2.1.0</version.assertj-assertions-generator-maven-plugin>
     <version.dc-commons-jdbi>4.2.1-SNAPSHOT</version.dc-commons-jdbi>
     <version.jdbi>3.20.1</version.jdbi>
     <version.testcontainers>1.16.0</version.testcontainers>
@@ -128,19 +127,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
-        <version>${version.assertj-assertions-generator-maven-plugin}</version>
-        <configuration>
-          <classes>
-            <param>de.digitalcollections.cudami.server.backend.impl.asserts.IdentifiableAssert</param>
-          </classes>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/CudamiAssertions.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/CudamiAssertions.java
@@ -1,0 +1,11 @@
+package de.digitalcollections.cudami.server.backend.impl.asserts;
+
+import de.digitalcollections.model.identifiable.Identifiable;
+import org.assertj.core.api.Assertions;
+
+public class CudamiAssertions extends Assertions {
+
+  public static IdentifiableAssert assertThat(Identifiable actual) {
+    return new IdentifiableAssert(actual);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
@@ -4,7 +4,7 @@ import de.digitalcollections.model.identifiable.Identifiable;
 import org.assertj.core.api.AbstractAssert;
 
 /**
- * The IdentifiableAssert compares to identifiables field by field with the exception of
+ * The IdentifiableAssert compares two identifiables field by field with the exception of
  * lastModified.
  */
 public class IdentifiableAssert extends AbstractAssert<IdentifiableAssert, Identifiable> {

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
@@ -1,0 +1,31 @@
+package de.digitalcollections.cudami.server.backend.impl.asserts;
+
+import de.digitalcollections.model.identifiable.Identifiable;
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * The IdentifiableAssert compares to identifiables field by field with the exception of
+ * lastModified.
+ */
+public class IdentifiableAssert extends AbstractAssert<IdentifiableAssert, Identifiable> {
+
+  Identifiable actual;
+
+  public IdentifiableAssert(Identifiable identifiable) {
+    super(identifiable, IdentifiableAssert.class);
+    actual = identifiable;
+  }
+
+  public static IdentifiableAssert assertThat(Identifiable identifiable) {
+    return new IdentifiableAssert(identifiable);
+  }
+
+  @Override
+  public IdentifiableAssert isEqualTo(Object expected) {
+    if (expected instanceof Identifiable) {
+      ((Identifiable) expected).setLastModified(actual.getLastModified());
+    }
+
+    return super.isEqualTo(expected);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
@@ -9,7 +9,7 @@ import org.assertj.core.api.AbstractAssert;
  */
 public class IdentifiableAssert extends AbstractAssert<IdentifiableAssert, Identifiable> {
 
-  Identifiable actual;
+  private Identifiable actual;
 
   public IdentifiableAssert(Identifiable identifiable) {
     super(identifiable, IdentifiableAssert.class);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/asserts/IdentifiableAssert.java
@@ -16,10 +16,6 @@ public class IdentifiableAssert extends AbstractAssert<IdentifiableAssert, Ident
     actual = identifiable;
   }
 
-  public static IdentifiableAssert assertThat(Identifiable identifiable) {
-    return new IdentifiableAssert(identifiable);
-  }
-
   @Override
   public IdentifiableAssert isEqualTo(Object expected) {
     if (expected instanceof Identifiable) {

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
@@ -3,7 +3,6 @@ package de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable;
 import static de.digitalcollections.cudami.server.backend.impl.asserts.CudamiAssertions.assertThat;
 
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
-import de.digitalcollections.cudami.server.backend.impl.asserts.IdentifiableAssert;
 import de.digitalcollections.cudami.server.backend.impl.database.config.SpringConfigBackendDatabase;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.IdentifiableType;
@@ -69,7 +68,7 @@ class IdentifiableRepositoryImplTest {
     identifiable = this.repo.save(identifiable);
 
     Identifiable actual = this.repo.findOne(identifiable.getUuid());
-    IdentifiableAssert.assertThat(actual).isEqualTo(identifiable);
+    assertThat(actual).isEqualTo(identifiable);
   }
 
   @Test

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
@@ -64,7 +64,8 @@ class IdentifiableRepositoryImplTest {
     identifiable.setType(IdentifiableType.RESOURCE);
     identifiable.setLabel("test");
     identifiable.setLastModified(LocalDateTime.now());
-    this.repo.save(identifiable);
+
+    identifiable = this.repo.save(identifiable);
 
     Identifiable actual = this.repo.findOne(identifiable.getUuid());
     assertThat(actual).isEqualTo(identifiable);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
@@ -1,8 +1,9 @@
 package de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static de.digitalcollections.cudami.server.backend.impl.asserts.CudamiAssertions.assertThat;
 
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
+import de.digitalcollections.cudami.server.backend.impl.asserts.IdentifiableAssert;
 import de.digitalcollections.cudami.server.backend.impl.database.config.SpringConfigBackendDatabase;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.IdentifiableType;
@@ -68,7 +69,7 @@ class IdentifiableRepositoryImplTest {
     identifiable = this.repo.save(identifiable);
 
     Identifiable actual = this.repo.findOne(identifiable.getUuid());
-    assertThat(actual).isEqualTo(identifiable);
+    IdentifiableAssert.assertThat(actual).isEqualTo(identifiable);
   }
 
   @Test


### PR DESCRIPTION
Neues Assert für Identifiables, das das Feld `lastModified` aus dem `isEqualTo`-Vergleich herausnimmt, bzw. es dort elegant neutralisiert.