### PR TITLE
Remove obsolete hal-browser dependency

### DIFF
--- a/dc-cudami-server/dc-cudami-server-webapp/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-webapp/pom.xml
@@ -169,10 +169,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>hal-browser</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/dc-cudami-templates/template-website-springboot/pom.xml
+++ b/dc-cudami-templates/template-website-springboot/pom.xml
@@ -62,10 +62,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>hal-browser</artifactId>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
It is not versioned anymore in `spring-boot-starter-parent` causing #1336 to fail, so we remove the dependency, because it is not used anymore.