### PR TITLE
Fix UrlAlias generation for sub-pages

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
@@ -205,7 +205,7 @@ public class V9_02_02__DML_Fill_urlaliases extends BaseJavaMigration {
             } catch (SQLException e) {
               throw new RuntimeException(
                   "Cannot migrate subpages for websiteUuid="
-                      + webpages
+                      + websiteUuid
                       + ", uuid="
                       + uuid
                       + ": "

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
@@ -148,31 +148,74 @@ public class V9_02_02__DML_Fill_urlaliases extends BaseJavaMigration {
           JSONObject jsonObject = new JSONObject(w.toString());
           UUID uuid = UUID.fromString(jsonObject.getString("w_uuid"));
           UUID websiteUuid = UUID.fromString(jsonObject.getString("ws_uuid"));
-          try {
-            Map<String, String> labels =
-                new ObjectMapper().readValue(jsonObject.getString("label"), HashMap.class);
-            labels.forEach(
-                (language, label) -> {
-                  UrlAlias urlAlias =
-                      buildUrlAlias(
-                          jdbcTemplate,
-                          null,
-                          IdentifiableType.RESOURCE,
-                          uuid,
-                          language,
-                          label,
-                          websiteUuid);
-                  try {
-                    saveUrlAlias(jdbcTemplate, urlAlias);
-                  } catch (SQLException e) {
-                    throw new RuntimeException("Cannot save urlAlias " + urlAlias + ": " + e, e);
-                  }
-                });
-          } catch (JsonProcessingException e) {
-            throw new RuntimeException("Cannot parse " + w + ": " + e, e);
-          }
+          createUrlAliasAndMigrateSubpages(
+              jdbcTemplate, webpages, w, jsonObject, uuid, websiteUuid);
         });
     LOGGER.info("Successfully added {} UrlAliases for webpages", webpages.size());
+  }
+
+  private void migrateSubpages(JdbcTemplate jdbcTemplate, UUID websiteUuid, UUID parentWebpageUuid)
+      throws SQLException {
+    String selectQuery =
+        "SELECT w.uuid AS w_uuid, w.label AS label FROM webpages w, webpage_webpages ww WHERE ww.parent_webpage_uuid = '"
+            + parentWebpageUuid
+            + "' and ww.child_webpage_uuid=w.uuid";
+    List<Map<String, String>> webpages = jdbcTemplate.queryForList(selectQuery);
+    if (webpages.isEmpty()) {
+      return;
+    }
+
+    webpages.forEach(
+        w -> {
+          JSONObject jsonObject = new JSONObject(w.toString());
+          UUID uuid = UUID.fromString(jsonObject.getString("w_uuid"));
+          createUrlAliasAndMigrateSubpages(
+              jdbcTemplate, webpages, w, jsonObject, uuid, websiteUuid);
+        });
+  }
+
+  private void createUrlAliasAndMigrateSubpages(
+      JdbcTemplate jdbcTemplate,
+      List<Map<String, String>> webpages,
+      Map<String, String> w,
+      JSONObject jsonObject,
+      UUID uuid,
+      UUID websiteUuid) {
+    try {
+      Map<String, String> labels =
+          new ObjectMapper().readValue(jsonObject.getString("label"), HashMap.class);
+      labels.forEach(
+          (language, label) -> {
+            UrlAlias urlAlias =
+                buildUrlAlias(
+                    jdbcTemplate,
+                    null,
+                    IdentifiableType.RESOURCE,
+                    uuid,
+                    language,
+                    label,
+                    websiteUuid);
+            try {
+              saveUrlAlias(jdbcTemplate, urlAlias);
+            } catch (SQLException e) {
+              throw new RuntimeException("Cannot save urlAlias " + urlAlias + ": " + e, e);
+            }
+            try {
+              migrateSubpages(jdbcTemplate, websiteUuid, uuid);
+            } catch (SQLException e) {
+              throw new RuntimeException(
+                  "Cannot migrate subpages for websiteUuid="
+                      + webpages
+                      + ", uuid="
+                      + uuid
+                      + ": "
+                      + e,
+                  e);
+            }
+          });
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Cannot parse " + w + ": " + e, e);
+    }
   }
 
   private void migrateIdentifiables(
@@ -251,7 +294,8 @@ public class V9_02_02__DML_Fill_urlaliases extends BaseJavaMigration {
     }
 
     if (!slug.equals(baseSlug)) {
-      LOGGER.warn("{}: Building slug with suffix={}", entityType, slug);
+      LOGGER.warn(
+          "{}: Building slug with suffix={}", entityType != null ? entityType : "WEBPAGE", slug);
     }
 
     UrlAlias urlAlias = new UrlAlias();

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
@@ -148,8 +148,7 @@ public class V9_02_02__DML_Fill_urlaliases extends BaseJavaMigration {
           JSONObject jsonObject = new JSONObject(w.toString());
           UUID uuid = UUID.fromString(jsonObject.getString("w_uuid"));
           UUID websiteUuid = UUID.fromString(jsonObject.getString("ws_uuid"));
-          createUrlAliasAndMigrateSubpages(
-              jdbcTemplate, webpages, w, jsonObject, uuid, websiteUuid);
+          createUrlAliasAndMigrateSubpages(jdbcTemplate, jsonObject, uuid, websiteUuid);
         });
     LOGGER.info("Successfully added {} UrlAliases for webpages", webpages.size());
   }
