### PR TITLE
Align UrlAlias to changed labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ node_modules
 /dc-cudami-editor/nbproject/project.properties
 /dc-cudami-editor/bin
 **/nbproject/
-application-*.yaml
+application-local.yaml
+application-local.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ node_modules
 /dc-cudami-editor/nbproject/project.properties
 /dc-cudami-editor/bin
 **/nbproject/
+application-*.yaml
+

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
@@ -43,21 +43,46 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
       CudamiConfig cudamiConfig,
       SlugGeneratorService slugGeneratorService)
       throws CudamiServiceException {
+
+    if (actualIdentifiable == null
+        || identifiableInDatabase == null
+        || cudamiConfig == null
+        || slugGeneratorService == null) {
+      throw new CudamiServiceException(
+          "Missing argument. Every parameter must be passed (not null).");
+    }
+
     IdentifiableUrlAliasAlignHelper<I> inst =
         new IdentifiableUrlAliasAlignHelper<>(
             actualIdentifiable, identifiableInDatabase, cudamiConfig, slugGeneratorService);
-    inst.fixMissingLocalizedUrlAliases();
-    inst.alignLabelUpdate();
-    inst.ensureDefaultAliasesExist();
+    try {
+      inst.fixMissingLocalizedUrlAliases();
+      inst.alignLabelUpdate();
+      inst.ensureDefaultAliasesExist();
+    } catch (RuntimeException e) {
+      throw new CudamiServiceException(
+          "Uncaught error in IdentifiableUrlAliasAlignHelper::alignForUpdate.", e);
+    }
   }
 
   public static <I extends Identifiable> void checkDefaultAliases(
       I actualIdentifiable, CudamiConfig cudamiConfig, SlugGeneratorService slugGeneratorService)
       throws CudamiServiceException {
+
+    if (actualIdentifiable == null || cudamiConfig == null || slugGeneratorService == null) {
+      throw new CudamiServiceException(
+          "Missing argument. Every parameter must be passed (not null).");
+    }
+
     IdentifiableUrlAliasAlignHelper<I> inst =
         new IdentifiableUrlAliasAlignHelper<>(
             actualIdentifiable, null, cudamiConfig, slugGeneratorService);
-    inst.ensureDefaultAliasesExist();
+    try {
+      inst.ensureDefaultAliasesExist();
+    } catch (RuntimeException e) {
+      throw new CudamiServiceException(
+          "Uncaught error in IdentifiableUrlAliasAlignHelper::checkDefaultAliases.", e);
+    }
   }
 
   private void alignLabelUpdate() throws CudamiServiceException {
@@ -166,7 +191,8 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
       }
 
       // check that a primary alias exists for this language, even for webpages
