### PR TITLE
Rerefactor transactional annotation

### DIFF
--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -38,12 +38,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service("identifiableService")
-@Transactional(
-    rollbackFor = {
-      IdentifiableServiceException.class,
-      ValidationException.class,
-      RuntimeException.class
-    })
+@Transactional(rollbackFor = {Exception.class})
 public class IdentifiableServiceImpl<I extends Identifiable> implements IdentifiableService<I> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IdentifiableServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifierTypeServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifierTypeServiceImpl.java
@@ -13,8 +13,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(rollbackFor = {Exception.class})
 public class IdentifierTypeServiceImpl implements IdentifierTypeService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IdentifierTypeServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/FamilyNameServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/FamilyNameServiceImpl.java
@@ -10,10 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class FamilyNameServiceImpl extends IdentifiableServiceImpl<FamilyName>
     implements FamilyNameService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/GivenNameServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/GivenNameServiceImpl.java
@@ -10,10 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class GivenNameServiceImpl extends IdentifiableServiceImpl<GivenName>
     implements GivenNameService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** Service implementation for UrlAlias handling. */
 @Service
-@Transactional(rollbackFor = {RuntimeException.class, CudamiServiceException.class})
+@Transactional(rollbackFor = {Exception.class})
 public class UrlAliasServiceImpl implements UrlAliasService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UrlAliasServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ArticleServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ArticleServiceImpl.java
@@ -15,11 +15,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /** Service for Article handling. */
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class ArticleServiceImpl extends EntityServiceImpl<Article> implements ArticleService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArticleServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
@@ -22,10 +22,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional(rollbackFor = {IdentifiableServiceException.class, RuntimeException.class})
 public class CollectionServiceImpl extends EntityServiceImpl<Collection>
     implements CollectionService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/DigitalObjectServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/DigitalObjectServiceImpl.java
@@ -22,11 +22,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /** Service for Digital Object handling. */
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class DigitalObjectServiceImpl extends EntityServiceImpl<DigitalObject>
     implements DigitalObjectService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/EntityServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/EntityServiceImpl.java