@@ -169,18 +168,12 @@ public class V9_02_02__DML_Fill_urlaliases extends BaseJavaMigration {
         w -> {
           JSONObject jsonObject = new JSONObject(w.toString());
           UUID uuid = UUID.fromString(jsonObject.getString("w_uuid"));
-          createUrlAliasAndMigrateSubpages(
-              jdbcTemplate, webpages, w, jsonObject, uuid, websiteUuid);
+          createUrlAliasAndMigrateSubpages(jdbcTemplate, jsonObject, uuid, websiteUuid);
         });
   }
 
   private void createUrlAliasAndMigrateSubpages(
-      JdbcTemplate jdbcTemplate,
-      List<Map<String, String>> webpages,
-      Map<String, String> w,
-      JSONObject jsonObject,
-      UUID uuid,
-      UUID websiteUuid) {
+      JdbcTemplate jdbcTemplate, JSONObject jsonObject, UUID uuid, UUID websiteUuid) {
     try {
       Map<String, String> labels =
           new ObjectMapper().readValue(jsonObject.getString("label"), HashMap.class);
@@ -214,7 +207,7 @@ public class V9_02_02__DML_Fill_urlaliases extends BaseJavaMigration {
             }
           });
     } catch (JsonProcessingException e) {
-      throw new RuntimeException("Cannot parse " + w + ": " + e, e);
+      throw new RuntimeException("Cannot parse " + jsonObject + ": " + e, e);
     }
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/database/migration/V9_02_02__DML_Fill_urlaliases.java
@@ -156,9 +156,9 @@ public class V9_02_02__DML_Fill_urlaliases extends BaseJavaMigration {
   private void migrateSubpages(JdbcTemplate jdbcTemplate, UUID websiteUuid, UUID parentWebpageUuid)
       throws SQLException {
     String selectQuery =
-        "SELECT w.uuid AS w_uuid, w.label AS label FROM webpages w, webpage_webpages ww WHERE ww.parent_webpage_uuid = '"
+        "SELECT w.uuid AS w_uuid, w.label AS label FROM webpages w INNER JOIN webpage_webpages ww ON ww.child_webpage_uuid=w.uuid WHERE ww.parent_webpage_uuid = '"
             + parentWebpageUuid
-            + "' and ww.child_webpage_uuid=w.uuid";
+            + "'";
     List<Map<String, String>> webpages = jdbcTemplate.queryForList(selectQuery);
     if (webpages.isEmpty()) {
       return;


### PR DESCRIPTION
Fix UrlAlias generation for sub-pages

To make this Fix effective, you have to re-run the migration (and hope, that nobody entered or modified UrlAliases yet), by
deleting the old one in the database:

```
delete from url_aliases;
delete from flyway_schema_history where version='9.02.02';
```