### PR TITLE
Fix the logic to handle generated urlaliases

### DIFF
--- a/dc-cudami-editor/src/components/UrlAliases.jsx
+++ b/dc-cudami-editor/src/components/UrlAliases.jsx
@@ -41,22 +41,21 @@ const sortByWebsite = (
 
 const UrlAlias = ({
   lastPublished,
-  onChange,
+  onChangePrimary,
   onRemove,
   primary = false,
-  readOnly,
   slug,
   url = '',
 }) => {
   const {i18n, t} = useTranslation()
   const uiLocale = i18n.language
-  const showRemoveButton = !(lastPublished || primary || readOnly)
+  const showRemoveButton = !(lastPublished || !onRemove || primary)
   return (
     <ListGroupItem className="align-items-center d-flex justify-content-between">
-      <FormGroup check className={classNames({'pl-0': readOnly})}>
+      <FormGroup check className={classNames({'pl-0': !onChangePrimary})}>
         <Label check>
-          {!readOnly && (
-            <Input checked={primary} onChange={onChange} type="radio" />
+          {!!onChangePrimary && (
+            <Input checked={primary} onChange={onChangePrimary} type="radio" />
           )}
           {`${url.replace(/\/$/, '')}/${slug}`}
         </Label>
@@ -99,19 +98,18 @@ const UrlAliases = ({
                   <UrlAlias
                     key={slug}
                     lastPublished={lastPublished}
-                    onChange={() =>
-                      onUpdate(setNewPrimary(aliases, slug, website))
-                    }
-                    onRemove={() =>
-                      publish('editor.show-remove-urlalias-dialog', {
-                        slug,
-                        website,
-                      })
-                    }
                     primary={primary}
-                    readOnly={readOnly}
                     slug={slug}
                     url={website?.url}
+                    {...(!readOnly && {
+                      onChangePrimary: () =>
+                        onUpdate(setNewPrimary(aliases, slug, website)),
+                      onRemove: () =>
+                        publish('editor.show-remove-urlalias-dialog', {
+                          slug,
+                          website,
+                        }),
+                    })}
                   />
                 ))}
             </ListGroup>

--- a/dc-cudami-editor/src/components/UrlAliases.jsx
+++ b/dc-cudami-editor/src/components/UrlAliases.jsx
@@ -52,7 +52,7 @@ const EditableUrlAlias = ({onChange, slug, url = ''}) => (
 )
 
 const UrlAlias = ({
-  lastPublished,
+  lastPublished = false,
   onChangePrimary,
   onRemove,
   primary = false,

--- a/dc-cudami-editor/src/components/UrlAliases.jsx
+++ b/dc-cudami-editor/src/components/UrlAliases.jsx
@@ -45,7 +45,8 @@ const sortByWebsite = (
 const EditableUrlAlias = ({onChange, slug, url = ''}) => (
   <InputGroup>
     <InputGroupAddon addonType="prepend">
-      <InputGroupText>{`${url.replace(/\/$/, '')}/`}</InputGroupText>
+      {/* Ensure that the url ends with a slash */}
+      <InputGroupText>{`${url.replace(/\/*$/, '/')}`}</InputGroupText>
     </InputGroupAddon>
     <Input onChange={(evt) => onChange(evt.target.value)} value={slug} />
   </InputGroup>
@@ -69,7 +70,8 @@ const UrlAlias = ({
           {!!onChangePrimary && (
             <Input checked={primary} onChange={onChangePrimary} type="radio" />
           )}
-          {`${url.replace(/\/$/, '')}/${slug}`}
+          {/* Ensure that the url ends with a slash */}
+          {`${url.replace(/\/*$/, '/')}${slug}`}
         </Label>
       </FormGroup>
       {lastPublished && !primary && (

--- a/dc-cudami-editor/src/components/UrlAliases.jsx
+++ b/dc-cudami-editor/src/components/UrlAliases.jsx
@@ -9,6 +9,9 @@ import {
   Button,
   FormGroup,
   Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
   Label,
   ListGroup,
   ListGroupItem,
@@ -38,6 +41,15 @@ const sortByWebsite = (
   }
   return website1.url > website2.url ? 1 : -1
 }
+
+const EditableUrlAlias = ({onChange, slug, url = ''}) => (
+  <InputGroup>
+    <InputGroupAddon addonType="prepend">
+      <InputGroupText>{`${url.replace(/\/$/, '')}/`}</InputGroupText>
+    </InputGroupAddon>
+    <Input onChange={(evt) => onChange(evt.target.value)} value={slug} />
+  </InputGroup>
+)
 
 const UrlAlias = ({
   lastPublished,
@@ -119,5 +131,5 @@ const UrlAliases = ({
   )
 }
 
-export {UrlAlias}
+export {EditableUrlAlias, UrlAlias}
 export default UrlAliases

--- a/dc-cudami-editor/src/components/UrlAliases.jsx
+++ b/dc-cudami-editor/src/components/UrlAliases.jsx
@@ -63,7 +63,7 @@ const UrlAlias = ({
   const uiLocale = i18n.language
   const showRemoveButton = !(lastPublished || !onRemove || primary)
   return (
-    <ListGroupItem className="align-items-center d-flex justify-content-between">
+    <ListGroupItem className="align-items-center d-flex justify-content-between py-2">
       <FormGroup check className={classNames({'pl-0': !onChangePrimary})}>
         <Label check>
           {!!onChangePrimary && (

--- a/dc-cudami-editor/src/components/dialogs/AddUrlAliasesDialog.jsx
+++ b/dc-cudami-editor/src/components/dialogs/AddUrlAliasesDialog.jsx
@@ -208,7 +208,6 @@ const AddUrlAliasesDialog = ({
           <ListGroup>
             <UrlAlias
               primary={newUrlAlias.primary}
-              readOnly={true}
               slug={newUrlAlias.slug}
               url={newUrlAlias.website?.url}
             />

--- a/dc-cudami-editor/src/components/dialogs/ConfirmGeneratatedUrlAliasesDialog.jsx
+++ b/dc-cudami-editor/src/components/dialogs/ConfirmGeneratatedUrlAliasesDialog.jsx
@@ -1,47 +1,73 @@
-import groupBy from 'lodash/groupBy'
+import {useState} from 'react'
 import {useTranslation} from 'react-i18next'
 import {
   Button,
   ButtonGroup,
   FormGroup,
   Label,
+  ListGroup,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
 } from 'reactstrap'
 
-import UrlAliases from '../UrlAliases'
+import {EditableUrlAlias, UrlAlias} from '../UrlAliases'
 
 const ConfirmGeneratatedUrlAliasesDialog = ({
   isOpen,
   generatedUrlAliases = {},
+  onChange,
   onConfirm,
   toggle,
 }) => {
+  const [editable, setEditable] = useState(false)
   const {t} = useTranslation()
   return (
-    <Modal isOpen={isOpen} size="lg" toggle={toggle}>
-      <ModalHeader toggle={toggle}>{t('generatedUrlAliases')}</ModalHeader>
+    <Modal isOpen={isOpen} size="lg">
+      <ModalHeader
+        cssModule={{
+          'modal-title': 'd-flex justify-content-between modal-title w-100',
+        }}
+      >
+        {t('generatedUrlAliases')}
+        {!editable && (
+          <Button color="primary" onClick={() => setEditable(true)} size="xs">
+            {t('edit')}
+          </Button>
+        )}
+      </ModalHeader>
       <ModalBody>
-        {Object.entries(generatedUrlAliases).map(([language, aliases]) => (
+        {Object.entries(generatedUrlAliases).map(([language, [alias]]) => (
           <FormGroup key={language}>
             <Label className="align-middle mb-0">
               {t(`languageNames:${language}`)}
             </Label>
-            <UrlAliases
-              aliasesToRender={groupBy(aliases, 'website.uuid')}
-              readOnly={true}
-              showAll={true}
-            />
+            {editable ? (
+              <EditableUrlAlias
+                onChange={(slug) =>
+                  onChange({
+                    ...generatedUrlAliases,
+                    [language]: [{...alias, slug}],
+                  })
+                }
+                slug={alias.slug}
+                url={alias.website?.url}
+              />
+            ) : (
+              <ListGroup>
+                <UrlAlias
+                  primary={alias.primary}
+                  slug={alias.slug}
+                  url={alias.website?.url}
+                />
+              </ListGroup>
+            )}
           </FormGroup>
         ))}
       </ModalBody>
       <ModalFooter>
         <ButtonGroup>
-          <Button className="mr-1" color="light" onClick={toggle}>
-            {t('no')}
-          </Button>
           <Button
             color="success"
             onClick={() => {

--- a/dc-cudami-editor/src/components/forms/IdentifiableForm.jsx
+++ b/dc-cudami-editor/src/components/forms/IdentifiableForm.jsx
@@ -319,6 +319,11 @@ class IdentifiableForm extends Component {
     const identifiable = {
       ...this.state.identifiable,
       description: this.cleanUpJson(this.state.identifiable.description),
+      localizedUrlAliases: mergeWith(
+        this.state.identifiable.localizedUrlAliases,
+        this.state.generatedUrlAliases ?? {},
+        (objValue, srcValue) => (objValue ?? []).concat(srcValue),
+      ),
     }
     if (identifiable.text) {
       identifiable.text = this.cleanUpJson(this.state.identifiable.text)
@@ -369,23 +374,14 @@ class IdentifiableForm extends Component {
   }
 
   validateUrlAliases = async () => {
-    const {dialogsOpen, identifiable} = this.state
     const generatedUrlAliases = await this.getGeneratedUrlAliases()
     if (Object.keys(generatedUrlAliases).length > 0) {
       return this.setState({
         dialogsOpen: {
-          ...dialogsOpen,
+          ...this.state.dialogsOpen,
           confirmGeneratatedUrlAliases: true,
         },
         generatedUrlAliases,
-        identifiable: {
-          ...identifiable,
-          localizedUrlAliases: mergeWith(
-            identifiable.localizedUrlAliases,
-            generatedUrlAliases,
-            (objValue, srcValue) => (objValue ?? []).concat(srcValue),
-          ),
-        },
       })
     }
     this.submitIdentifiable()
@@ -487,6 +483,9 @@ class IdentifiableForm extends Component {
           <ConfirmGeneratatedUrlAliasesDialog
             generatedUrlAliases={generatedUrlAliases}
             isOpen={dialogsOpen.confirmGeneratatedUrlAliases}
+            onChange={(generatedUrlAliases) =>
+              this.setState({generatedUrlAliases})
+            }
             onConfirm={this.submitIdentifiable}
             toggle={() => this.toggleDialog('confirmGeneratatedUrlAliases')}
           />

--- a/dc-cudami-editor/src/locales/de/translation.json
+++ b/dc-cudami-editor/src/locales/de/translation.json
@@ -138,7 +138,7 @@
     "defineRenderingHints": "Darstellungshinweise festlegen",
     "description": "Kurzbeschreibung",
     "dragAndDropImage": "Datei zum Hochladen hier hereinziehen und ablegen",
-    "edit": "bearbeiten",
+    "edit": "Bearbeiten",
     "editArticle": "Artikel bearbeiten",
     "editCollection": "Sammlung bearbeiten",
     "editCorporateBody": "Institution bearbeiten",

--- a/dc-cudami-editor/src/locales/en/translation.json
+++ b/dc-cudami-editor/src/locales/en/translation.json
@@ -138,7 +138,7 @@
     "defineRenderingHints": "Define rendering hints",
     "description": "Abstract",
     "dragAndDropImage": "Drag and drop file to upload here",
-    "edit": "edit",
+    "edit": "Edit",
     "editArticle": "Edit article",
     "editCollection": "Edit collection",
     "editCorporateBody": "Edit corporate body",


### PR DESCRIPTION
This PR fixes the logic to handle generated urlaliases:
- it's not possible anymore to close the dialog to confirm them by clicking on `no` or outside the dialog
- the dialog to confirm them has no `x` anymore to close it
- every entry in the dialog can now be edited before confirmation