### PR TITLE
Add default values if there are no existing urlaliases on edit

### DIFF
--- a/dc-cudami-editor/src/components/dialogs/AddUrlAliasesDialog.jsx
+++ b/dc-cudami-editor/src/components/dialogs/AddUrlAliasesDialog.jsx
@@ -31,7 +31,7 @@ import {UrlAlias} from '../UrlAliases'
 
 const AddUrlAliasesDialog = ({
   activeLanguage,
-  existingUrlAliases,
+  existingUrlAliases = [],
   isOpen,
   onSubmit,
   parentWebsite,

--- a/dc-cudami-editor/src/components/forms/IdentifiableForm.jsx
+++ b/dc-cudami-editor/src/components/forms/IdentifiableForm.jsx
@@ -217,7 +217,7 @@ class IdentifiableForm extends Component {
     const {existingLanguages, identifiable} = this.state
     const languagesWithoutGeneratedSlug = existingLanguages.filter(
       (language) => {
-        const listOfAliases = identifiable.localizedUrlAliases?.[language]
+        const listOfAliases = identifiable.localizedUrlAliases?.[language] ?? []
         return (
           !listOfAliases.length ||
           listOfAliases.every(
@@ -380,7 +380,7 @@ class IdentifiableForm extends Component {
           localizedUrlAliases: mergeWith(
             identifiable.localizedUrlAliases,
             generatedUrlAliases,
-            (objValue, srcValue) => objValue.concat(srcValue),
+            (objValue, srcValue) => (objValue ?? []).concat(srcValue),
           ),
         },
       })


### PR DESCRIPTION
This PR adds default values if there are no existing urlaliases on edit caused by a missing migration of a webpage's webpages.