### PR TITLE
Fix findByIdentifier

### DIFF
--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/agent/CudamiFamilyNamesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/agent/CudamiFamilyNamesClient.java
@@ -1,28 +1,20 @@
 package de.digitalcollections.cudami.client.identifiable.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.digitalcollections.cudami.client.CudamiBaseClient;
 import de.digitalcollections.cudami.client.exceptions.HttpException;
+import de.digitalcollections.cudami.client.identifiable.CudamiIdentifiablesClient;
 import de.digitalcollections.model.identifiable.agent.FamilyName;
 import de.digitalcollections.model.paging.SearchPageRequest;
 import de.digitalcollections.model.paging.SearchPageResponse;
 import java.net.http.HttpClient;
-import java.util.UUID;
 
-public class CudamiFamilyNamesClient extends CudamiBaseClient<FamilyName> {
+public class CudamiFamilyNamesClient extends CudamiIdentifiablesClient<FamilyName> {
 
   public CudamiFamilyNamesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
-    super(http, serverUrl, FamilyName.class, mapper);
+    super(http, serverUrl, FamilyName.class, mapper, "/v5/familynames");
   }
 
-  public long count() throws HttpException {
-    return Long.parseLong(doGetRequestForString("/v5/familynames/count"));
-  }
-
-  public FamilyName create() {
-    return new FamilyName();
-  }
-
+  @Override
   public SearchPageResponse<FamilyName> find(SearchPageRequest searchPageRequest)
       throws HttpException {
     return doGetSearchRequestForPagedObjectList("/v5/familynames", searchPageRequest);
@@ -53,22 +45,5 @@ public class CudamiFamilyNamesClient extends CudamiBaseClient<FamilyName> {
             nullHandling,
             language,
             initial);
-  }
-
-  public FamilyName findOne(UUID uuid) throws HttpException {
-    return doGetRequestForObject(String.format("/v5/familynames/%s", uuid));
-  }
-
-  public FamilyName findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format("/v5/familynames/identifier?namespace=%s&id=%s", namespace, id));
-  }
-
-  public FamilyName save(FamilyName familyName) throws HttpException {
-    return doPostRequestForObject("/v5/familynames", familyName);
-  }
-
-  public FamilyName update(UUID uuid, FamilyName familyName) throws HttpException {
-    return doPutRequestForObject(String.format("/v5/familynames/%s", uuid), familyName);
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/agent/CudamiGivenNamesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/agent/CudamiGivenNamesClient.java
@@ -1,30 +1,17 @@
 package de.digitalcollections.cudami.client.identifiable.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.digitalcollections.cudami.client.CudamiBaseClient;
 import de.digitalcollections.cudami.client.exceptions.HttpException;
+import de.digitalcollections.cudami.client.identifiable.CudamiIdentifiablesClient;
 import de.digitalcollections.model.identifiable.agent.GivenName;
 import de.digitalcollections.model.paging.PageRequest;
 import de.digitalcollections.model.paging.PageResponse;
 import java.net.http.HttpClient;
-import java.util.UUID;
 
-public class CudamiGivenNamesClient extends CudamiBaseClient<GivenName> {
+public class CudamiGivenNamesClient extends CudamiIdentifiablesClient<GivenName> {
 
   public CudamiGivenNamesClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
-    super(http, serverUrl, GivenName.class, mapper);
-  }
-
-  public long count() throws HttpException {
-    return Long.parseLong(doGetRequestForString("/v5/givennames/count"));
-  }
-
-  public GivenName create() {
-    return new GivenName();
-  }
-
-  public PageResponse<GivenName> find(PageRequest pageRequest) throws HttpException {
-    return doGetRequestForPagedObjectList("/v5/givennames", pageRequest);
+    super(http, serverUrl, GivenName.class, mapper, "/v5/givennames");
   }
 
   public PageResponse findByLanguageAndInitial(
@@ -50,22 +37,5 @@ public class CudamiGivenNamesClient extends CudamiBaseClient<GivenName> {
         nullHandling,
         language,
         initial);
-  }
-
-  public GivenName findOne(UUID uuid) throws HttpException {
-    return doGetRequestForObject(String.format("/v5/givennames/%s", uuid));
-  }
-
-  public GivenName findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format("/v5/givennames/identifier?namespace=%s&id=%s", namespace, id));
-  }
-
-  public GivenName save(GivenName givenName) throws HttpException {
-    return doPostRequestForObject("/v5/givennames", givenName);
-  }
-
-  public GivenName update(UUID uuid, GivenName givenName) throws HttpException {
-    return doPutRequestForObject(String.format("/v5/givennames/%s", uuid), givenName);
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiCorporateBodiesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiCorporateBodiesClient.java
@@ -22,6 +22,7 @@ public class CudamiCorporateBodiesClient extends CudamiIdentifiablesClient<Corpo
   // TODO: Implement with test
   @Deprecated(since = "5.0", forRemoval = true)
   /** @deprecated Please use {@link #find(SearchPageRequest)} instead */
+  @Override
   public PageResponse<CorporateBody> find(PageRequest pageRequest) throws HttpException {
     return super.find(pageRequest);
   }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiPersonsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiPersonsClient.java
@@ -75,10 +75,4 @@ public class CudamiPersonsClient extends CudamiIdentifiablesClient<Person> {
     return doGetRequestForObjectList(
         String.format(baseEndpoint + "/%s/works", uuidPerson), Work.class);
   }
-
-  @Override
-  public Person findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format(baseEndpoint + "/identifier?namespace=%s&id=%s", namespace, id));
-  }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiPersonsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiPersonsClient.java
@@ -21,6 +21,7 @@ public class CudamiPersonsClient extends CudamiIdentifiablesClient<Person> {
 
   @Deprecated(since = "5.0", forRemoval = true)
   /** @deprecated Please use {@link #find(SearchPageRequest)} instead */
+  @Override
   public PageResponse<Person> find(PageRequest pageRequest) throws HttpException {
     return super.find(pageRequest);
   }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiGeoLocationsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiGeoLocationsClient.java
@@ -55,11 +55,6 @@ public class CudamiGeoLocationsClient extends CudamiIdentifiablesClient<GeoLocat
         initial);
   }
 
