### PR TITLE
Add usage of excludes for generated URL aliases in frontend

### DIFF
--- a/dc-cudami-admin/pom.xml
+++ b/dc-cudami-admin/pom.xml
@@ -63,6 +63,10 @@
       <artifactId>dc-cudami-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>de.digitalcollections.cudami</groupId>
+      <artifactId>dc-cudami-model</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.digitalcollections.model</groupId>
       <artifactId>dc-model</artifactId>
     </dependency>

--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/ConfigController.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/ConfigController.java
@@ -16,7 +16,7 @@ public class ConfigController {
   }
 
   @GetMapping("/api/config")
-  public CudamiConfig getLanguages() throws HttpException {
+  public CudamiConfig getConfig() throws HttpException {
     return service.getConfig();
   }
 }

--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/ConfigController.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/ConfigController.java
@@ -1,0 +1,22 @@
+package de.digitalcollections.cudami.admin.controller;
+
+import de.digitalcollections.cudami.client.CudamiClient;
+import de.digitalcollections.cudami.client.config.CudamiConfigClient;
+import de.digitalcollections.cudami.client.exceptions.HttpException;
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ConfigController {
+  private final CudamiConfigClient service;
+
+  public ConfigController(CudamiClient cudamiClient) {
+    this.service = cudamiClient.forConfig();
+  }
+
+  @GetMapping("/api/config")
+  public CudamiConfig getLanguages() throws HttpException {
+    return service.getConfig();
+  }
+}

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
@@ -127,6 +127,10 @@ public class CudamiClient {
     return cudamiCollectionsClient;
   }
 
+  public CudamiConfigClient forConfig() {
+    return cudamiConfigClient;
+  }
+
   public CudamiCorporateBodiesClient forCorporateBodies() {
     return cudamiCorporateBodiesClient;
   }

--- a/dc-cudami-editor/src/api.js
+++ b/dc-cudami-editor/src/api.js
@@ -1,6 +1,7 @@
 export const typeToEndpointMapping = {
   article: 'articles',
   collection: 'collections',
+  config: 'config',
   corporateBody: 'corporatebodies',
   digitalObject: 'digitalobjects',
   entity: 'entities',
@@ -102,6 +103,17 @@ export async function generateSlug(contextPath, language, slug, websiteUuid) {
     return await response.json()
   } catch (err) {
     return slug
+  }
+}
+
+export async function getConfig(contextPath) {
+  const url = `${contextPath}api/${typeToEndpointMapping.config}`
+  try {
+    const response = await fetch(url)
+    const json = await response.json()
+    return json
+  } catch (err) {
+    return {}
   }
 }
 


### PR DESCRIPTION
This PR ensures that the generated URL aliases will only be created if the `entityType` of the identifiable is not included in the list of excludes.