### PR TITLE
Fixed find method to use base url instead of search endpoint

### DIFF
--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClient.java
@@ -2,12 +2,21 @@ package de.digitalcollections.cudami.client.identifiable.entity.geo.location;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.identifiable.entity.CudamiEntitiesClient;
+import de.digitalcollections.model.exception.TechnicalException;
 import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
+import de.digitalcollections.model.paging.SearchPageRequest;
+import de.digitalcollections.model.paging.SearchPageResponse;
 import java.net.http.HttpClient;
 
 public class CudamiHumanSettlementsClient extends CudamiEntitiesClient<HumanSettlement> {
 
   public CudamiHumanSettlementsClient(HttpClient http, String serverUrl, ObjectMapper mapper) {
     super(http, serverUrl, HumanSettlement.class, mapper, "/v5/humansettlements");
+  }
+
+  @Override
+  public SearchPageResponse<HumanSettlement> find(SearchPageRequest searchPageRequest)
+      throws TechnicalException {
+    return doGetSearchRequestForPagedObjectList(baseEndpoint, searchPageRequest);
   }
 }

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/entity/geo/location/CudamiHumanSettlementsClientTest.java
@@ -1,9 +1,43 @@
 package de.digitalcollections.cudami.client.identifiable.entity.geo.location;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import de.digitalcollections.cudami.client.identifiable.entity.BaseCudamiEntitiesClientTest;
 import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
+import de.digitalcollections.model.paging.SearchPageRequest;
+import de.digitalcollections.model.paging.SearchPageResponse;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 @DisplayName("The client for HumanSettlements")
 class CudamiHumanSettlementsClientTest
-    extends BaseCudamiEntitiesClientTest<HumanSettlement, CudamiHumanSettlementsClient> {}
+    extends BaseCudamiEntitiesClientTest<HumanSettlement, CudamiHumanSettlementsClient> {
+
+  @Test
+  @DisplayName("can execute the find method with a SearchPageRequest")
+  @Override
+  public void testFindWithSearchPageRequest() throws Exception {
+    String bodyJson = "{}";
+    when(httpResponse.body()).thenReturn(bodyJson.getBytes(StandardCharsets.UTF_8));
+
+    SearchPageRequest searchPageRequest = new SearchPageRequest();
+    SearchPageResponse<HumanSettlement> response = client.find(searchPageRequest);
+    assertThat(response).isNotNull();
+
+    verifyHttpRequestByMethodAndRelativeURL("get", "?pageNumber=0&pageSize=0");
+  }
+
+  @Test
+  @DisplayName("can execute the find method with a search term and max results")
+  @Override
+  public void testFindWithSearchTermAndMaxResults() throws Exception {
+    String bodyJson = "{\"content\":[]}";
+    when(httpResponse.body()).thenReturn(bodyJson.getBytes(StandardCharsets.UTF_8));
+
+    assertThat(client.find("foo", 100)).isNotNull();
+
+    verifyHttpRequestByMethodAndRelativeURL("get", "?pageNumber=0&pageSize=100&searchTerm=foo");
+  }
+}


### PR DESCRIPTION
Fix `find` method in `CudamiHumanSettlementsClient` to use the base endpoint and not `/search`