-  public GeoLocation findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format("%s/identifier?namespace=%s&id=%s", baseEndpoint, namespace, id));
-  }
-
   public List<Locale> getLanguages() throws HttpException {
     return doGetRequestForObjectList(baseEndpoint + "/languages", Locale.class);
   }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiGeoLocationsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiGeoLocationsClient.java
@@ -20,10 +20,12 @@ public class CudamiGeoLocationsClient extends CudamiIdentifiablesClient<GeoLocat
 
   @Deprecated(since = "5.0", forRemoval = true)
   /** @deprecated Please use {@link #find(SearchPageRequest)} instead */
+  @Override
   public PageResponse<GeoLocation> find(PageRequest pageRequest) throws HttpException {
     return super.find(pageRequest);
   }
 
+  @Override
   public SearchPageResponse<GeoLocation> find(SearchPageRequest searchPageRequest)
       throws HttpException {
     // Interestingly without "/search" in the path

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClient.java
@@ -38,10 +38,4 @@ public class CudamiHumanSettlementsClient extends CudamiIdentifiablesClient<Huma
         language,
         initial);
   }
-
-  @Override
-  public HumanSettlement findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format("%s/identifier?namespace=%s&id=%s", baseEndpoint, namespace, id));
-  }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/work/CudamiItemsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/work/CudamiItemsClient.java
@@ -1,8 +1,8 @@
 package de.digitalcollections.cudami.client.identifiable.entity.work;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.digitalcollections.cudami.client.CudamiBaseClient;
 import de.digitalcollections.cudami.client.exceptions.HttpException;
+import de.digitalcollections.cudami.client.identifiable.CudamiIdentifiablesClient;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.work.Item;
 import de.digitalcollections.model.identifiable.entity.work.Work;
@@ -12,10 +12,10 @@ import java.net.http.HttpClient;
 import java.util.List;
 import java.util.UUID;
 
