### PR TITLE
Fix update of identifiable with incomplete UrlAliases

### DIFF
--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -350,8 +350,8 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
                             && Objects.equals(
                                 ua.getTargetLanguage(), primaryFromDb.getTargetLanguage()))) {
               primaryFromDb.setPrimary(false);
-              urlAliasesToUpdate.add(primaryFromDb);
             }
+            urlAliasesToUpdate.add(primaryFromDb);
           }
         }
       }


### PR DESCRIPTION
On update if only one primary UrlAlias is provided then a new primary alias for the other language is created. That's not how it should go. This small PR fixes this mistake.