@@ -29,15 +29,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service("entityService")
-@Transactional(
-    rollbackFor = {
-      IdentifiableServiceException.class,
-      ValidationException.class,
-      RuntimeException.class
-    })
 public class EntityServiceImpl<E extends Entity> extends IdentifiableServiceImpl<E>
     implements EntityService<E> {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ProjectServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ProjectServiceImpl.java
@@ -17,10 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class ProjectServiceImpl extends EntityServiceImpl<Project> implements ProjectService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProjectServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/TopicServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/TopicServiceImpl.java
@@ -21,11 +21,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /** Service for Topic handling. */
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional(rollbackFor = {IdentifiableServiceException.class, RuntimeException.class})
 public class TopicServiceImpl extends EntityServiceImpl<Topic> implements TopicService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TopicServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/WebsiteServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/WebsiteServiceImpl.java
@@ -14,11 +14,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /** Service for Website handling. */
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class WebsiteServiceImpl extends EntityServiceImpl<Website> implements WebsiteService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebsiteServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/AgentServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/AgentServiceImpl.java
@@ -14,11 +14,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /** Service for Agent handling. */
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class AgentServiceImpl extends EntityServiceImpl<Agent> implements AgentService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/CorporateBodyServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/CorporateBodyServiceImpl.java
@@ -15,10 +15,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class CorporateBodyServiceImpl extends EntityServiceImpl<CorporateBody>
     implements CorporateBodyService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/PersonServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/PersonServiceImpl.java
@@ -17,10 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class PersonServiceImpl extends EntityServiceImpl<Person> implements PersonService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PersonServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/GeoLocationServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/GeoLocationServiceImpl.java
@@ -10,10 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class GeoLocationServiceImpl extends EntityServiceImpl<GeoLocation>
     implements GeoLocationService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/HumanSettlementServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/HumanSettlementServiceImpl.java
@@ -10,10 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class HumanSettlementServiceImpl extends EntityServiceImpl<HumanSettlement>
     implements HumanSettlementService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/relation/EntityRelationServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/relation/EntityRelationServiceImpl.java
@@ -9,8 +9,10 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(rollbackFor = {Exception.class})
 public class EntityRelationServiceImpl implements EntityRelationService {
 
   private final EntityRelationRepository repository;

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/relation/PredicateServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/relation/PredicateServiceImpl.java
@@ -6,9 +6,11 @@ import de.digitalcollections.model.relation.Predicate;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Service for managing predicates */
 @Service
+@Transactional(rollbackFor = {Exception.class})
 public class PredicateServiceImpl implements PredicateService {
 
   @Autowired private PredicateRepository repository;

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/ItemServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/ItemServiceImpl.java
@@ -14,10 +14,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class ItemServiceImpl extends EntityServiceImpl<Item> implements ItemService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ItemServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/WorkServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/WorkServiceImpl.java
@@ -14,10 +14,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class WorkServiceImpl extends EntityServiceImpl<Work> implements WorkService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WorkServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ApplicationFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ApplicationFileResourceServiceImpl.java
@@ -13,10 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class ApplicationFileResourceServiceImpl
     extends IdentifiableServiceImpl<ApplicationFileResource>
     implements ApplicationFileResourceService {

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/AudioFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/AudioFileResourceServiceImpl.java
@@ -13,10 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class AudioFileResourceServiceImpl extends IdentifiableServiceImpl<AudioFileResource>
     implements AudioFileResourceService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceBinaryServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceBinaryServiceImpl.java
@@ -14,9 +14,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.w3c.dom.Document;
 
 @Service
+@Transactional(rollbackFor = {Exception.class})
 public class FileResourceBinaryServiceImpl implements FileResourceBinaryService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FileResourceBinaryServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
@@ -30,15 +30,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service("fileResourceMetadataService")
-@Transactional(
-    rollbackFor = {
-      IdentifiableServiceException.class,
-      ValidationException.class,
-      RuntimeException.class
-    })
 public class FileResourceMetadataServiceImpl extends IdentifiableServiceImpl<FileResource>
     implements FileResourceMetadataService<FileResource> {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ImageFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ImageFileResourceServiceImpl.java
@@ -13,10 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class ImageFileResourceServiceImpl extends IdentifiableServiceImpl<ImageFileResource>
     implements ImageFileResourceService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImpl.java
@@ -13,10 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class LinkedDataFileResourceServiceImpl
     extends IdentifiableServiceImpl<LinkedDataFileResource>
     implements LinkedDataFileResourceService {

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/TextFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/TextFileResourceServiceImpl.java
@@ -13,10 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class TextFileResourceServiceImpl extends IdentifiableServiceImpl<TextFileResource>
     implements TextFileResourceService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/VideoFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/VideoFileResourceServiceImpl.java
@@ -13,10 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional
 public class VideoFileResourceServiceImpl extends IdentifiableServiceImpl<VideoFileResource>
     implements VideoFileResourceService {
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/versioning/VersionServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/versioning/VersionServiceImpl.java
@@ -10,8 +10,10 @@ import de.digitalcollections.model.identifiable.versioning.Version;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(rollbackFor = {Exception.class})
 public class VersionServiceImpl implements VersionService {
 
   @Autowired private VersionRepository repository;

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImpl.java
@@ -26,11 +26,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /** Service for Webpage handling. */
+// @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-@Transactional(rollbackFor = {RuntimeException.class, IdentifiableServiceException.class})
 public class WebpageServiceImpl extends IdentifiableServiceImpl<Webpage> implements WebpageService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebpageServiceImpl.class);


### PR DESCRIPTION
1. rerefactor `@Transactional`:
   > I messed it up a bit: `@Transactional` is inherited by derived classes. 
   If an derived class is annotated with `@Transactional` again then the former from the super class is overriden.
   So here I make sure that only the super class is annotated and all subclasses got a comment.
2. add `@Transactional` to those classes that I have overseen
3. expand `rollbackFor`: any Exception causes a rollback of the db so we need not keep track on newly introduced Exceptions
