### PR TITLE
Only look at former primary aliases and take full target into account

### DIFF
--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -352,8 +352,7 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
                                         .equals(primaryFromDb.getWebsite().getUuid())
                                 || ua.getWebsite() == primaryFromDb.getWebsite())
                             && Objects.equals(
-                                ua.getTargetLanguage(), primaryFromDb.getTargetLanguage())
-                            && ua.getTargetUuid() == primaryFromDb.getTargetUuid())) {
+                                ua.getTargetLanguage(), primaryFromDb.getTargetLanguage()))) {
               primaryFromDb.setPrimary(false);
               urlAliasesToUpdate.add(primaryFromDb);
             }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -335,10 +335,14 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
         LocalizedUrlAliases allPrimaries =
             urlAliasService.findLocalizedUrlAliases(identifiable.getUuid());
         if (allPrimaries != null) {
-          allPrimaries.flatten().removeIf(ua -> !ua.isPrimary());
 
+          // Only look at the non primary aliases
+          allPrimaries.flatten().removeIf(ua -> !ua.isPrimary());
+          // and check, if there are conflicting primary aliases for the same target, which
+          // must be set to non-primary then
           for (UrlAlias primaryFromDb : allPrimaries.flatten()) {
             if (urlAliasesToUpdate.flatten().stream()
+                .filter(ua -> ua.isPrimary())
                 .anyMatch(
                     ua ->
                         (ua.getWebsite() != null
@@ -348,10 +352,11 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
                                         .equals(primaryFromDb.getWebsite().getUuid())
                                 || ua.getWebsite() == primaryFromDb.getWebsite())
                             && Objects.equals(
-                                ua.getTargetLanguage(), primaryFromDb.getTargetLanguage()))) {
+                                ua.getTargetLanguage(), primaryFromDb.getTargetLanguage())
+                            && ua.getTargetUuid() == primaryFromDb.getTargetUuid())) {
               primaryFromDb.setPrimary(false);
+              urlAliasesToUpdate.add(primaryFromDb);
             }
-            urlAliasesToUpdate.add(primaryFromDb);
           }
         }
       }


### PR DESCRIPTION
The step, which removes former primary aliases from database must:

1.) Only look at the former primary aliases in the database
~~2.) Take the target uuid into calculation, to reliably get the target. Target language alone is not sufficient.~~