### PR TITLE
Fix update of lastPublished of UrlAlias

### DIFF
--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
@@ -266,9 +266,15 @@ public class UrlAliasServiceImpl implements UrlAliasService {
   protected void checkPublication(UrlAlias urlAlias) throws CudamiServiceException {
     if (urlAlias.getLastPublished() != null) {
       if (urlAlias.getUuid() != null) {
-        // Only the primary flag can change
-        UrlAlias publishedAlias = this.findOne(urlAlias.getUuid());
+        UrlAlias publishedAlias = findOne(urlAlias.getUuid());
+        if (!publishedAlias.isPrimary() && urlAlias.isPrimary()) {
+          // set lastPublished to current date
+          urlAlias.setLastPublished(LocalDateTime.now());
+        }
+        // Only the primary flag and lastPublished are permitted to be changed
+        // so we sync these two objects and compare them
         publishedAlias.setPrimary(urlAlias.isPrimary());
+        publishedAlias.setLastPublished(urlAlias.getLastPublished());
         if (!urlAlias.equals(publishedAlias)) {
           // there are more changes than permitted
           throw new CudamiServiceException(

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
@@ -283,11 +283,9 @@ public class UrlAliasServiceImpl implements UrlAliasService {
                   urlAlias.getUuid()));
         }
       }
-    } else {
+    } else if (urlAlias.isPrimary()) {
       // no publishing date yet
-      if (urlAlias.isPrimary()) {
-        urlAlias.setLastPublished(LocalDateTime.now());
-      }
+      urlAlias.setLastPublished(LocalDateTime.now());
     }
   }
 

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImplTest.java
@@ -590,7 +590,7 @@ class UrlAliasServiceImplTest {
     UrlAlias urlAlias =
         createUrlAlias("hurz", true, "de", false, UUID.randomUUID(), UUID.randomUUID());
     urlAlias.setPrimary(false);
-    LocalDateTime publicationDate = LocalDateTime.now();
+    LocalDateTime publicationDate = LocalDateTime.now().minusDays(1);
     urlAlias.setLastPublished(publicationDate);
     when(repo.findOne(eq(urlAlias.getUuid()))).thenReturn(urlAlias);
 

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImplTest.java
@@ -583,6 +583,50 @@ class UrlAliasServiceImplTest {
         });
   }
 
+  @DisplayName("checkPublication sets lastPublished to now when an alias becomes primary again")
+  @Test
+  public void checkPublicationSetLastPublishedAgain()
+      throws UrlAliasRepositoryException, CudamiServiceException {
+    UrlAlias urlAlias =
+        createUrlAlias("hurz", true, "de", false, UUID.randomUUID(), UUID.randomUUID());
+    urlAlias.setPrimary(false);
+    LocalDateTime publicationDate = LocalDateTime.now();
+    urlAlias.setLastPublished(publicationDate);
+    when(repo.findOne(eq(urlAlias.getUuid()))).thenReturn(urlAlias);
+
+    UrlAlias changedUrlAlias = deepCopy(urlAlias);
+    changedUrlAlias.setPrimary(true);
+
+    assertThat(changedUrlAlias.getLastPublished()).isEqualTo(publicationDate);
+    service.checkPublication(changedUrlAlias);
+    assertThat(changedUrlAlias.getLastPublished()).isNotEqualTo(publicationDate);
+    assertThat(changedUrlAlias.getLastPublished().compareTo(publicationDate))
+        .isEqualTo(1); // =later than publicationDate
+    assertThat(changedUrlAlias.isPrimary()).isTrue();
+  }
+
+  @DisplayName("checkPublication does not set lastPublished primary is set to false")
+  @Test
+  public void checkPublicationLastPublishedNotSet()
+      throws UrlAliasRepositoryException, CudamiServiceException {
+    UrlAlias urlAlias =
+        createUrlAlias("hurz", true, "de", false, UUID.randomUUID(), UUID.randomUUID());
+    urlAlias.setPrimary(true);
+    LocalDateTime publicationDate = LocalDateTime.now();
+    urlAlias.setLastPublished(publicationDate);
+    when(repo.findOne(eq(urlAlias.getUuid()))).thenReturn(urlAlias);
+
+    UrlAlias changedUrlAlias = deepCopy(urlAlias);
+    changedUrlAlias.setPrimary(false);
+
+    assertThat(changedUrlAlias.getLastPublished()).isEqualTo(publicationDate);
+    service.checkPublication(changedUrlAlias);
+    assertThat(changedUrlAlias.getLastPublished()).isEqualTo(publicationDate);
+    assertThat(changedUrlAlias.getLastPublished().compareTo(publicationDate))
+        .isEqualTo(0); // =equal
+    assertThat(changedUrlAlias.isPrimary()).isFalse();
+  }
+
   @DisplayName("can successfully validate an empty LocalizedUrlAlias")
   @Test
   public void allowEmptyLocalizedUrlAlias() throws ValidationException {
@@ -798,6 +842,7 @@ class UrlAliasServiceImplTest {
     copy.setSlug(urlAlias.getSlug());
     copy.setTargetIdentifiableType(urlAlias.getTargetIdentifiableType());
     copy.setTargetEntityType(urlAlias.getTargetEntityType());
+    copy.setTargetUuid(urlAlias.getTargetUuid());
     return copy;
   }
 }


### PR DESCRIPTION
When an UrlAlias becomes `primary` then `lastPublished` must be set to current timestamp. Some small tests were added as well.  

Ticket: mdz/webapps/internal/cudami/-/issues/239