-      if (!urlAliases.get(lang).stream().anyMatch(alias -> alias.isPrimary())) {
+      if (urlAliases.get(lang) == null
+          || !urlAliases.get(lang).stream().anyMatch(alias -> alias.isPrimary())) {
         throw new CudamiServiceException(
             String.format(
                 "There is not any primary alias for language '%s' of identifiable '%s'.",

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
@@ -1,0 +1,246 @@
+package de.digitalcollections.cudami.server.business.impl.service.identifiable;
+
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
+import de.digitalcollections.model.identifiable.Identifiable;
+import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
+import de.digitalcollections.model.identifiable.alias.UrlAlias;
+import de.digitalcollections.model.identifiable.entity.Entity;
+import de.digitalcollections.model.identifiable.entity.Website;
+import de.digitalcollections.model.identifiable.web.Webpage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
+
+  private CudamiConfig cudamiConfig;
+  private SlugGeneratorService slugGeneratorService;
+
+  // the old one that is already in database
+  private I identifiableInDatabase;
+  // the one that should be saved later
+  private I actualIdentifiable;
+
+  private IdentifiableUrlAliasAlignHelper(
+      I actualIdentifiable,
+      I identifiableInDatabase,
+      CudamiConfig cudamiConfig,
+      SlugGeneratorService slugGeneratorService) {
+    this.actualIdentifiable = actualIdentifiable;
+    this.identifiableInDatabase = identifiableInDatabase;
+    this.cudamiConfig = cudamiConfig;
+    this.slugGeneratorService = slugGeneratorService;
+  }
+
+  public static <I extends Identifiable> void alignForUpdate(
+      I actualIdentifiable,
+      I identifiableInDatabase,
+      CudamiConfig cudamiConfig,
+      SlugGeneratorService slugGeneratorService)
+      throws CudamiServiceException {
+    IdentifiableUrlAliasAlignHelper<I> inst =
+        new IdentifiableUrlAliasAlignHelper<>(
+            actualIdentifiable, identifiableInDatabase, cudamiConfig, slugGeneratorService);
+    inst.fixMissingLocalizedUrlAliases();
+    inst.alignLabelUpdate();
+    inst.ensureDefaultAliasesExist();
+  }
+
+  public static <I extends Identifiable> void checkDefaultAliases(
+      I actualIdentifiable, CudamiConfig cudamiConfig, SlugGeneratorService slugGeneratorService)
+      throws CudamiServiceException {
+    IdentifiableUrlAliasAlignHelper<I> inst =
+        new IdentifiableUrlAliasAlignHelper<>(
+            actualIdentifiable, null, cudamiConfig, slugGeneratorService);
+    inst.ensureDefaultAliasesExist();
+  }
+
+  private void alignLabelUpdate() throws CudamiServiceException {
+    if (actualIdentifiable == null
+        || (actualIdentifiable instanceof Entity)
+            && cudamiConfig
+                .getUrlAlias()
+                .getGenerationExcludes()
+                .contains(((Entity) actualIdentifiable).getEntityType())
+        || actualIdentifiable.getLabel() == null) {
+      return;
+    }
+    if (identifiableInDatabase == null) {
+      return;
+    }
+    List<UrlAlias> newAliases = new ArrayList<>();
+    for (Locale langFromDb : identifiableInDatabase.getLabel().getLocales()) {
+      // check all in db EXISTING label languages; we are into label changes ONLY
+      String labelSavedInDb = identifiableInDatabase.getLabel().get(langFromDb);
+      String labelInIdentifiable = actualIdentifiable.getLabel().get(langFromDb);
+      if (Objects.equals(labelSavedInDb, labelInIdentifiable) || labelInIdentifiable == null) {
+        continue;
+      }
+      // if we get any NPE here then a former safe or update operation went wrong already; should
+      // never happen
+      List<UrlAlias> primariesFromDb =
+          getPrimaryUrlAliases(identifiableInDatabase.getLocalizedUrlAliases(), langFromDb);
+      if (actualIdentifiable.getLocalizedUrlAliases() == null) {
+        actualIdentifiable.setLocalizedUrlAliases(new LocalizedUrlAliases());
+      }
+      for (UrlAlias primaryFromDb : primariesFromDb) {
+        final UUID websiteUuid =
+            primaryFromDb.getWebsite() != null ? primaryFromDb.getWebsite().getUuid() : null;
+        String newSlug = slugGeneratorService.apply(langFromDb, labelInIdentifiable, websiteUuid);
+        // if this slug already exists in the identifiable then we must silently go on, otherwise we
+        // will add it
+        if (actualIdentifiable.getLocalizedUrlAliases().flatten().stream()
+            .anyMatch(
+                ua ->
+                    Objects.equals(ua.getSlug(), newSlug)
+                        && Objects.equals(ua.getTargetLanguage(), langFromDb)
+                        && Objects.equals(
+                            ua.getWebsite() != null ? ua.getWebsite().getUuid() : null,
+                            websiteUuid))) {
+          continue;
+        }
+        UrlAlias newAlias = new UrlAlias();
+        newAlias.setSlug(newSlug);
+        newAlias.setTargetIdentifiableType(actualIdentifiable.getType());
+        newAlias.setTargetLanguage(langFromDb);
+        newAlias.setTargetUuid(actualIdentifiable.getUuid());
+        if (actualIdentifiable instanceof Entity) {
+          newAlias.setTargetEntityType(((Entity) actualIdentifiable).getEntityType());
+        }
+        if (websiteUuid != null) {
+          Website ws = new Website();
+          ws.setUuid(websiteUuid);
+          newAlias.setWebsite(ws);
+        }
+        newAlias.setPrimary(true);
+
+        actualIdentifiable.getLocalizedUrlAliases().add(newAlias);
+        newAliases.add(newAlias);
+      }
+    }
+
+    // finally we set primary flag of current primary aliases to false
+    unsetConflictingPrimaries(
+        getPrimaryUrlAliases(identifiableInDatabase.getLocalizedUrlAliases(), null), newAliases);
+  }
+
+  private void ensureDefaultAliasesExist() throws CudamiServiceException {
+    if ((actualIdentifiable instanceof Entity)
+        && cudamiConfig
+            .getUrlAlias()
+            .getGenerationExcludes()
+            .contains(((Entity) actualIdentifiable).getEntityType())) {
+      return;
+    }
+    LocalizedUrlAliases urlAliases = actualIdentifiable.getLocalizedUrlAliases();
+    if (urlAliases == null) {
+      urlAliases = new LocalizedUrlAliases();
+      actualIdentifiable.setLocalizedUrlAliases(urlAliases);
+    }
+    for (Locale lang : actualIdentifiable.getLabel().getLocales()) {
+      // not for webpages
+      if (!(actualIdentifiable instanceof Webpage)
+          && (!urlAliases.containsKey(lang)
+              || urlAliases.get(lang).stream().allMatch(alias -> alias.getWebsite() != null))) {
+        // there is not any default alias (w/o website); create one.
+        UrlAlias defaultAlias = new UrlAlias();
+        defaultAlias.setTargetIdentifiableType(actualIdentifiable.getType());
+        defaultAlias.setTargetLanguage(lang);
+        defaultAlias.setTargetUuid(actualIdentifiable.getUuid());
+        if (actualIdentifiable instanceof Entity) {
+          defaultAlias.setTargetEntityType(((Entity) actualIdentifiable).getEntityType());
+        }
+        defaultAlias.setPrimary(!urlAliases.containsKey(lang));
+        try {
+          defaultAlias.setSlug(
+              slugGeneratorService.apply(lang, actualIdentifiable.getLabel().getText(lang), null));
+        } catch (CudamiServiceException e) {
+          throw new CudamiServiceException("An error occured during slug generation.", e);
+        }
+        urlAliases.add(defaultAlias);
+      }
+
+      // check that a primary alias exists for this language, even for webpages
+      if (!urlAliases.get(lang).stream().anyMatch(alias -> alias.isPrimary())) {
+        throw new CudamiServiceException(
+            String.format(
+                "There is not any primary alias for language '%s' of identifiable '%s'.",
+                lang, actualIdentifiable.getUuid()));
+      }
+    }
+  }
+
+  private void fixMissingLocalizedUrlAliases() {
+    if (actualIdentifiable.getLocalizedUrlAliases() == null
+        || actualIdentifiable.getLocalizedUrlAliases().isEmpty()) {
+      // if this field is unset then we check the DB
+      LocalizedUrlAliases aliasesFromDb = identifiableInDatabase.getLocalizedUrlAliases();
+      actualIdentifiable.setLocalizedUrlAliases(aliasesFromDb);
+    } else if (actualIdentifiable.getLocalizedUrlAliases().flatten().stream()
+        .allMatch(ua -> ua.isPrimary())) {
+      // there are only primary aliases: conflicting ones in DB must be unset
+      // conflicting aliases: equal websiteUuid & targetLanguage
+      LocalizedUrlAliases urlAliasesToUpdate = actualIdentifiable.getLocalizedUrlAliases();
+      // only primary aliases (as the var name suggests)
+      List<UrlAlias> allPrimariesFromDb =
+          getPrimaryUrlAliases(identifiableInDatabase.getLocalizedUrlAliases(), null);
+      // now we check whether any primary from the DB conflict with the new ones
+      unsetConflictingPrimaries(allPrimariesFromDb, urlAliasesToUpdate.flatten());
+    }
+  }
+
+  private List<UrlAlias> getPrimaryUrlAliases(
+      LocalizedUrlAliases localizedUrlAliases, Locale lang) {
+    if (localizedUrlAliases == null) {
+      return new ArrayList<>();
+    }
+    return localizedUrlAliases.flatten().stream()
+        .filter(ua -> ua.isPrimary() && (lang != null ? ua.getTargetLanguage().equals(lang) : true))
+        .collect(Collectors.toList());
+  }
+
+  private void unsetConflictingPrimaries(
+      List<UrlAlias> primariesFromDb, List<UrlAlias> newPrimaryAliases) {
+    for (UrlAlias primaryFromDb : primariesFromDb) {
+      if (newPrimaryAliases.stream()
+          .filter(ua -> !ua.equals(primaryFromDb)) // if new one is equal to alias from DB -> ignore
+          .anyMatch(
+              ua ->
+                  (ua.getWebsite() != null
+                              && primaryFromDb.getWebsite() != null
+                              && ua.getWebsite()
+                                  .getUuid()
+                                  .equals(primaryFromDb.getWebsite().getUuid())
+                          || ua.getWebsite() == primaryFromDb.getWebsite())
+                      && Objects.equals(
+                          ua.getTargetLanguage(), primaryFromDb.getTargetLanguage()))) {
+        // UrlAlias in the database conflicts with a new created one
+        // so we set primary flag of the old one to false
+        primaryFromDb.setPrimary(false);
+      }
+      // must be outside preceding `if` to avoid creation of new aliases in
+      // `ensureDefaultAliasesExist`
+      // either set primary of the alias in the identifiable or add the primary from database to
+      // complete
+      // tha aliases of the identifiable
+      Optional<UrlAlias> oldPrimary =
+          actualIdentifiable.getLocalizedUrlAliases().flatten().stream()
+              .filter(ua -> Objects.equals(ua.getUuid(), primaryFromDb.getUuid()))
+              .findFirst();
+      if (oldPrimary.isPresent()) {
+        oldPrimary.get().setPrimary(primaryFromDb.isPrimary());
+      } else {
+        actualIdentifiable.getLocalizedUrlAliases().add(primaryFromDb);
+      }
+    }
+  }
+
+  public interface SlugGeneratorService {
+    String apply(Locale locale, String label, UUID website) throws CudamiServiceException;
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
@@ -276,7 +276,7 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
       // `ensureDefaultAliasesExist`
       // either set primary of the alias in the identifiable or add the primary from database to
       // complete
-      // tha aliases of the identifiable
+      // the aliases of the identifiable
       Optional<UrlAlias> oldPrimary =
           actualIdentifiable.getLocalizedUrlAliases().flatten().stream()
               .filter(ua -> Objects.equals(ua.getUuid(), primaryFromDb.getUuid()))

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
@@ -37,6 +37,16 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
     this.slugGeneratorService = slugGeneratorService;
   }
 
+  /**
+   * Align all UrlAliases to fit in with the updating/updated identifiable. It is also ensured that
+   * default aliases exist and missing ones are created.
+   *
+   * @param actualIdentifiable the object that is/was updated
+   * @param identifiableInDatabase the existing object saved in storage prior to any update
+   * @param cudamiConfig
+   * @param slugGeneratorService slug generator method
+   * @throws CudamiServiceException
+   */
   public static <I extends Identifiable> void alignForUpdate(
       I actualIdentifiable,
       I identifiableInDatabase,
@@ -65,6 +75,16 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
     }
   }
 
+  /**
+   * Ensure that default aliases exist (new ones can be created). For an update of an existing
+   * identifiable {@link #alignForUpdate(Identifiable, Identifiable, CudamiConfig,
+   * SlugGeneratorService)} should be used instead.
+   *
+   * @param actualIdentifiable the (new) identifiable
+   * @param cudamiConfig
+   * @param slugGeneratorService slug generator method
+   * @throws CudamiServiceException
+   */
   public static <I extends Identifiable> void checkDefaultAliases(
       I actualIdentifiable, CudamiConfig cudamiConfig, SlugGeneratorService slugGeneratorService)
       throws CudamiServiceException {
@@ -232,6 +252,9 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
 
   private void unsetConflictingPrimaries(
       List<UrlAlias> primariesFromDb, List<UrlAlias> newPrimaryAliases) {
+    if (primariesFromDb == null || newPrimaryAliases == null) {
+      return;
+    }
     for (UrlAlias primaryFromDb : primariesFromDb) {
       if (newPrimaryAliases.stream()
           .filter(ua -> !ua.equals(primaryFromDb)) // if new one is equal to alias from DB -> ignore
@@ -266,6 +289,8 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
     }
   }
 
+  // We do not want to have any services in this class but we need the slug generator.
+  // It can easyly be passed into a parameter of this functional interface type.
   public interface SlugGeneratorService {
     String apply(Locale locale, String label, UUID website) throws CudamiServiceException;
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
@@ -21,11 +21,8 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.ali
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
 import de.digitalcollections.model.identifiable.alias.UrlAlias;
-import de.digitalcollections.model.identifiable.entity.DigitalObject;
-import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.entity.EntityType;
 import de.digitalcollections.model.identifiable.entity.Website;
-import de.digitalcollections.model.identifiable.web.Webpage;
 import de.digitalcollections.model.text.LocalizedText;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -105,143 +102,144 @@ class IdentifiableServiceImplTest {
         });
   }
 
-  @DisplayName("does not guarantee URLAliases for some entity types")
-  @Test
-  public void noUrlAliasesForSomeEntityTypes() throws IdentifiableServiceException {
-    DigitalObject identifiable = new DigitalObject();
-    identifiable.setLabel("label");
-    service.ensureDefaultAliasesExist(identifiable);
-    assertThat(identifiable.getLocalizedUrlAliases()).isNull();
-  }
+  //  @DisplayName("does not guarantee URLAliases for some entity types")
+  //  @Test
+  //  public void noUrlAliasesForSomeEntityTypes() throws IdentifiableServiceException {
+  //    DigitalObject identifiable = new DigitalObject();
+  //    identifiable.setLabel("label");
+  //    service.ensureDefaultAliasesExist(identifiable);
+  //    assertThat(identifiable.getLocalizedUrlAliases()).isNull();
+  //  }
+  //
+  //  @DisplayName("can create an LocalizedUrlAlias, when it's missing")
+  //  @Test
+  //  public void createLocalizedUrlAliasWhenMissing() throws IdentifiableServiceException {
+  //    Identifiable identifiable = new Identifiable();
+  //    identifiable.setLabel("label");
+  //    service.ensureDefaultAliasesExist(identifiable);
+  //    assertThat(identifiable.getLocalizedUrlAliases()).isNotNull();
+  //  }
+  //
+  //  @DisplayName("sets all required attribute of a created default UrlAlias")
+  //  @Test
+  //  public void fillsAttributeOnCreatedDefaultUrlAlias()
+  //      throws IdentifiableServiceException, CudamiServiceException {
+  //    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
+  //        .thenReturn("hallo-welt");
+  //
+  //    UUID expectedTargetUuid = UUID.randomUUID();
+  //
+  //    Entity entity = new Entity();
+  //    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
+  //    entity.setUuid(expectedTargetUuid);
+  //    service.ensureDefaultAliasesExist(entity);
+  //
+  //    UrlAlias actual = entity.getLocalizedUrlAliases().flatten().get(0);
+  //    assertThat(actual.getLastPublished()).isNull(); // is set by the repository
+  //    assertThat(actual.isPrimary()).isTrue();
+  //    assertThat(actual.getCreated()).isNull(); // is set by the repository
+  //    assertThat(actual.getTargetUuid()).isEqualTo(expectedTargetUuid);
+  //    assertThat(actual.getTargetIdentifiableType()).isEqualTo(entity.getType());
+  //    assertThat(actual.getTargetEntityType()).isEqualTo(entity.getEntityType());
+  //    assertThat(actual.getWebsite()).isNull(); // no default website given
+  //    assertThat(actual.getSlug()).isEqualTo("hallo-welt");
+  //    assertThat(actual.getTargetLanguage()).isEqualTo(Locale.GERMAN);
+  //  }
+  //
+  //  @DisplayName("does not create a default UrlAliases for a webpage")
+  //  @Test
+  //  public void noDefaultUrlAliasCreationForWebpage()
+  //      throws CudamiServiceException, IdentifiableServiceException {
+  //    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
+  //        .thenReturn("hallo-welt");
+  //    UUID expectedTargetUuid = UUID.randomUUID();
+  //
+  //    Identifiable identifiable = new Webpage();
+  //    identifiable.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
+  //    identifiable.setUuid(expectedTargetUuid);
+  //
+  //    service.ensureDefaultAliasesExist(identifiable);
+  //
+  //    assertThat(identifiable.getLocalizedUrlAliases().isEmpty());
+  //  }
 
-  @DisplayName("can create an LocalizedUrlAlias, when it's missing")
-  @Test
-  public void createLocalizedUrlAliasWhenMissing() throws IdentifiableServiceException {
-    Identifiable identifiable = new Identifiable();
-    identifiable.setLabel("label");
-    service.ensureDefaultAliasesExist(identifiable);
-    assertThat(identifiable.getLocalizedUrlAliases()).isNotNull();
-  }
-
-  @DisplayName("sets all required attribute of a created default UrlAlias")
-  @Test
-  public void fillsAttributeOnCreatedDefaultUrlAlias()
-      throws IdentifiableServiceException, CudamiServiceException {
-    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
-        .thenReturn("hallo-welt");
-
-    UUID expectedTargetUuid = UUID.randomUUID();
-
-    Entity entity = new Entity();
-    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
-    entity.setUuid(expectedTargetUuid);
-    service.ensureDefaultAliasesExist(entity);
-
-    UrlAlias actual = entity.getLocalizedUrlAliases().flatten().get(0);
-    assertThat(actual.getLastPublished()).isNull(); // is set by the repository
-    assertThat(actual.isPrimary()).isTrue();
-    assertThat(actual.getCreated()).isNull(); // is set by the repository
-    assertThat(actual.getTargetUuid()).isEqualTo(expectedTargetUuid);
-    assertThat(actual.getTargetIdentifiableType()).isEqualTo(entity.getType());
-    assertThat(actual.getTargetEntityType()).isEqualTo(entity.getEntityType());
-    assertThat(actual.getWebsite()).isNull(); // no default website given
-    assertThat(actual.getSlug()).isEqualTo("hallo-welt");
-    assertThat(actual.getTargetLanguage()).isEqualTo(Locale.GERMAN);
-  }
-
-  @DisplayName("does not create a default UrlAliases for a webpage")
-  @Test
-  public void noDefaultUrlAliasCreationForWebpage()
-      throws CudamiServiceException, IdentifiableServiceException {
-    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
-        .thenReturn("hallo-welt");
-    UUID expectedTargetUuid = UUID.randomUUID();
-
-    Identifiable identifiable = new Webpage();
-    identifiable.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
-    identifiable.setUuid(expectedTargetUuid);
-
-    service.ensureDefaultAliasesExist(identifiable);
-
-    assertThat(identifiable.getLocalizedUrlAliases().isEmpty());
-  }
-
-  @DisplayName("adds an url alias for a certain language, when it's missing")
-  @Test
-  public void addUrlAliasWhenMissingInLanguage()
-      throws CudamiServiceException, IdentifiableServiceException {
-    when(urlAliasService.generateSlug(eq(Locale.GERMAN), any(String.class), eq(null)))
-        .thenReturn("hallo-welt");
-    when(urlAliasService.generateSlug(eq(Locale.ENGLISH), any(String.class), eq(null)))
-        .thenReturn("hello-world");
-
-    UUID expectedTargetUuid = UUID.randomUUID();
-
-    Entity entity = new Entity();
-    final LocalizedText label = new LocalizedText(Locale.GERMAN, "Hallo Welt");
-    label.setText(Locale.ENGLISH, "hello world");
-    entity.setLabel(label);
-    entity.setUuid(expectedTargetUuid);
-
-    // Let's assume, we only have localized aliases for the german label yet
-    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases();
-    UrlAlias germanUrlAlias = new UrlAlias();
-    germanUrlAlias.setPrimary(true);
-    germanUrlAlias.setSlug("hallo-welt");
-    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
-    germanUrlAlias.setTargetUuid(expectedTargetUuid);
-    localizedUrlALiases.add(germanUrlAlias);
-    entity.setLocalizedUrlAliases(localizedUrlALiases);
-
-    service.ensureDefaultAliasesExist(entity);
-
-    assertThat(localizedUrlALiases.flatten()).hasSize(2); // german and english
-    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.GERMAN)).isTrue();
-    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.ENGLISH)).isTrue();
-
-    assertThat(localizedUrlALiases.get(Locale.ENGLISH).get(0).getSlug()).isEqualTo("hello-world");
-  }
-
-  @DisplayName("throws an exception, when primary UrlAliases are missing")
-  @Test
-  public void missingPrimaryUrlAliases() {
-    UUID expectedTargetUuid = UUID.randomUUID();
-
-    Entity entity = new Entity();
-    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
-    entity.setUuid(expectedTargetUuid);
-
-    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases();
-    UrlAlias germanUrlAlias = new UrlAlias();
-    germanUrlAlias.setPrimary(false);
-    germanUrlAlias.setSlug("hallo-welt");
-    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
-    germanUrlAlias.setTargetUuid(expectedTargetUuid);
-    localizedUrlALiases.add(germanUrlAlias);
-    entity.setLocalizedUrlAliases(localizedUrlALiases);
-
-    assertThrows(
-        IdentifiableServiceException.class,
-        () -> {
-          service.ensureDefaultAliasesExist(entity);
-        });
-  }
-
-  @DisplayName("throws an Exception, when slug generation fails")
-  @Test
-  public void failingSlugGeneration() throws CudamiServiceException {
-    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
-        .thenThrow(new CudamiServiceException("boo"));
-
-    Identifiable identifiable = new Identifiable();
-    identifiable.setLabel("label");
-
-    assertThrows(
-        IdentifiableServiceException.class,
-        () -> {
-          service.ensureDefaultAliasesExist(identifiable);
-        });
-  }
+  //  @DisplayName("adds an url alias for a certain language, when it's missing")
+  //  @Test
+  //  public void addUrlAliasWhenMissingInLanguage()
+  //      throws CudamiServiceException, IdentifiableServiceException {
+  //    when(urlAliasService.generateSlug(eq(Locale.GERMAN), any(String.class), eq(null)))
+  //        .thenReturn("hallo-welt");
+  //    when(urlAliasService.generateSlug(eq(Locale.ENGLISH), any(String.class), eq(null)))
+  //        .thenReturn("hello-world");
+  //
+  //    UUID expectedTargetUuid = UUID.randomUUID();
+  //
+  //    Entity entity = new Entity();
+  //    final LocalizedText label = new LocalizedText(Locale.GERMAN, "Hallo Welt");
+  //    label.setText(Locale.ENGLISH, "hello world");
+  //    entity.setLabel(label);
+  //    entity.setUuid(expectedTargetUuid);
+  //
+  //    // Let's assume, we only have localized aliases for the german label yet
+  //    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases();
+  //    UrlAlias germanUrlAlias = new UrlAlias();
+  //    germanUrlAlias.setPrimary(true);
+  //    germanUrlAlias.setSlug("hallo-welt");
+  //    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
+  //    germanUrlAlias.setTargetUuid(expectedTargetUuid);
+  //    localizedUrlALiases.add(germanUrlAlias);
+  //    entity.setLocalizedUrlAliases(localizedUrlALiases);
+  //
+  //    service.ensureDefaultAliasesExist(entity);
+  //
+  //    assertThat(localizedUrlALiases.flatten()).hasSize(2); // german and english
+  //    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.GERMAN)).isTrue();
+  //    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.ENGLISH)).isTrue();
+  //
+  //
+  // assertThat(localizedUrlALiases.get(Locale.ENGLISH).get(0).getSlug()).isEqualTo("hello-world");
+  //  }
+  //
+  //  @DisplayName("throws an exception, when primary UrlAliases are missing")
+  //  @Test
+  //  public void missingPrimaryUrlAliases() {
+  //    UUID expectedTargetUuid = UUID.randomUUID();
+  //
+  //    Entity entity = new Entity();
+  //    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
+  //    entity.setUuid(expectedTargetUuid);
+  //
+  //    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases();
+  //    UrlAlias germanUrlAlias = new UrlAlias();
+  //    germanUrlAlias.setPrimary(false);
+  //    germanUrlAlias.setSlug("hallo-welt");
+  //    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
+  //    germanUrlAlias.setTargetUuid(expectedTargetUuid);
+  //    localizedUrlALiases.add(germanUrlAlias);
+  //    entity.setLocalizedUrlAliases(localizedUrlALiases);
+  //
+  //    assertThrows(
+  //        IdentifiableServiceException.class,
+  //        () -> {
+  //          service.ensureDefaultAliasesExist(entity);
+  //        });
+  //  }
+  //
+  //  @DisplayName("throws an Exception, when slug generation fails")
+  //  @Test
+  //  public void failingSlugGeneration() throws CudamiServiceException {
+  //    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
+  //        .thenThrow(new CudamiServiceException("boo"));
+  //
+  //    Identifiable identifiable = new Identifiable();
+  //    identifiable.setLabel("label");
+  //
+  //    assertThrows(
+  //        IdentifiableServiceException.class,
+  //        () -> {
+  //          service.ensureDefaultAliasesExist(identifiable);
+  //        });
+  //  }
 
   @DisplayName("throws an Exception to trigger a rollback on save, when saving in the repo fails")
   @Test

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
@@ -42,9 +42,10 @@ class IdentifiableServiceImplTest {
   private IdentifierRepository identifierRepository;
 
   @BeforeEach
-  public void beforeEach() {
+  public void beforeEach() throws CudamiServiceException {
     repo = mock(IdentifiableRepository.class);
     urlAliasService = mock(UrlAliasService.class);
+    when(urlAliasService.generateSlug(any(), eq("label"), eq(null))).thenReturn("label");
     identifierRepository = mock(IdentifierRepository.class);
     CudamiConfig cudamiConfig = new CudamiConfig();
     CudamiConfig.UrlAlias urlAliasConfig = new CudamiConfig.UrlAlias();
@@ -101,145 +102,6 @@ class IdentifiableServiceImplTest {
           service.delete(List.of(UUID.randomUUID()));
         });
   }
-
-  //  @DisplayName("does not guarantee URLAliases for some entity types")
-  //  @Test
-  //  public void noUrlAliasesForSomeEntityTypes() throws IdentifiableServiceException {
-  //    DigitalObject identifiable = new DigitalObject();
-  //    identifiable.setLabel("label");
-  //    service.ensureDefaultAliasesExist(identifiable);
-  //    assertThat(identifiable.getLocalizedUrlAliases()).isNull();
-  //  }
-  //
-  //  @DisplayName("can create an LocalizedUrlAlias, when it's missing")
-  //  @Test
-  //  public void createLocalizedUrlAliasWhenMissing() throws IdentifiableServiceException {
-  //    Identifiable identifiable = new Identifiable();
-  //    identifiable.setLabel("label");
-  //    service.ensureDefaultAliasesExist(identifiable);
-  //    assertThat(identifiable.getLocalizedUrlAliases()).isNotNull();
-  //  }
-  //
-  //  @DisplayName("sets all required attribute of a created default UrlAlias")
-  //  @Test
-  //  public void fillsAttributeOnCreatedDefaultUrlAlias()
-  //      throws IdentifiableServiceException, CudamiServiceException {
-  //    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
-  //        .thenReturn("hallo-welt");
-  //
-  //    UUID expectedTargetUuid = UUID.randomUUID();
-  //
-  //    Entity entity = new Entity();
-  //    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
-  //    entity.setUuid(expectedTargetUuid);
-  //    service.ensureDefaultAliasesExist(entity);
-  //
-  //    UrlAlias actual = entity.getLocalizedUrlAliases().flatten().get(0);
-  //    assertThat(actual.getLastPublished()).isNull(); // is set by the repository
-  //    assertThat(actual.isPrimary()).isTrue();
-  //    assertThat(actual.getCreated()).isNull(); // is set by the repository
-  //    assertThat(actual.getTargetUuid()).isEqualTo(expectedTargetUuid);
-  //    assertThat(actual.getTargetIdentifiableType()).isEqualTo(entity.getType());
-  //    assertThat(actual.getTargetEntityType()).isEqualTo(entity.getEntityType());
-  //    assertThat(actual.getWebsite()).isNull(); // no default website given
-  //    assertThat(actual.getSlug()).isEqualTo("hallo-welt");
-  //    assertThat(actual.getTargetLanguage()).isEqualTo(Locale.GERMAN);
-  //  }
-  //
-  //  @DisplayName("does not create a default UrlAliases for a webpage")
-  //  @Test
-  //  public void noDefaultUrlAliasCreationForWebpage()
-  //      throws CudamiServiceException, IdentifiableServiceException {
-  //    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
-  //        .thenReturn("hallo-welt");
-  //    UUID expectedTargetUuid = UUID.randomUUID();
-  //
-  //    Identifiable identifiable = new Webpage();
-  //    identifiable.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
-  //    identifiable.setUuid(expectedTargetUuid);
-  //
-  //    service.ensureDefaultAliasesExist(identifiable);
-  //
-  //    assertThat(identifiable.getLocalizedUrlAliases().isEmpty());
-  //  }
-
-  //  @DisplayName("adds an url alias for a certain language, when it's missing")
-  //  @Test
-  //  public void addUrlAliasWhenMissingInLanguage()
-  //      throws CudamiServiceException, IdentifiableServiceException {
-  //    when(urlAliasService.generateSlug(eq(Locale.GERMAN), any(String.class), eq(null)))
-  //        .thenReturn("hallo-welt");
-  //    when(urlAliasService.generateSlug(eq(Locale.ENGLISH), any(String.class), eq(null)))
-  //        .thenReturn("hello-world");
-  //
-  //    UUID expectedTargetUuid = UUID.randomUUID();
-  //
-  //    Entity entity = new Entity();
-  //    final LocalizedText label = new LocalizedText(Locale.GERMAN, "Hallo Welt");
-  //    label.setText(Locale.ENGLISH, "hello world");
-  //    entity.setLabel(label);
-  //    entity.setUuid(expectedTargetUuid);
-  //
-  //    // Let's assume, we only have localized aliases for the german label yet
-  //    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases();
-  //    UrlAlias germanUrlAlias = new UrlAlias();
-  //    germanUrlAlias.setPrimary(true);
-  //    germanUrlAlias.setSlug("hallo-welt");
-  //    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
-  //    germanUrlAlias.setTargetUuid(expectedTargetUuid);
-  //    localizedUrlALiases.add(germanUrlAlias);
-  //    entity.setLocalizedUrlAliases(localizedUrlALiases);
-  //
-  //    service.ensureDefaultAliasesExist(entity);
-  //
-  //    assertThat(localizedUrlALiases.flatten()).hasSize(2); // german and english
-  //    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.GERMAN)).isTrue();
-  //    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.ENGLISH)).isTrue();
-  //
-  //
-  // assertThat(localizedUrlALiases.get(Locale.ENGLISH).get(0).getSlug()).isEqualTo("hello-world");
-  //  }
-  //
-  //  @DisplayName("throws an exception, when primary UrlAliases are missing")
-  //  @Test
-  //  public void missingPrimaryUrlAliases() {
-  //    UUID expectedTargetUuid = UUID.randomUUID();
-  //
-  //    Entity entity = new Entity();
-  //    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
-  //    entity.setUuid(expectedTargetUuid);
-  //
-  //    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases();
-  //    UrlAlias germanUrlAlias = new UrlAlias();
-  //    germanUrlAlias.setPrimary(false);
-  //    germanUrlAlias.setSlug("hallo-welt");
-  //    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
-  //    germanUrlAlias.setTargetUuid(expectedTargetUuid);
-  //    localizedUrlALiases.add(germanUrlAlias);
-  //    entity.setLocalizedUrlAliases(localizedUrlALiases);
-  //
-  //    assertThrows(
-  //        IdentifiableServiceException.class,
-  //        () -> {
-  //          service.ensureDefaultAliasesExist(entity);
-  //        });
-  //  }
-  //
-  //  @DisplayName("throws an Exception, when slug generation fails")
-  //  @Test
-  //  public void failingSlugGeneration() throws CudamiServiceException {
-  //    when(urlAliasService.generateSlug(any(Locale.class), any(String.class), eq(null)))
-  //        .thenThrow(new CudamiServiceException("boo"));
-  //
-  //    Identifiable identifiable = new Identifiable();
-  //    identifiable.setLabel("label");
-  //
-  //    assertThrows(
-  //        IdentifiableServiceException.class,
-  //        () -> {
-  //          service.ensureDefaultAliasesExist(identifiable);
-  //        });
-  //  }
 
   @DisplayName("throws an Exception to trigger a rollback on save, when saving in the repo fails")
   @Test
@@ -317,7 +179,9 @@ class IdentifiableServiceImplTest {
     identifiable.setUuid(targetUuid);
     identifiable.setLabel(new LocalizedText(Locale.GERMAN, "label"));
 
-    when(repo.update(eq(identifiable))).thenReturn(identifiable);
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    identifiableInDb.setLabel(new LocalizedText(Locale.GERMAN, "label"));
 
     LocalizedUrlAliases localizedUrlAliases = new LocalizedUrlAliases();
     UrlAlias urlAlias = new UrlAlias();
@@ -327,7 +191,8 @@ class IdentifiableServiceImplTest {
     localizedUrlAliases.add(urlAlias);
     identifiable.setLocalizedUrlAliases(localizedUrlAliases);
 
-    when(urlAliasService.findPrimaryLinksForTarget(any())).thenReturn(new ArrayList<>());
+    when(repo.update(eq(identifiable))).thenReturn(identifiable);
+    when(repo.findOne(eq(targetUuid))).thenReturn(identifiableInDb);
 
     service.update(identifiable);
     verify(urlAliasService, times(1)).deleteAllForTarget(eq(targetUuid));
@@ -353,7 +218,7 @@ class IdentifiableServiceImplTest {
     localizedUrlAliases.add(urlAlias);
     identifiable.setLocalizedUrlAliases(localizedUrlAliases);
     when(repo.update(eq(identifiable))).thenReturn(identifiable);
-    when(urlAliasService.findPrimaryLinksForTarget(eq(targetUuid))).thenReturn(List.of(urlAlias));
+    when(repo.findOne(eq(targetUuid))).thenReturn(identifiable);
 
     service.update(identifiable);
 
@@ -369,6 +234,11 @@ class IdentifiableServiceImplTest {
     identifiable.setUuid(targetUuid);
     identifiable.setLabel(new LocalizedText(Locale.GERMAN, "label"));
 
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    identifiableInDb.setLabel(new LocalizedText(Locale.GERMAN, "oldlabel"));
+
+    when(repo.findOne(eq(targetUuid))).thenReturn(identifiableInDb);
     when(repo.update(eq(identifiable))).thenReturn(identifiable);
 
     service.update(identifiable);
@@ -382,8 +252,6 @@ class IdentifiableServiceImplTest {
   public void exceptionOnMultiplePrimaryEntries()
       throws CudamiServiceException, ValidationException {
     UUID targetUuid = UUID.randomUUID();
-
-    when(urlAliasService.findLocalizedUrlAliases(eq(targetUuid))).thenReturn(null);
 
     Website website = new Website();
     website.setUuid(UUID.randomUUID());
@@ -411,6 +279,13 @@ class IdentifiableServiceImplTest {
     identifiable.setLocalizedUrlAliases(localizedUrlAliases);
     identifiable.setLabel(new LocalizedText(Locale.forLanguageTag("de"), "slug"));
 
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    identifiableInDb.setLabel(new LocalizedText(Locale.forLanguageTag("de"), "slug"));
+
+    when(repo.findOne(any(UUID.class))).thenReturn(identifiableInDb);
+    when(repo.update(identifiable)).thenReturn(identifiable);
+
     when(urlAliasService.findPrimaryLinksForTarget(any())).thenReturn(new ArrayList<>());
     doThrow(new ValidationException("no way!"))
         .when(urlAliasService)
@@ -429,9 +304,6 @@ class IdentifiableServiceImplTest {
   public void exceptionOnMultiplePrimaryEntriesBasedOnSlug()
       throws CudamiServiceException, ValidationException {
     UUID targetUuid = UUID.randomUUID();
-
-    when(urlAliasService.findLocalizedUrlAliases(eq(targetUuid))).thenReturn(null);
-    when(urlAliasService.findPrimaryLinksForTarget(any())).thenReturn(new ArrayList<>());
 
     LocalizedUrlAliases localizedUrlAliases = new LocalizedUrlAliases();
 
@@ -456,6 +328,13 @@ class IdentifiableServiceImplTest {
     identifiable.setLocalizedUrlAliases(localizedUrlAliases);
     identifiable.setLabel(new LocalizedText(Locale.forLanguageTag("de"), "slug"));
 
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    identifiableInDb.setLabel(new LocalizedText(Locale.forLanguageTag("de"), "slug"));
+
+    when(repo.findOne(any(UUID.class))).thenReturn(identifiableInDb);
+    when(repo.update(identifiable)).thenReturn(identifiable);
+
     doThrow(new ValidationException("no way!"))
         .when(urlAliasService)
         .validate(eq(localizedUrlAliases));
@@ -472,9 +351,6 @@ class IdentifiableServiceImplTest {
   public void allowMultiplePrimariesForDifferentTuples()
       throws CudamiServiceException, IdentifiableServiceException, ValidationException {
     UUID targetUuid = UUID.randomUUID();
-
-    when(urlAliasService.findLocalizedUrlAliases(eq(targetUuid))).thenReturn(null);
-    when(urlAliasService.findPrimaryLinksForTarget(any())).thenReturn(new ArrayList<>());
 
     Website website = new Website();
     website.setUuid(UUID.randomUUID());
@@ -506,6 +382,12 @@ class IdentifiableServiceImplTest {
     identifiable.setLabel(label);
 
     when(repo.update(identifiable)).thenReturn(identifiable);
+
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    identifiableInDb.setLabel(new LocalizedText(Locale.forLanguageTag("de"), "label"));
+
+    when(repo.findOne(any(UUID.class))).thenReturn(identifiableInDb);
 
     service.update(identifiable);
   }
@@ -539,6 +421,15 @@ class IdentifiableServiceImplTest {
     localizedUrlAliases.add(firstPrimaryUrlAlias, secondPrimaryUrlAlias);
 
     when(urlAliasService.findLocalizedUrlAliases(eq(targetUuid))).thenReturn(localizedUrlAliases);
+
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    LocalizedText labelDb = new LocalizedText(Locale.GERMAN, "label");
+    labelDb.setText(Locale.ENGLISH, "label");
+    identifiableInDb.setLabel(labelDb);
+    identifiableInDb.setLocalizedUrlAliases(localizedUrlAliases);
+
+    when(repo.findOne(eq(targetUuid))).thenReturn(identifiableInDb);
 
     Identifiable identifiable = new Identifiable();
     identifiable.setUuid(targetUuid);
@@ -588,8 +479,15 @@ class IdentifiableServiceImplTest {
     storedUrlAliases.add(firstStoredPrimaryUrlAlias, secondStoredPrimaryUrlAlias);
 
     when(urlAliasService.findLocalizedUrlAliases(eq(targetUuid))).thenReturn(storedUrlAliases);
-    when(urlAliasService.findPrimaryLinksForTarget(eq(targetUuid)))
-        .thenReturn(List.of(firstStoredPrimaryUrlAlias, secondStoredPrimaryUrlAlias));
+
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    LocalizedText label = new LocalizedText(Locale.GERMAN, "label");
+    label.setText(Locale.ENGLISH, "label");
+    identifiableInDb.setLabel(label);
+    identifiableInDb.setLocalizedUrlAliases(storedUrlAliases);
+
+    when(repo.findOne(eq(targetUuid))).thenReturn(identifiableInDb);
 
     // new ones
     LocalizedUrlAliases localizedUrlAliases = new LocalizedUrlAliases();
@@ -610,8 +508,6 @@ class IdentifiableServiceImplTest {
 
     Identifiable identifiable = new Identifiable();
     identifiable.setUuid(targetUuid);
-    LocalizedText label = new LocalizedText(Locale.GERMAN, "label");
-    label.setText(Locale.ENGLISH, "label");
     identifiable.setLabel(label);
     identifiable.setLocalizedUrlAliases(localizedUrlAliases);
 
@@ -659,8 +555,15 @@ class IdentifiableServiceImplTest {
     storedUrlAliases.add(firstStoredPrimaryUrlAlias, secondStoredPrimaryUrlAlias);
 
     when(urlAliasService.findLocalizedUrlAliases(eq(targetUuid))).thenReturn(storedUrlAliases);
-    when(urlAliasService.findPrimaryLinksForTarget(eq(targetUuid)))
-        .thenReturn(List.of(firstStoredPrimaryUrlAlias, secondStoredPrimaryUrlAlias));
+
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    LocalizedText label = new LocalizedText(Locale.GERMAN, "label");
+    label.setText(Locale.ENGLISH, "label");
+    identifiableInDb.setLabel(label);
+    identifiableInDb.setLocalizedUrlAliases(storedUrlAliases);
+
+    when(repo.findOne(eq(targetUuid))).thenReturn(identifiableInDb);
 
     // new one
     LocalizedUrlAliases localizedUrlAliases = new LocalizedUrlAliases();
@@ -675,8 +578,6 @@ class IdentifiableServiceImplTest {
 
     Identifiable identifiable = new Identifiable();
     identifiable.setUuid(targetUuid);
-    LocalizedText label = new LocalizedText(Locale.GERMAN, "label");
-    label.setText(Locale.ENGLISH, "label");
     identifiable.setLabel(label);
     identifiable.setLocalizedUrlAliases(localizedUrlAliases);
 
@@ -712,8 +613,14 @@ class IdentifiableServiceImplTest {
     LocalizedUrlAliases storedUrlAliases = new LocalizedUrlAliases(firstStoredPrimaryUrlAlias);
 
     when(urlAliasService.findLocalizedUrlAliases(eq(targetUuid))).thenReturn(storedUrlAliases);
-    when(urlAliasService.findPrimaryLinksForTarget(eq(targetUuid)))
-        .thenReturn(List.of(firstStoredPrimaryUrlAlias));
+
+    Identifiable identifiableInDb = new Identifiable();
+    identifiableInDb.setUuid(targetUuid);
+    LocalizedText labelDb = new LocalizedText(Locale.GERMAN, "label");
+    identifiableInDb.setLabel(labelDb);
+    identifiableInDb.setLocalizedUrlAliases(storedUrlAliases);
+
+    when(repo.findOne(eq(targetUuid))).thenReturn(identifiableInDb);
 
     // aliases in object to update
     UrlAlias firstPrimaryUrlAlias = new UrlAlias(); // equals to DB

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelperTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelperTest.java
@@ -1,0 +1,186 @@
+package de.digitalcollections.cudami.server.business.impl.service.identifiable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
+import de.digitalcollections.model.identifiable.Identifiable;
+import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
+import de.digitalcollections.model.identifiable.alias.UrlAlias;
+import de.digitalcollections.model.identifiable.entity.DigitalObject;
+import de.digitalcollections.model.identifiable.entity.Entity;
+import de.digitalcollections.model.identifiable.entity.EntityType;
+import de.digitalcollections.model.identifiable.web.Webpage;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Identifiable-UrlAlias-Align-Helper tests")
+public class IdentifiableUrlAliasAlignHelperTest {
+
+  CudamiConfig cudamiConfig;
+  IdentifiableUrlAliasAlignHelper.SlugGeneratorService slugGeneratorService;
+
+  @BeforeEach
+  public void setup() {
+    cudamiConfig = new CudamiConfig();
+    CudamiConfig.UrlAlias urlAliasConfig = new CudamiConfig.UrlAlias();
+    urlAliasConfig.setGenerationExcludes(List.of(EntityType.DIGITAL_OBJECT));
+    cudamiConfig.setUrlAlias(urlAliasConfig);
+
+    slugGeneratorService = mock(IdentifiableUrlAliasAlignHelper.SlugGeneratorService.class);
+  }
+
+  @DisplayName("does not guarantee URLAliases for some entity types")
+  @Test
+  public void noUrlAliasesForSomeEntityTypes() throws CudamiServiceException {
+    DigitalObject identifiable = new DigitalObject();
+    identifiable.setLabel("label");
+    IdentifiableUrlAliasAlignHelper.checkDefaultAliases(
+        identifiable, cudamiConfig, slugGeneratorService);
+    assertThat(identifiable.getLocalizedUrlAliases()).isNull();
+  }
+
+  @DisplayName("can create an LocalizedUrlAlias, when it's missing")
+  @Test
+  public void createLocalizedUrlAliasWhenMissing() throws CudamiServiceException {
+    Identifiable identifiable = new Identifiable();
+    identifiable.setLabel("label");
+    when(slugGeneratorService.apply(any(), any(), any())).thenReturn("label");
+
+    IdentifiableUrlAliasAlignHelper.checkDefaultAliases(
+        identifiable, cudamiConfig, slugGeneratorService);
+    assertThat(identifiable.getLocalizedUrlAliases()).isNotNull();
+  }
+
+  @DisplayName("sets all required attribute of a created default UrlAlias")
+  @Test
+  public void fillsAttributeOnCreatedDefaultUrlAlias() throws CudamiServiceException {
+    when(slugGeneratorService.apply(any(Locale.class), any(String.class), eq(null)))
+        .thenReturn("hallo-welt");
+
+    UUID expectedTargetUuid = UUID.randomUUID();
+
+    Entity entity = new Entity();
+    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
+    entity.setUuid(expectedTargetUuid);
+    IdentifiableUrlAliasAlignHelper.checkDefaultAliases(entity, cudamiConfig, slugGeneratorService);
+
+    UrlAlias actual = entity.getLocalizedUrlAliases().flatten().get(0);
+    assertThat(actual.getLastPublished()).isNull(); // is set by the repository
+    assertThat(actual.isPrimary()).isTrue();
+    assertThat(actual.getCreated()).isNull(); // is set by the repository
+    assertThat(actual.getTargetUuid()).isEqualTo(expectedTargetUuid);
+    assertThat(actual.getTargetIdentifiableType()).isEqualTo(entity.getType());
+    assertThat(actual.getTargetEntityType()).isEqualTo(entity.getEntityType());
+    assertThat(actual.getWebsite()).isNull(); // no default website given
+    assertThat(actual.getSlug()).isEqualTo("hallo-welt");
+    assertThat(actual.getTargetLanguage()).isEqualTo(Locale.GERMAN);
+  }
+
+  @DisplayName("does not create a default UrlAliases for a webpage")
+  @Test
+  public void noDefaultUrlAliasCreationForWebpage() throws CudamiServiceException {
+    when(slugGeneratorService.apply(any(Locale.class), any(String.class), eq(null)))
+        .thenReturn("hallo-welt");
+    UUID expectedTargetUuid = UUID.randomUUID();
+
+    Identifiable identifiable = new Webpage();
+    identifiable.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
+    identifiable.setUuid(expectedTargetUuid);
+
+    assertThrows(
+        CudamiServiceException.class,
+        () -> {
+          IdentifiableUrlAliasAlignHelper.checkDefaultAliases(
+              identifiable, cudamiConfig, slugGeneratorService);
+        });
+
+    assertThat(identifiable.getLocalizedUrlAliases().isEmpty());
+  }
+
+  @DisplayName("adds an url alias for a certain language, when it's missing")
+  @Test
+  public void addUrlAliasWhenMissingInLanguage() throws CudamiServiceException {
+    when(slugGeneratorService.apply(eq(Locale.GERMAN), any(String.class), eq(null)))
+        .thenReturn("hallo-welt");
+    when(slugGeneratorService.apply(eq(Locale.ENGLISH), any(String.class), eq(null)))
+        .thenReturn("hello-world");
+
+    UUID expectedTargetUuid = UUID.randomUUID();
+
+    Entity entity = new Entity();
+    final LocalizedText label = new LocalizedText(Locale.GERMAN, "Hallo Welt");
+    label.setText(Locale.ENGLISH, "hello world");
+    entity.setLabel(label);
+    entity.setUuid(expectedTargetUuid);
+
+    // Let's assume, we only have localized aliases for the german label yet
+    UrlAlias germanUrlAlias = new UrlAlias();
+    germanUrlAlias.setPrimary(true);
+    germanUrlAlias.setSlug("hallo-welt");
+    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
+    germanUrlAlias.setTargetUuid(expectedTargetUuid);
+    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases(germanUrlAlias);
+    entity.setLocalizedUrlAliases(localizedUrlALiases);
+
+    IdentifiableUrlAliasAlignHelper.checkDefaultAliases(entity, cudamiConfig, slugGeneratorService);
+
+    assertThat(localizedUrlALiases.flatten()).hasSize(2); // german and english
+    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.GERMAN)).isTrue();
+    assertThat(localizedUrlALiases.hasTargetLanguage(Locale.ENGLISH)).isTrue();
+
+    assertThat(localizedUrlALiases.get(Locale.ENGLISH).get(0).getSlug()).isEqualTo("hello-world");
+  }
+
+  @DisplayName("throws an exception, when primary UrlAliases are missing")
+  @Test
+  public void missingPrimaryUrlAliases() {
+    UUID expectedTargetUuid = UUID.randomUUID();
+
+    Entity entity = new Entity();
+    entity.setLabel(new LocalizedText(Locale.GERMAN, "Hallo Welt"));
+    entity.setUuid(expectedTargetUuid);
+
+    UrlAlias germanUrlAlias = new UrlAlias();
+    germanUrlAlias.setPrimary(false);
+    germanUrlAlias.setSlug("hallo-welt");
+    germanUrlAlias.setTargetLanguage(Locale.GERMAN);
+    germanUrlAlias.setTargetUuid(expectedTargetUuid);
+    LocalizedUrlAliases localizedUrlALiases = new LocalizedUrlAliases(germanUrlAlias);
+    entity.setLocalizedUrlAliases(localizedUrlALiases);
+
+    assertThrows(
+        CudamiServiceException.class,
+        () -> {
+          IdentifiableUrlAliasAlignHelper.checkDefaultAliases(
+              entity, cudamiConfig, slugGeneratorService);
+        });
+  }
+
+  @DisplayName("throws an Exception, when slug generation fails")
+  @Test
+  public void failingSlugGeneration() throws CudamiServiceException {
+    when(slugGeneratorService.apply(any(Locale.class), any(String.class), eq(null)))
+        .thenThrow(new CudamiServiceException("boo"));
+
+    Identifiable identifiable = new Identifiable();
+    identifiable.setLabel("label");
+
+    assertThrows(
+        CudamiServiceException.class,
+        () -> {
+          IdentifiableUrlAliasAlignHelper.checkDefaultAliases(
+              identifiable, cudamiConfig, slugGeneratorService);
+        });
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelperTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelperTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.digitalcollections.cudami.model.config.CudamiConfig;
@@ -20,6 +23,7 @@ import de.digitalcollections.model.text.LocalizedText;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,6 +64,8 @@ public class IdentifiableUrlAliasAlignHelperTest {
     IdentifiableUrlAliasAlignHelper.checkDefaultAliases(
         identifiable, cudamiConfig, slugGeneratorService);
     assertThat(identifiable.getLocalizedUrlAliases()).isNotNull();
+    assertThat(identifiable.getLocalizedUrlAliases().flatten().size()).isEqualTo(1);
+    assertThat(identifiable.getLocalizedUrlAliases().flatten().get(0).isPrimary()).isTrue();
   }
 
   @DisplayName("sets all required attribute of a created default UrlAlias")
@@ -75,6 +81,7 @@ public class IdentifiableUrlAliasAlignHelperTest {
     entity.setUuid(expectedTargetUuid);
     IdentifiableUrlAliasAlignHelper.checkDefaultAliases(entity, cudamiConfig, slugGeneratorService);
 
+    assertThat(entity.getLocalizedUrlAliases().flatten().size()).isEqualTo(1);
     UrlAlias actual = entity.getLocalizedUrlAliases().flatten().get(0);
     assertThat(actual.getLastPublished()).isNull(); // is set by the repository
     assertThat(actual.isPrimary()).isTrue();
@@ -90,8 +97,6 @@ public class IdentifiableUrlAliasAlignHelperTest {
   @DisplayName("does not create a default UrlAliases for a webpage")
   @Test
   public void noDefaultUrlAliasCreationForWebpage() throws CudamiServiceException {
-    when(slugGeneratorService.apply(any(Locale.class), any(String.class), eq(null)))
-        .thenReturn("hallo-welt");
     UUID expectedTargetUuid = UUID.randomUUID();
 
     Identifiable identifiable = new Webpage();
@@ -140,6 +145,7 @@ public class IdentifiableUrlAliasAlignHelperTest {
     assertThat(localizedUrlALiases.hasTargetLanguage(Locale.ENGLISH)).isTrue();
 
     assertThat(localizedUrlALiases.get(Locale.ENGLISH).get(0).getSlug()).isEqualTo("hello-world");
+    assertThat(localizedUrlALiases.get(Locale.ENGLISH).get(0).isPrimary()).isTrue();
   }
 
   @DisplayName("throws an exception, when primary UrlAliases are missing")
@@ -182,5 +188,563 @@ public class IdentifiableUrlAliasAlignHelperTest {
           IdentifiableUrlAliasAlignHelper.checkDefaultAliases(
               identifiable, cudamiConfig, slugGeneratorService);
         });
+  }
+
+  @DisplayName("if there are not any aliases then fetch them from object of db")
+  @Test
+  public void fetchAliasesfromSavedObject() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    dbIdent.setLocalizedUrlAliases(
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID())));
+
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isEqualTo(dbIdent);
+  }
+
+  @DisplayName("if there are only different primary aliases then unset existing ones - 2 vs. 2")
+  @Test
+  public void unsetExistingPrimaries() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.GERMAN, "somethingelse", false, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "neuer-alias", true),
+            new SlugPrimaryTuple(Locale.ENGLISH, "new-alias", true));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size())
+        .isEqualTo(4); // non primary is absent thus it will be deleted
+    assertThat(dbAliases.flatten()).allMatch(ua -> !ua.isPrimary());
+
+    // keep in mind that `aliases` now contains those from db too
+    assertThat(locUrlAliases.flatten().stream().filter(ua -> ua.isPrimary()))
+        .allMatch(ua -> Pattern.matches("neuer-alias|new-alias", ua.getSlug()))
+        .size()
+        .isEqualTo(2);
+    assertThat(locUrlAliases.flatten().stream().filter(ua -> !ua.isPrimary()))
+        .allMatch(ua -> Pattern.matches("hallo-welt|hello-world", ua.getSlug()))
+        .size()
+        .isEqualTo(2);
+  }
+
+  @DisplayName("if there are only different primary aliases then unset existing ones - 1 vs. 2")
+  @Test
+  public void unsetExistingPrimary() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(targetUuid, new SlugPrimaryTuple(Locale.GERMAN, "neuer-alias", true));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(3);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isFalse();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("neuer-alias");
+              assertThat(ua.isPrimary()).isTrue();
+            });
+  }
+
+  @DisplayName("2 existing aliases + 1 new alias")
+  @Test
+  public void addNewAlias() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(
+                Locale.GERMAN, "hallo-welt", true, dbAliases.get(Locale.GERMAN).get(0).getUuid()),
+            new SlugPrimaryTuple(
+                Locale.ENGLISH,
+                "hello-world",
+                true,
+                dbAliases.get(Locale.ENGLISH).get(0).getUuid()),
+            new SlugPrimaryTuple(Locale.GERMAN, "neuer-alias", false));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(3);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("neuer-alias");
+              assertThat(ua.isPrimary()).isFalse();
+            });
+  }
+
+  @DisplayName("2 existing aliases + 1 new alias, primary too")
+  @Test
+  public void addPrimaryAlias() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(
+                Locale.GERMAN, "hallo-welt", true, dbAliases.get(Locale.GERMAN).get(0).getUuid()),
+            new SlugPrimaryTuple(
+                Locale.ENGLISH,
+                "hello-world",
+                true,
+                dbAliases.get(Locale.ENGLISH).get(0).getUuid()),
+            new SlugPrimaryTuple(Locale.GERMAN, "neuer-alias", true));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(3);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isFalse();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("neuer-alias");
+              assertThat(ua.isPrimary()).isTrue();
+            });
+  }
+
+  @DisplayName("2 existing aliases, no changes")
+  @Test
+  public void doNothingIfNoChanges() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(
+                Locale.GERMAN, "hallo-welt", true, dbAliases.get(Locale.GERMAN).get(0).getUuid()),
+            new SlugPrimaryTuple(
+                Locale.ENGLISH,
+                "hello-world",
+                true,
+                dbAliases.get(Locale.ENGLISH).get(0).getUuid()));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isTrue();
+            });
+  }
+
+  @DisplayName("2 existing aliases, 1 label changed")
+  @Test
+  public void labelChanged() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello new world"); // different label
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(
+                Locale.GERMAN, "hallo-welt", true, dbAliases.get(Locale.GERMAN).get(0).getUuid()),
+            new SlugPrimaryTuple(
+                Locale.ENGLISH,
+                "hello-world",
+                true,
+                dbAliases.get(Locale.ENGLISH).get(0).getUuid()));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    when(slugGeneratorService.apply(eq(Locale.ENGLISH), eq("hello new world"), eq(null)))
+        .thenReturn("hello-new-world");
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(3);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isFalse();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-new-world");
+              assertThat(ua.isPrimary()).isTrue();
+            });
+    verify(slugGeneratorService, times(1)).apply(any(), any(), any());
+  }
+
+  @DisplayName("2 existing aliases, 1 label changed + new alias already passed")
+  @Test
+  public void labelChangedWithNewAlias() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbLabels.setText(Locale.ENGLISH, "hello world");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello new world"); // different label
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(
+                Locale.GERMAN, "hallo-welt", true, dbAliases.get(Locale.GERMAN).get(0).getUuid()),
+            new SlugPrimaryTuple(
+                Locale.ENGLISH,
+                "hello-world",
+                true,
+                dbAliases.get(Locale.ENGLISH).get(0).getUuid()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-new-world", false));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    when(slugGeneratorService.apply(eq(Locale.ENGLISH), eq("hello new world"), eq(null)))
+        .thenReturn("hello-new-world");
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(3);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-new-world");
+              assertThat(ua.isPrimary()).isFalse();
+            });
+    verify(slugGeneratorService, times(1)).apply(any(), any(), any());
+  }
+
+  @DisplayName("1 existing alias, 1 new label -> automatically create new alias")
+  @Test
+  public void addLabel() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid, new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(
+                Locale.GERMAN, "hallo-welt", true, dbAliases.flatten().get(0).getUuid()));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    when(slugGeneratorService.apply(eq(Locale.ENGLISH), eq("hello world"), eq(null)))
+        .thenReturn("hello-world");
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isTrue();
+            });
+    verify(slugGeneratorService, times(1)).apply(any(), any(), any());
+  }
+
+  @DisplayName("1 existing alias, 1 new label + fitting alias")
+  @Test
+  public void addLabelAndAlias() throws CudamiServiceException {
+    UUID targetUuid = UUID.randomUUID();
+
+    // DB
+    Identifiable dbIdent = new Identifiable();
+    LocalizedText dbLabels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    dbIdent.setLabel(dbLabels);
+    LocalizedUrlAliases dbAliases =
+        createAliases(
+            targetUuid, new SlugPrimaryTuple(Locale.GERMAN, "hallo-welt", true, UUID.randomUUID()));
+    dbIdent.setLocalizedUrlAliases(dbAliases);
+
+    // Update
+    Identifiable identifiable = new Identifiable();
+    LocalizedText labels = new LocalizedText(Locale.GERMAN, "hallo welt");
+    labels.setText(Locale.ENGLISH, "hello world");
+    identifiable.setLabel(labels);
+    LocalizedUrlAliases aliases =
+        createAliases(
+            targetUuid,
+            new SlugPrimaryTuple(
+                Locale.GERMAN, "hallo-welt", true, dbAliases.flatten().get(0).getUuid()),
+            new SlugPrimaryTuple(Locale.ENGLISH, "hello-world", true));
+    identifiable.setLocalizedUrlAliases(aliases);
+
+    when(slugGeneratorService.apply(eq(Locale.ENGLISH), eq("hello world"), eq(null)))
+        .thenReturn("hello-world");
+
+    IdentifiableUrlAliasAlignHelper.alignForUpdate(
+        identifiable, dbIdent, cudamiConfig, slugGeneratorService);
+
+    assertThat(identifiable).isNotEqualTo(dbIdent);
+
+    LocalizedUrlAliases locUrlAliases = identifiable.getLocalizedUrlAliases();
+    assertThat(locUrlAliases.size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten().size()).isEqualTo(2);
+    assertThat(locUrlAliases.flatten())
+        .satisfiesExactlyInAnyOrder(
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hallo-welt");
+              assertThat(ua.isPrimary()).isTrue();
+            },
+            ua -> {
+              assertThat(ua.getSlug()).isEqualTo("hello-world");
+              assertThat(ua.isPrimary()).isTrue();
+            });
+    verify(slugGeneratorService, never()).apply(any(), any(), any());
+  }
+
+  private LocalizedUrlAliases createAliases(UUID target, SlugPrimaryTuple... slugTuples) {
+    LocalizedUrlAliases aliases = new LocalizedUrlAliases();
+    for (var tuple : slugTuples) {
+      UrlAlias alias = new UrlAlias();
+      alias.setSlug(tuple.slug);
+      alias.setPrimary(tuple.isPrimary);
+      alias.setTargetUuid(target);
+      alias.setTargetLanguage(tuple.lang);
+      alias.setUuid(tuple.uuid);
+      aliases.add(alias);
+    }
+    return aliases;
+  }
+
+  class SlugPrimaryTuple {
+    public Locale lang;
+    public String slug;
+    public boolean isPrimary;
+    public UUID uuid;
+
+    public SlugPrimaryTuple(Locale lang, String slug, boolean isPrimary, UUID aliasUuid) {
+      this.lang = lang;
+      this.slug = slug;
+      this.isPrimary = isPrimary;
+      this.uuid = aliasUuid;
+    }
+
+    public SlugPrimaryTuple(Locale lang, String slug, boolean isPrimary) {
+      this(lang, slug, isPrimary, null);
+    }
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImplTest.java
@@ -221,17 +221,17 @@ class WebpageServiceImplTest {
   @DisplayName("does not allow empty UrlAliases at update")
   public void updateWithEmptyUrlAliases()
       throws ValidationException, IdentifiableServiceException, CudamiServiceException {
-    UUID webpage_uuid = UUID.randomUUID();
+    UUID webpageUuid = UUID.randomUUID();
 
     // in DB
     Webpage dbWebpage = new Webpage();
-    dbWebpage.setUuid(webpage_uuid);
+    dbWebpage.setUuid(webpageUuid);
     dbWebpage.setLabel("test");
-    when(repo.findOne(eq(webpage_uuid))).thenReturn(dbWebpage);
+    when(repo.findOne(eq(webpageUuid))).thenReturn(dbWebpage);
 
     Webpage webpage = new Webpage();
     webpage.setLabel("test");
-    webpage.setUuid(webpage_uuid);
+    webpage.setUuid(webpageUuid);
     when(repo.update(eq(webpage))).thenReturn(webpage);
     UrlAlias dummyAlias = new UrlAlias();
     Website dummyWebsite = new Website();

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImplTest.java
@@ -203,35 +203,46 @@ class WebpageServiceImplTest {
   }
 
   @Test
-  @DisplayName("allows empty UrlAliases at save and automatically creates an UrlAlias")
+  @DisplayName("does not allow empty UrlAliases at save")
   public void saveWithEmptyUrlAliases()
       throws ValidationException, IdentifiableServiceException, CudamiServiceException {
     Webpage webpage = new Webpage();
     webpage.setLabel("test");
     when(repo.save(eq(webpage))).thenReturn(webpage);
-    UrlAlias dummyAlias = new UrlAlias();
-    Website dummyWebsite = new Website();
-    dummyWebsite.setUuid(UUID.randomUUID());
-    dummyAlias.setWebsite(dummyWebsite);
-    when(urlAliasService.create(any(UrlAlias.class))).thenReturn(dummyAlias);
-    service.save(webpage);
+    assertThrows(
+        IdentifiableServiceException.class,
+        () -> {
+          service.save(webpage);
+        });
     verify(repo, times(1)).save(any(Webpage.class));
   }
 
   @Test
-  @DisplayName("allows empty UrlAliases at update and automatically creates an UrlAlias")
+  @DisplayName("does not allow empty UrlAliases at update")
   public void updateWithEmptyUrlAliases()
       throws ValidationException, IdentifiableServiceException, CudamiServiceException {
+    UUID webpage_uuid = UUID.randomUUID();
+
+    // in DB
+    Webpage dbWebpage = new Webpage();
+    dbWebpage.setUuid(webpage_uuid);
+    dbWebpage.setLabel("test");
+    when(repo.findOne(eq(webpage_uuid))).thenReturn(dbWebpage);
+
     Webpage webpage = new Webpage();
     webpage.setLabel("test");
-    webpage.setUuid(UUID.randomUUID());
+    webpage.setUuid(webpage_uuid);
     when(repo.update(eq(webpage))).thenReturn(webpage);
     UrlAlias dummyAlias = new UrlAlias();
     Website dummyWebsite = new Website();
     dummyWebsite.setUuid(UUID.randomUUID());
     dummyAlias.setWebsite(dummyWebsite);
     when(urlAliasService.create(any(UrlAlias.class))).thenReturn(dummyAlias);
-    service.update(webpage);
+    assertThrows(
+        IdentifiableServiceException.class,
+        () -> {
+          service.update(webpage);
+        });
     verify(repo, times(1)).update(any(Webpage.class));
   }
 


### PR DESCRIPTION
- add profile specific application.yaml (e.g. application-local.yaml) to `.gitignore`
- new UrlAlias as primary link if label changes
- refactor UrlAlias logic in `IdentifiableServiceImpl`

Ticket: mdz/webapps/internal/cudami/-/issues/242