-public class CudamiItemsClient extends CudamiBaseClient<Item> {
+public class CudamiItemsClient extends CudamiIdentifiablesClient<Item> {
 
   public CudamiItemsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
-    super(http, serverUrl, Item.class, mapper);
+    super(http, serverUrl, Item.class, mapper, "/v5/items");
   }
 
   public Boolean addDigitalObject(UUID itemUuid, UUID digitalObjectUuid) throws HttpException {
@@ -29,18 +29,6 @@ public class CudamiItemsClient extends CudamiBaseClient<Item> {
     return (boolean)
         doPostRequestForObject(
             String.format("/v5/items/%s/works/%s", itemUuid, workUuid), Boolean.class);
-  }
-
-  public long count() throws HttpException {
-    return Long.parseLong(doGetRequestForString("/v5/items/count"));
-  }
-
-  public Item create() {
-    return new Item();
-  }
-
-  public PageResponse<Item> find(PageRequest pageRequest) throws HttpException {
-    return doGetRequestForPagedObjectList("/v5/items", pageRequest);
   }
 
   public PageResponse findByLanguageAndInitial(
@@ -68,15 +56,6 @@ public class CudamiItemsClient extends CudamiBaseClient<Item> {
         initial);
   }
 
-  public Item findOne(UUID uuid) throws HttpException {
-    return doGetRequestForObject(String.format("/v5/items/%s", uuid));
-  }
-
-  public Item findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format("/v5/items/identifier?namespace=%s&id=%s", namespace, id));
-  }
-
   public List getDigitalObjects(UUID uuid) throws HttpException {
     return doGetRequestForObjectList(
         String.format("/v5/items/%s/digitalobjects", uuid), DigitalObject.class);
@@ -84,13 +63,5 @@ public class CudamiItemsClient extends CudamiBaseClient<Item> {
 
   public List getWorks(UUID uuid) throws HttpException {
     return doGetRequestForObjectList(String.format("/v5/items/%s/works", uuid), Work.class);
-  }
-
-  public Item save(Item item) throws HttpException {
-    return doPostRequestForObject("/v5/items", item);
-  }
-
-  public Item update(UUID uuid, Item item) throws HttpException {
-    return doPutRequestForObject(String.format("/v5/items/%s", uuid), item);
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/work/CudamiWorksClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/work/CudamiWorksClient.java
@@ -1,8 +1,8 @@
 package de.digitalcollections.cudami.client.identifiable.entity.work;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.digitalcollections.cudami.client.CudamiBaseClient;
 import de.digitalcollections.cudami.client.exceptions.HttpException;
+import de.digitalcollections.cudami.client.identifiable.CudamiIdentifiablesClient;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.agent.Agent;
 import de.digitalcollections.model.identifiable.entity.work.Item;
@@ -14,22 +14,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-public class CudamiWorksClient extends CudamiBaseClient<Work> {
+public class CudamiWorksClient extends CudamiIdentifiablesClient<Work> {
 
   public CudamiWorksClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
-    super(http, serverUrl, Work.class, mapper);
-  }
-
-  public long count() throws HttpException {
-    return Long.parseLong(doGetRequestForString("/v5/works/count"));
-  }
-
-  public Work create() {
-    return new Work();
-  }
-
-  public PageResponse<Work> find(PageRequest pageRequest) throws HttpException {
-    return doGetRequestForPagedObjectList("/v5/works", pageRequest);
+    super(http, serverUrl, Work.class, mapper, "/v5/works");
   }
 
   public PageResponse findByLanguageAndInitial(
@@ -57,15 +45,6 @@ public class CudamiWorksClient extends CudamiBaseClient<Work> {
         initial);
   }
 
-  public Work findOne(UUID uuid) throws HttpException {
-    return doGetRequestForObject(String.format("/v5/works/%s", uuid));
-  }
-
-  public Work findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format("/v5/works/identifier?namespace=%s&id=%s", namespace, id));
-  }
-
   public Set<Agent> getCreators(UUID uuid) throws HttpException {
     return (Set<Agent>)
         doGetRequestForObjectList(
@@ -74,13 +53,5 @@ public class CudamiWorksClient extends CudamiBaseClient<Work> {
 
   public List getItems(UUID uuid) throws HttpException {
     return doGetRequestForObjectList(String.format("/v5/works/%s/items", uuid), Item.class);
-  }
-
-  public Work save(Work work) throws HttpException {
-    return doPostRequestForObject("/v5/works", work);
-  }
-
-  public Work update(UUID uuid, Work work) throws HttpException {
-    return doPutRequestForObject(String.format("/v5/works/%s", uuid), work);
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/resource/CudamiFileResourcesMetadataClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/resource/CudamiFileResourcesMetadataClient.java
@@ -23,10 +23,12 @@ public class CudamiFileResourcesMetadataClient extends CudamiIdentifiablesClient
 
   @Deprecated(since = "5.0", forRemoval = true)
   /** @deprecated Please use {@link #find(SearchPageRequest)} instead */
+  @Override
   public PageResponse<FileResource> find(PageRequest pageRequest) throws HttpException {
     return super.find(pageRequest);
   }
 
+  @Override
   public SearchPageResponse<FileResource> find(SearchPageRequest searchPageRequest)
       throws HttpException {
     return doGetSearchRequestForPagedObjectList(baseEndpoint, searchPageRequest);

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/resource/CudamiFileResourcesMetadataClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/resource/CudamiFileResourcesMetadataClient.java
@@ -40,11 +40,6 @@ public class CudamiFileResourcesMetadataClient extends CudamiIdentifiablesClient
         String.format("%s/type/%s", baseEndpoint, type), searchPageRequest);
   }
 
-  public FileResource findOneByIdentifier(String namespace, String id) throws HttpException {
-    return doGetRequestForObject(
-        String.format("%s/identifier/%s:%s.json", baseEndpoint, namespace, id));
-  }
-
   public List<Locale> getLanguages() throws HttpException {
     return doGetRequestForObjectList(baseEndpoint + "/languages", Locale.class);
   }

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiPersonsClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiPersonsClientTest.java
@@ -94,6 +94,6 @@ class CudamiPersonsClientTest
     client.findOneByIdentifier(identifierNamespace, identifierValue);
 
     verifyHttpRequestByMethodAndRelativeURL(
-        "get", "/identifier?namespace=" + identifierNamespace + "&id=" + identifierValue);
+        "get", "/identifier/" + identifierNamespace + ":" + identifierValue + ".json");
   }
 }

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiGeoLocationsClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiGeoLocationsClientTest.java
@@ -25,7 +25,7 @@ class CudamiGeoLocationsClientTest
     client.findOneByIdentifier(identifierNamespace, identifierValue);
 
     verifyHttpRequestByMethodAndRelativeURL(
-        "get", "/identifier?namespace=" + identifierNamespace + "&id=" + identifierValue);
+        "get", "/identifier/" + identifierNamespace + ":" + identifierValue + ".json");
   }
 
   @Test

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClientTest.java
@@ -19,7 +19,7 @@ class CudamiHumanSettlementsClientTest
     client.findOneByIdentifier(identifierNamespace, identifierValue);
 
     verifyHttpRequestByMethodAndRelativeURL(
-        "get", "/identifier?namespace=" + identifierNamespace + "&id=" + identifierValue);
+        "get", "/identifier/" + identifierNamespace + ":" + identifierValue + ".json");
   }
 
   @Test

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
@@ -11,12 +11,12 @@ import de.digitalcollections.model.paging.Sorting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -102,15 +102,14 @@ public class FamilyNameController {
   @GetMapping(
       value = {"/v5/familynames/identifier"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public void getByIdentifier(
+  public ResponseEntity<Void> getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
       @RequestParam(name = "id", required = true) String id,
-      HttpServletRequest request,
-      HttpServletResponse response)
+      HttpServletRequest request)
       throws IdentifiableServiceException {
-    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-    response.setHeader(
-        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    URI newLocation =
+        URI.create(request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(newLocation).build();
   }
 
   @Operation(summary = "save a newly created family")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -58,6 +60,16 @@ public class FamilyNameController {
     return familyNameService.findByLanguageAndInitial(pageRequest, language, initial);
   }
 
+  @Operation(summary = "Get a familyname by namespace and id")
+  @GetMapping(
+      value = {"/v5/familynames/identifier/{namespace}:{id}"},
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<FamilyName> findByIdentifier(
+      @PathVariable String namespace, @PathVariable String id) throws IdentifiableServiceException {
+    FamilyName result = familyNameService.getByIdentifier(namespace, id);
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
   @Operation(summary = "Get a familyname by uuid")
   @GetMapping(
       value = {"/v5/familynames/{uuid}"},
@@ -90,12 +102,15 @@ public class FamilyNameController {
   @GetMapping(
       value = {"/v5/familynames/identifier"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<FamilyName> getByIdentifier(
+  public void getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
-      @RequestParam(name = "id", required = true) String id)
+      @RequestParam(name = "id", required = true) String id,
+      HttpServletRequest request,
+      HttpServletResponse response)
       throws IdentifiableServiceException {
-    FamilyName result = familyNameService.getByIdentifier(namespace, id);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
+    response.setHeader(
+        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
   }
 
   @Operation(summary = "save a newly created family")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -58,6 +60,16 @@ public class GivenNameController {
     return givenNameService.findByLanguageAndInitial(pageRequest, language, initial);
   }
 
+  @Operation(summary = "Get a givenname by namespace and id")
+  @GetMapping(
+      value = {"/v5/givennames/identifier/{namespace}:{id}"},
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<GivenName> findByIdentifier(
+      @PathVariable String namespace, @PathVariable String id) throws IdentifiableServiceException {
+    GivenName result = givenNameService.getByIdentifier(namespace, id);
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
   @Operation(summary = "Get a givenname by uuid")
   @GetMapping(
       value = {"/v5/givennames/{uuid}"},
@@ -90,12 +102,15 @@ public class GivenNameController {
   @GetMapping(
       value = {"/v5/givennames/identifier"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<GivenName> getByIdentifier(
+  public void getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
-      @RequestParam(name = "id", required = true) String id)
+      @RequestParam(name = "id", required = true) String id,
+      HttpServletRequest request,
+      HttpServletResponse response)
       throws IdentifiableServiceException {
-    GivenName result = givenNameService.getByIdentifier(namespace, id);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
+    response.setHeader(
+        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
   }
 
   @Operation(summary = "save a newly created givenname")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
@@ -11,12 +11,12 @@ import de.digitalcollections.model.paging.Sorting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -102,15 +102,14 @@ public class GivenNameController {
   @GetMapping(
       value = {"/v5/givennames/identifier"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public void getByIdentifier(
+  public ResponseEntity<Void> getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
       @RequestParam(name = "id", required = true) String id,
-      HttpServletRequest request,
-      HttpServletResponse response)
+      HttpServletRequest request)
       throws IdentifiableServiceException {
-    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-    response.setHeader(
-        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    URI newLocation =
+        URI.create(request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(newLocation).build();
   }
 
   @Operation(summary = "save a newly created givenname")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
@@ -16,13 +16,13 @@ import de.digitalcollections.model.paging.Sorting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -188,15 +188,14 @@ public class PersonController {
   @GetMapping(
       value = {"/v5/persons/identifier", "/v2/persons/identifier", "/latest/persons/identifier"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public void getByIdentifier(
+  public ResponseEntity<Void> getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
       @RequestParam(name = "id", required = true) String id,
-      HttpServletRequest request,
-      HttpServletResponse response)
+      HttpServletRequest request)
       throws IdentifiableServiceException {
-    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-    response.setHeader(
-        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    URI newLocation =
+        URI.create(request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(newLocation).build();
   }
 
   @Operation(summary = "Get a person's digital objects")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -82,6 +84,20 @@ public class PersonController {
       return personService.find(searchPageRequest);
     }
     return personService.findByLanguageAndInitial(searchPageRequest, language, initial);
+  }
+
+  @Operation(summary = "Get a person by namespace and id")
+  @GetMapping(
+      value = {
+        "/v5/persons/identifier/{namespace}:{id}",
+        "/v2/persons/identifier/{namespace}:{id}",
+        "/latest/persons/identifier/{namespace}:{id}"
+      },
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Person> findByIdentifier(
+      @PathVariable String namespace, @PathVariable String id) throws IdentifiableServiceException {
+    Person result = personService.getByIdentifier(namespace, id);
+    return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
   @Operation(summary = "get all persons born at given geo location")
@@ -172,12 +188,15 @@ public class PersonController {
   @GetMapping(
       value = {"/v5/persons/identifier", "/v2/persons/identifier", "/latest/persons/identifier"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<Person> getByIdentifier(
+  public void getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
-      @RequestParam(name = "id", required = true) String id)
+      @RequestParam(name = "id", required = true) String id,
+      HttpServletRequest request,
+      HttpServletResponse response)
       throws IdentifiableServiceException {
-    Person result = personService.getByIdentifier(namespace, id);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
+    response.setHeader(
+        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
   }
 
   @Operation(summary = "Get a person's digital objects")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
@@ -11,12 +11,12 @@ import de.digitalcollections.model.paging.Sorting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -123,15 +123,14 @@ public class GeoLocationController {
         "/latest/geolocations/identifier"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public void getByIdentifier(
+  public ResponseEntity<Void> getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
       @RequestParam(name = "id", required = true) String id,
-      HttpServletRequest request,
-      HttpServletResponse response)
+      HttpServletRequest request)
       throws IdentifiableServiceException {
-    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-    response.setHeader(
-        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    URI newLocation =
+        URI.create(request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(newLocation).build();
   }
 
   @Operation(summary = "Get languages of all geolocations")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -62,6 +64,20 @@ public class HumanSettlementController {
     return humanSettlementService.findByLanguageAndInitial(pageRequest, language, initial);
   }
 
+  @Operation(summary = "Get a human settlement by namespace and id")
+  @GetMapping(
+      value = {
+        "/v5/humansettlements/identifier/{namespace}:{id}",
+        "/v2/humansettlements/identifier/{namespace}:{id}",
+        "/latest/humansettlements/identifier/{namespace}:{id}"
+      },
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<HumanSettlement> findByIdentifier(
+      @PathVariable String namespace, @PathVariable String id) throws IdentifiableServiceException {
+    HumanSettlement result = humanSettlementService.getByIdentifier(namespace, id);
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
   @Operation(summary = "Get a human settlement by uuid")
   @GetMapping(
       value = {
@@ -102,12 +118,15 @@ public class HumanSettlementController {
         "/latest/humansettlements/identifier"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<HumanSettlement> getByIdentifier(
+  public void getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
-      @RequestParam(name = "id", required = true) String id)
+      @RequestParam(name = "id", required = true) String id,
+      HttpServletRequest request,
+      HttpServletResponse response)
       throws IdentifiableServiceException {
-    HumanSettlement result = humanSettlementService.getByIdentifier(namespace, id);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
+    response.setHeader(
+        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
   }
 
   @Operation(summary = "save a newly created human settlement")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
@@ -11,12 +11,12 @@ import de.digitalcollections.model.paging.Sorting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -118,15 +118,14 @@ public class HumanSettlementController {
         "/latest/humansettlements/identifier"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public void getByIdentifier(
+  public ResponseEntity<Void> getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
       @RequestParam(name = "id", required = true) String id,
-      HttpServletRequest request,
-      HttpServletResponse response)
+      HttpServletRequest request)
       throws IdentifiableServiceException {
-    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-    response.setHeader(
-        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    URI newLocation =
+        URI.create(request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(newLocation).build();
   }
 
   @Operation(summary = "save a newly created human settlement")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
@@ -13,12 +13,12 @@ import de.digitalcollections.model.paging.Sorting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -119,15 +119,14 @@ public class ItemController {
   @GetMapping(
       value = {"/v5/items/identifier", "/v2/items/identifier", "/latest/items/identifier"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public void getByIdentifier(
+  public ResponseEntity<Void> getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
       @RequestParam(name = "id", required = true) String id,
-      HttpServletRequest request,
-      HttpServletResponse response)
+      HttpServletRequest request)
       throws IdentifiableServiceException {
-    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-    response.setHeader(
-        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    URI newLocation =
+        URI.create(request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(newLocation).build();
   }
 
   @Operation(summary = "save a newly created item")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
@@ -13,11 +13,11 @@ import de.digitalcollections.model.paging.Sorting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -126,15 +126,14 @@ public class WorkController {
         "/latest/works/identifier",
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public void getByIdentifier(
+  public ResponseEntity<Void> getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
       @RequestParam(name = "id", required = true) String id,
-      HttpServletRequest request,
-      HttpServletResponse response)
+      HttpServletRequest request)
       throws IdentifiableServiceException {
-    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-    response.setHeader(
-        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    URI newLocation =
+        URI.create(request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
+    return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(newLocation).build();
   }
 
   @Operation(summary = "save a newly created work")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -71,6 +73,20 @@ public class WorkController {
     return workService.findByLanguageAndInitial(pageRequest, language, initial);
   }
 
+  @Operation(summary = "Get a work by namespace and id")
+  @GetMapping(
+      value = {
+        "/v5/works/identifier/{namespace}:{id}",
+        "/v2/works/identifier/{namespace}:{id}",
+        "/latest/works/identifier/{namespace}:{id}",
+      },
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Work> findByIdentifier(
+      @PathVariable String namespace, @PathVariable String id) throws IdentifiableServiceException {
+    Work result = workService.getByIdentifier(namespace, id);
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
   @Operation(summary = "Get a work by uuid")
   @GetMapping(
       value = {
@@ -110,12 +126,15 @@ public class WorkController {
         "/latest/works/identifier",
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<Work> getByIdentifier(
+  public void getByIdentifier(
       @RequestParam(name = "namespace", required = true) String namespace,
-      @RequestParam(name = "id", required = true) String id)
+      @RequestParam(name = "id", required = true) String id,
+      HttpServletRequest request,
+      HttpServletResponse response)
       throws IdentifiableServiceException {
-    Work result = workService.getByIdentifier(namespace, id);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
+    response.setHeader(
+        "Location", request.getRequestURI().concat(String.format("/%s:%s", namespace, id)));
   }
 
   @Operation(summary = "save a newly created work")


### PR DESCRIPTION
This PR changes `/v*/*/identifier?namespace=ns&id=id` to `/v*/*/identifier/ns:id` for some controllers and adds redirects for the old endpoints.