### PR TITLE
Refactor digitalobject dependencies

### DIFF
--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiDigitalObjectsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiDigitalObjectsClient.java
@@ -2,7 +2,13 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.exception.TechnicalException;
+<<<<<<< HEAD
 import de.digitalcollections.model.filter.Filtering;
+=======
+import de.digitalcollections.model.filter.FilterCriterion;
+import de.digitalcollections.model.filter.FilterOperation;
+import de.digitalcollections.model.filter.FilteringBuilder;
+>>>>>>> Version dependency downgrade
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.Project;

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiDigitalObjectsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiDigitalObjectsClient.java
@@ -2,13 +2,7 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.exception.TechnicalException;
-<<<<<<< HEAD
 import de.digitalcollections.model.filter.Filtering;
-=======
-import de.digitalcollections.model.filter.FilterCriterion;
-import de.digitalcollections.model.filter.FilterOperation;
-import de.digitalcollections.model.filter.FilteringBuilder;
->>>>>>> Version dependency downgrade
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.Project;

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/DigitalObjectRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/DigitalObjectRepository.java
@@ -6,7 +6,6 @@ import de.digitalcollections.model.identifiable.entity.Project;
 import de.digitalcollections.model.identifiable.entity.work.Item;
 import de.digitalcollections.model.identifiable.resource.FileResource;
 import de.digitalcollections.model.identifiable.resource.ImageFileResource;
-import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
 import de.digitalcollections.model.paging.SearchPageRequest;
 import de.digitalcollections.model.paging.SearchPageResponse;
 import java.util.List;
@@ -37,12 +36,6 @@ public interface DigitalObjectRepository extends EntityRepository<DigitalObject>
   }
 
   List<ImageFileResource> getImageFileResources(UUID digitalObjectUuid);
-
-  default List<LinkedDataFileResource> getLinkedDataFileResources(DigitalObject digitalObject) {
-    return getLinkedDataFileResources(digitalObject.getUuid());
-  }
-
-  List<LinkedDataFileResource> getLinkedDataFileResources(UUID digitalObjectUuid);
 
   default List<FileResource> getRenderingFileResources(DigitalObject digitalObject) {
     return getRenderingFileResources(digitalObject.getUuid());
@@ -91,16 +84,4 @@ public interface DigitalObjectRepository extends EntityRepository<DigitalObject>
 
   List<FileResource> saveRenderingResources(
       UUID digitalObjectUuid, List<FileResource> renderingResources);
-
-  default List<LinkedDataFileResource> saveLinkedDataFileResources(
-      DigitalObject digitalObject, List<LinkedDataFileResource> linkedDataFileResources) {
-    if (linkedDataFileResources == null) {
-      return null;
-    }
-
-    return saveLinkedDataFileResources(digitalObject.getUuid(), linkedDataFileResources);
-  }
-
-  List<LinkedDataFileResource> saveLinkedDataFileResources(
-      UUID digitalObjectUuid, List<LinkedDataFileResource> linkedDataFileResources);
 }

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/DigitalObjectRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/DigitalObjectRepository.java
@@ -37,12 +37,6 @@ public interface DigitalObjectRepository extends EntityRepository<DigitalObject>
 
   List<ImageFileResource> getImageFileResources(UUID digitalObjectUuid);
 
-  default List<FileResource> getRenderingFileResources(DigitalObject digitalObject) {
-    return getRenderingFileResources(digitalObject.getUuid());
-  }
-
-  List<FileResource> getRenderingFileResources(UUID digitalObjectUuid);
-
   default Item getItem(DigitalObject digitalObject) {
     if (digitalObject == null) {
       return null;
@@ -73,15 +67,4 @@ public interface DigitalObjectRepository extends EntityRepository<DigitalObject>
   }
 
   List<FileResource> saveFileResources(UUID digitalObjectUuid, List<FileResource> fileResources);
-
-  default List<FileResource> saveRenderingResources(
-      DigitalObject digitalObject, List<FileResource> renderingResources) {
-    if (renderingResources == null) {
-      return null;
-    }
-    return saveRenderingResources(digitalObject.getUuid(), renderingResources);
-  }
-
-  List<FileResource> saveRenderingResources(
-      UUID digitalObjectUuid, List<FileResource> renderingResources);
 }

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/DigitalObjectRenderingFileResourceRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/DigitalObjectRenderingFileResourceRepository.java
@@ -14,13 +14,8 @@ public interface DigitalObjectRenderingFileResourceRepository {
    */
   List<FileResource> getForDigitalObjectUuid(UUID digitalObjectUuid);
 
-  /**
-   * Save the list of rendering FileResources for a DigitalObject, identified by its UUID
-   *
-   * @param digitalObjectUuid the UUID of the DigitalObject
-   * @param renderingResources the rendering FileResources
-   * @return list of rendering FileResources
-   */
-  List<FileResource> saveForDigitalObjectUuid(
+  public void deleteRelatedRenderingResourcesForDigitalObjectUuid(UUID digitalObjectUuid);
+
+  public void saveRelatedRenderingResourcesForDigitalObjectUuid(
       UUID digitalObjectUuid, List<FileResource> renderingResources);
 }

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/DigitalObjectRenderingFileResourceRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/DigitalObjectRenderingFileResourceRepository.java
@@ -1,0 +1,26 @@
+package de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource;
+
+import de.digitalcollections.model.identifiable.resource.FileResource;
+import java.util.List;
+import java.util.UUID;
+
+public interface DigitalObjectRenderingFileResourceRepository {
+
+  /**
+   * Retrieve the list of rendering FileResources for a DigitalObject, identified by its UUID
+   *
+   * @param digitalObjectUuid the UUID of the DigitalObject
+   * @return list of rendering FileResources
+   */
+  List<FileResource> getForDigitalObjectUuid(UUID digitalObjectUuid);
+
+  /**
+   * Save the list of rendering FileResources for a DigitalObject, identified by its UUID
+   *
+   * @param digitalObjectUuid the UUID of the DigitalObject
+   * @param renderingResources the rendering FileResources
+   * @return list of rendering FileResources
+   */
+  List<FileResource> saveForDigitalObjectUuid(
+      UUID digitalObjectUuid, List<FileResource> renderingResources);
+}

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/DigitalObjectRenderingFileResourceRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/DigitalObjectRenderingFileResourceRepository.java
@@ -12,10 +12,9 @@ public interface DigitalObjectRenderingFileResourceRepository {
    * @param digitalObjectUuid the UUID of the DigitalObject
    * @return list of rendering FileResources
    */
-  List<FileResource> getForDigitalObjectUuid(UUID digitalObjectUuid);
+  List<FileResource> findByDigitalObject(UUID digitalObjectUuid);
 
-  public void deleteRelatedRenderingResourcesForDigitalObjectUuid(UUID digitalObjectUuid);
+  public void removeByDigitalObject(UUID digitalObjectUuid);
 
-  public void saveRelatedRenderingResourcesForDigitalObjectUuid(
-      UUID digitalObjectUuid, List<FileResource> renderingResources);
+  public void saveForDigitalObject(UUID digitalObjectUuid, List<FileResource> renderingResources);
 }

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/LinkedDataFileResourceRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/resource/LinkedDataFileResourceRepository.java
@@ -1,7 +1,29 @@
 package de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource;
 
 import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
+import java.util.List;
+import java.util.UUID;
 
 /** Repository for LinkedDataFileResource persistence handling. */
 public interface LinkedDataFileResourceRepository
-    extends FileResourceMetadataRepository<LinkedDataFileResource> {}
+    extends FileResourceMetadataRepository<LinkedDataFileResource> {
+
+  /**
+   * Retrieve all LinkedDataFileResources for a DigitalObject, identified by its UUID
+   *
+   * @param digitalObjectUuid the UUID of the DigitalObject
+   * @return List of LinkedDataFileResources
+   */
+  List<LinkedDataFileResource> getLinkedDataFileResourcesForDigitalObjectUuid(
+      UUID digitalObjectUuid);
+
+  /**
+   * Save all LinkedDataFileResources for a DigitalObject, identified by its UUID
+   *
+   * @param digitalObjectUuid the UUID of the DigitalObject
+   * @param linkedDataFileResources List of LinkedDataFileResource to persist
+   * @return
+   */
+  List<LinkedDataFileResource> saveLinkedDataFileResources(
+      UUID digitalObjectUuid, List<LinkedDataFileResource> linkedDataFileResources);
+}

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -480,8 +480,6 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
       return;
     }
 
-    UUID uuid = digitalObject.getUuid();
-
     // Fill the previewImage
     UUID previewImageUuid =
         digitalObject.getPreviewImage() != null ? digitalObject.getPreviewImage().getUuid() : null;

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -38,7 +38,6 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.core.mapper.reflect.BeanMapper;
 import org.jdbi.v3.core.result.RowView;
 import org.jdbi.v3.core.statement.PreparedBatch;
 import org.slf4j.Logger;

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -196,7 +196,6 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
         SQL_SELECT_ALL_FIELDS_JOINS,
         createAdditionalReduceRowsBiFunction(),
         cudamiConfig.getOffsetForAlternativePaging());
-    dbi.registerRowMapper(BeanMapper.factory(License.class, LicenseRepositoryImpl.MAPPING_PREFIX));
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/DigitalObjectRenderingFileResourceRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/DigitalObjectRenderingFileResourceRepositoryImpl.java
@@ -1,0 +1,85 @@
+package de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable.resource;
+
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.DigitalObjectRenderingFileResourceRepository;
+import de.digitalcollections.model.identifiable.resource.FileResource;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.PreparedBatch;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DigitalObjectRenderingFileResourceRepositoryImpl
+    extends FileResourceMetadataRepositoryImpl<FileResource>
+    implements DigitalObjectRenderingFileResourceRepository {
+
+  public DigitalObjectRenderingFileResourceRepositoryImpl(Jdbi dbi, CudamiConfig cudamiConfig) {
+    super(dbi, cudamiConfig);
+  }
+
+  @Override
+  public List<FileResource> getForDigitalObjectUuid(UUID digitalObjectUuid) {
+    final String rfrTableAlias = getTableAlias();
+    final String rfrTableName = getTableName();
+    final String fieldsSql = getSqlSelectAllFields();
+    StringBuilder innerQuery =
+        new StringBuilder(
+            "SELECT dr.sortindex as idx, * FROM "
+                + rfrTableName
+                + " AS "
+                + rfrTableAlias
+                + " INNER JOIN digitalobject_renderingresources AS dr ON "
+                + rfrTableAlias
+                + ".uuid = dr.fileresource_uuid"
+                + " WHERE dr.digitalobject_uuid = :uuid"
+                + " ORDER by idx ASC");
+    Map<String, Object> argumentMappings = new HashMap<>();
+    argumentMappings.put("uuid", digitalObjectUuid);
+
+    List<FileResource> fileResources =
+        retrieveList(fieldsSql, innerQuery, argumentMappings, "ORDER BY idx ASC");
+
+    return fileResources;
+  }
+
+  @Override
+  public List<FileResource> saveForDigitalObjectUuid(
+      UUID digitalObjectUuid, List<FileResource> renderingResources) {
+    // as we store the whole list new: delete old entries
+    dbi.withHandle(
+        h ->
+            h.createUpdate(
+                    "DELETE FROM digitalobject_renderingresources WHERE digitalobject_uuid = :uuid")
+                .bind("uuid", digitalObjectUuid)
+                .execute());
+
+    if (renderingResources != null) {
+      // first save rendering resources
+      for (FileResource renderingResource : renderingResources) {
+        if (renderingResource.getUuid() == null) {
+          save(renderingResource);
+        }
+      }
+
+      // second: save relations to digital object
+      dbi.useHandle(
+          handle -> {
+            PreparedBatch preparedBatch =
+                handle.prepareBatch(
+                    "INSERT INTO digitalobject_renderingresources(digitalobject_uuid, fileresource_uuid, sortIndex) VALUES(:uuid, :fileResourceUuid, :sortIndex)");
+            for (FileResource renderingResource : renderingResources) {
+              preparedBatch
+                  .bind("uuid", digitalObjectUuid)
+                  .bind("fileResourceUuid", renderingResource.getUuid())
+                  .bind("sortIndex", getIndex(renderingResources, renderingResource))
+                  .add();
+            }
+            preparedBatch.execute();
+          });
+    }
+    return getForDigitalObjectUuid(digitalObjectUuid);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/DigitalObjectRenderingFileResourceRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/DigitalObjectRenderingFileResourceRepositoryImpl.java
@@ -39,7 +39,7 @@ public class DigitalObjectRenderingFileResourceRepositoryImpl
                 + rfrTableAlias
                 + ".uuid = dr.fileresource_uuid"
                 + " WHERE dr.digitalobject_uuid = :uuid"
-                + " ORDER by idx ASC");
+                + " ORDER by dr.sortindex ASC");
     Map<String, Object> argumentMappings = new HashMap<>();
     argumentMappings.put("uuid", digitalObjectUuid);
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/DigitalObjectRenderingFileResourceRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/DigitalObjectRenderingFileResourceRepositoryImpl.java
@@ -25,7 +25,7 @@ public class DigitalObjectRenderingFileResourceRepositoryImpl
   }
 
   @Override
-  public List<FileResource> getForDigitalObjectUuid(UUID digitalObjectUuid) {
+  public List<FileResource> findByDigitalObject(UUID digitalObjectUuid) {
     final String rfrTableAlias = getTableAlias();
     final String rfrTableName = getTableName();
     final String fieldsSql = getSqlSelectAllFields();
@@ -52,7 +52,7 @@ public class DigitalObjectRenderingFileResourceRepositoryImpl
   }
 
   @Override
-  public void deleteRelatedRenderingResourcesForDigitalObjectUuid(UUID digitalObjectUuid) {
+  public void removeByDigitalObject(UUID digitalObjectUuid) {
     dbi.withHandle(
         h ->
             h.createUpdate(
@@ -62,8 +62,7 @@ public class DigitalObjectRenderingFileResourceRepositoryImpl
   }
 
   @Override
-  public void saveRelatedRenderingResourcesForDigitalObjectUuid(
-      UUID digitalObjectUuid, List<FileResource> renderingResources) {
+  public void saveForDigitalObject(UUID digitalObjectUuid, List<FileResource> renderingResources) {
     dbi.useHandle(
         handle -> {
           PreparedBatch preparedBatch =
@@ -96,6 +95,7 @@ public class DigitalObjectRenderingFileResourceRepositoryImpl
         break;
       case "video":
         untypedFileResource.setFileResourceType(FileResourceType.VIDEO);
+        break;
       default:
         // nop
     }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
@@ -7,7 +7,11 @@ import de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable.Search
 import de.digitalcollections.model.identifiable.resource.FileResource;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiFunction;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.result.RowView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -110,6 +114,35 @@ public class FileResourceMetadataRepositoryImpl<F extends FileResource>
         sqlInsertFields,
         sqlInsertValues,
         sqlUpdateFieldValues,
+        offsetForAlternativePaging);
+  }
+
+  protected FileResourceMetadataRepositoryImpl(
+      Jdbi dbi,
+      String tableName,
+      String tableAlias,
+      String mappingPrefix,
+      String sqlSelectAllFields,
+      String sqlSelectReducedFields,
+      String sqlInsertFields,
+      String sqlInsertValues,
+      String sqlUpdateFieldValues,
+      String sqlSelectAllFieldsJoins,
+      BiFunction<Map<UUID, F>, RowView, Map<UUID, F>> additionalReduceRowsBiFunction,
+      int offsetForAlternativePaging) {
+    super(
+        dbi,
+        tableName,
+        tableAlias,
+        mappingPrefix,
+        FileResource.class,
+        sqlSelectAllFields,
+        sqlSelectReducedFields,
+        sqlInsertFields,
+        sqlInsertValues,
+        sqlUpdateFieldValues,
+        sqlSelectAllFieldsJoins,
+        additionalReduceRowsBiFunction,
         offsetForAlternativePaging);
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/LinkedDataFileResourceRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/LinkedDataFileResourceRepositoryImpl.java
@@ -115,7 +115,7 @@ public class LinkedDataFileResourceRepositoryImpl
                 + ldfrTableAlias
                 + ".uuid = dl.linkeddata_fileresource_uuid"
                 + " WHERE dl.digitalobject_uuid = :uuid"
-                + " ORDER by idx ASC");
+                + " ORDER by dl.sortindex ASC");
     Map<String, Object> argumentMappings = new HashMap<>();
     argumentMappings.put("uuid", digitalObjectUuid);
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImplTest.java
@@ -126,7 +126,7 @@ class DigitalObjectRepositoryImplTest {
   }
 
   @Test
-  @DisplayName("can save and retrieve a DigitalObject with all of its embedded resources")
+  @DisplayName("can save and retrieve a DigitalObject with all of its directly embedded resources")
   void saveDigitalObject() {
     // Insert a license with uuid
     ensureLicense(EXISTING_LICENSE);
@@ -151,19 +151,6 @@ class DigitalObjectRepositoryImplTest {
     GeoLocationRepositoryImpl geoLocationRepository =
         new GeoLocationRepositoryImpl(jdbi, cudamiConfig);
     geoLocationRepository.save(creationPlace);
-
-    // Insert a LinkedDataFileResource
-    LinkedDataFileResource linkedDataFileResource =
-        new LinkedDataFileResourceBuilder()
-            .withUuid(UUID.randomUUID())
-            .withLabel(Locale.GERMAN, "Linked Data")
-            .withContext("https://foo.bar/blubb.xml")
-            .withObjectType("XML")
-            .withFilename("blubb.xml") // required!!
-            .withMimeType(MimeType.MIME_APPLICATION_XML)
-            .build();
-
-    linkedDataFileResourceRepository.save(linkedDataFileResource);
 
     // Insert a rendering FileResource
     FileResource renderingResource = new FileResource();
@@ -195,7 +182,6 @@ class DigitalObjectRepositoryImplTest {
             .withDescription(Locale.ENGLISH, "description")
             .withLicense(EXISTING_LICENSE)
             .withCreationInfo(creationInfo)
-            .withLinkedDataFileResource(linkedDataFileResource)
             .withRenderingResource(renderingResource)
             .withParent(parent)
             .build();
@@ -215,9 +201,6 @@ class DigitalObjectRepositoryImplTest {
     assertThat(actual.getCreationInfo().getDate().format(DateTimeFormatter.ISO_DATE))
         .isEqualTo("2022-02-25");
     assertThat(actual.getCreationInfo().getGeoLocation()).isEqualTo(creationPlace);
-
-    assertThat(actual.getLinkedDataResources()).hasSize(1);
-    assertThat(actual.getLinkedDataResources().get(0)).isEqualTo(linkedDataFileResource);
 
     assertThat(actual.getRenderingResources()).hasSize(1);
     assertThat(actual.getRenderingResources().get(0)).isEqualTo(renderingResource);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImplTest.java
@@ -126,7 +126,7 @@ class DigitalObjectRepositoryImplTest {
   }
 
   @Test
-  @DisplayName("can save and retrieve a DigitalObject with all of its directly embedded resources")
+  @DisplayName("can save and retrieve a DigitalObject with its directly embedded resources")
   void saveDigitalObject() {
     // Insert a license with uuid
     ensureLicense(EXISTING_LICENSE);
@@ -152,17 +152,6 @@ class DigitalObjectRepositoryImplTest {
         new GeoLocationRepositoryImpl(jdbi, cudamiConfig);
     geoLocationRepository.save(creationPlace);
 
-    // Insert a rendering FileResource
-    FileResource renderingResource = new FileResource();
-    renderingResource.setUri(URI.create("https://bla.bla/foo.jpg"));
-    renderingResource.setMimeType(MimeType.MIME_IMAGE);
-    renderingResource.setUuid(UUID.randomUUID());
-    renderingResource.setFilename("foo.jpg");
-    renderingResource.setLabel(new LocalizedText(Locale.GERMAN, "Zeichnung"));
-    FileResourceMetadataRepositoryImpl<FileResource> fileResourceMetadataRepository =
-        new FileResourceMetadataRepositoryImpl<FileResource>(jdbi, cudamiConfig);
-    fileResourceMetadataRepository.save(renderingResource);
-
     // Build a CreationInfo object with the formerly persisted contents
     CreationInfo creationInfo =
         new CreationInfoBuilder()
@@ -182,7 +171,6 @@ class DigitalObjectRepositoryImplTest {
             .withDescription(Locale.ENGLISH, "description")
             .withLicense(EXISTING_LICENSE)
             .withCreationInfo(creationInfo)
-            .withRenderingResource(renderingResource)
             .withParent(parent)
             .build();
 
@@ -201,9 +189,6 @@ class DigitalObjectRepositoryImplTest {
     assertThat(actual.getCreationInfo().getDate().format(DateTimeFormatter.ISO_DATE))
         .isEqualTo("2022-02-25");
     assertThat(actual.getCreationInfo().getGeoLocation()).isEqualTo(creationPlace);
-
-    assertThat(actual.getRenderingResources()).hasSize(1);
-    assertThat(actual.getRenderingResources().get(0)).isEqualTo(renderingResource);
 
     assertThat(actual.getParent()).isNotNull();
     assertThat(actual.getParent().getUuid()).isEqualTo(parent.getUuid());
@@ -322,7 +307,7 @@ class DigitalObjectRepositoryImplTest {
   }
 
   @Test
-  @DisplayName("returns the fully filled DigitalObject by getByIdentifer")
+  @DisplayName("returns the partially filled DigitalObject by getByIdentifer")
   void returnGetByIdentifier() {
     DigitalObject digitalObject = buildDigitalObject();
     digitalObject = repo.save(digitalObject);
@@ -334,8 +319,6 @@ class DigitalObjectRepositoryImplTest {
     assertThat(actualCreationInfo).isNotNull();
     assertThat(actualCreationInfo.getCreator().getLabel().getText(Locale.GERMAN))
         .isEqualTo("Körperschaft");
-    assertThat(actual.getLinkedDataResources()).isNotEmpty();
-    assertThat(actual.getRenderingResources()).isNotEmpty();
     assertThat(actual.getParent()).isNotNull();
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/CorporateBodyRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/CorporateBodyRepositoryImplTest.java
@@ -1,0 +1,77 @@
+package de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable.entity.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import de.digitalcollections.cudami.server.backend.impl.database.config.SpringConfigBackendDatabase;
+import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
+import de.digitalcollections.model.identifiable.entity.agent.CorporateBodyBuilder;
+import java.util.Locale;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    webEnvironment = WebEnvironment.MOCK,
+    classes = {CorporateBodyRepositoryImpl.class})
+@ContextConfiguration(classes = SpringConfigBackendDatabase.class)
+@Sql(scripts = "classpath:cleanup_database.sql")
+@DisplayName("The CorporateBody Repository")
+class CorporateBodyRepositoryImplTest {
+
+  CorporateBodyRepositoryImpl repo;
+
+  @Autowired CudamiConfig cudamiConfig;
+
+  @Autowired PostgreSQLContainer postgreSQLContainer;
+  @Autowired Jdbi jdbi;
+
+  @BeforeEach
+  public void beforeEach() {
+    repo = new CorporateBodyRepositoryImpl(jdbi, cudamiConfig);
+  }
+
+  @Test
+  @DisplayName("can save a CorporateBody")
+  public void saveCorporateBody() {
+    CorporateBody creator =
+        new CorporateBodyBuilder()
+            .withLabel(Locale.GERMAN, "Körperschaft")
+            .withLabel(Locale.ENGLISH, "Corporate Body")
+            .build();
+
+    CorporateBodyRepositoryImpl corporateBodyRepository =
+        new CorporateBodyRepositoryImpl(jdbi, cudamiConfig);
+    CorporateBody actual = corporateBodyRepository.save(creator);
+
+    assertThat(actual.getUuid()).isNotNull();
+    assertThat(actual.getLabel().getLocales()).containsExactly(Locale.GERMAN, Locale.ENGLISH);
+  }
+
+  @Test
+  @DisplayName("can retrieve a CorporateBody")
+  public void saveAndRetrieveCorporateBody() {
+    CorporateBody creator =
+        new CorporateBodyBuilder()
+            .withLabel(Locale.GERMAN, "Körperschaft")
+            .withLabel(Locale.ENGLISH, "Corporate Body")
+            .build();
+
+    CorporateBodyRepositoryImpl corporateBodyRepository =
+        new CorporateBodyRepositoryImpl(jdbi, cudamiConfig);
+    CorporateBody persisted = corporateBodyRepository.save(creator);
+
+    CorporateBody actual = corporateBodyRepository.getByUuid(persisted.getUuid());
+    assertThat(actual).isEqualTo(persisted);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/LinkedDataFileResourceRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/LinkedDataFileResourceRepositoryImplTest.java
@@ -1,0 +1,113 @@
+package de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import de.digitalcollections.cudami.server.backend.impl.database.config.SpringConfigBackendDatabase;
+import de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable.entity.DigitalObjectRepositoryImpl;
+import de.digitalcollections.model.file.MimeType;
+import de.digitalcollections.model.identifiable.entity.DigitalObject;
+import de.digitalcollections.model.identifiable.entity.DigitalObjectBuilder;
+import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
+import de.digitalcollections.model.identifiable.resource.LinkedDataFileResourceBuilder;
+import java.util.List;
+import java.util.Locale;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    webEnvironment = WebEnvironment.MOCK,
+    classes = {LinkedDataFileResourceRepositoryImpl.class})
+@ContextConfiguration(classes = SpringConfigBackendDatabase.class)
+@Sql(scripts = "classpath:cleanup_database.sql")
+@DisplayName("The LinkedDataFileResource Repository")
+class LinkedDataFileResourceRepositoryImplTest {
+
+  LinkedDataFileResourceRepositoryImpl repo;
+
+  @Autowired CudamiConfig cudamiConfig;
+
+  @Autowired PostgreSQLContainer postgreSQLContainer;
+
+  @Autowired private DigitalObjectRepositoryImpl digitalObjectRepository;
+
+  @Autowired Jdbi jdbi;
+
+  @BeforeEach
+  public void beforeEach() {
+    repo = new LinkedDataFileResourceRepositoryImpl(jdbi, cudamiConfig);
+  }
+
+  @DisplayName("can save LinkedDataFileResources for a DigitalObject")
+  @Test
+  void saveLinkedDataFileResourceForDigitalObject() {
+    // Persist the DigitalObject
+    DigitalObject digitalObject =
+        new DigitalObjectBuilder()
+            .withLabel(Locale.GERMAN, "deutschsprachiges Label")
+            .withLabel(Locale.ENGLISH, "english label")
+            .withDescription(Locale.GERMAN, "Beschreibung")
+            .withDescription(Locale.ENGLISH, "description")
+            .build();
+    digitalObject = digitalObjectRepository.save(digitalObject);
+
+    // Try to persist the LinkedDataFileResource
+    LinkedDataFileResource linkedDataFileResource =
+        new LinkedDataFileResourceBuilder()
+            .withLabel(Locale.GERMAN, "Linked Data")
+            .withContext("https://foo.bar/blubb.xml")
+            .withObjectType("XML")
+            .withFilename("blubb.xml") // required!!
+            .withMimeType(MimeType.MIME_APPLICATION_XML)
+            .build();
+
+    List<LinkedDataFileResource> actual =
+        repo.saveLinkedDataFileResources(digitalObject.getUuid(), List.of(linkedDataFileResource));
+
+    assertThat(actual).hasSize(1);
+    assertThat(actual.get(0).getUuid()).isNotNull();
+  }
+
+  @DisplayName("can retrieve LinkedDataFileResources for a DigitalObject")
+  @Test
+  void retrieveLinkedDataFileResourcesForDigitalObject() {
+    // Persist the DigitalObject
+    DigitalObject digitalObject =
+        new DigitalObjectBuilder()
+            .withLabel(Locale.GERMAN, "deutschsprachiges Label")
+            .withLabel(Locale.ENGLISH, "english label")
+            .withDescription(Locale.GERMAN, "Beschreibung")
+            .withDescription(Locale.ENGLISH, "description")
+            .build();
+    digitalObject = digitalObjectRepository.save(digitalObject);
+
+    // Try to persist the LinkedDataFileResource
+    LinkedDataFileResource linkedDataFileResource =
+        new LinkedDataFileResourceBuilder()
+            .withLabel(Locale.GERMAN, "Linked Data")
+            .withContext("https://foo.bar/blubb.xml")
+            .withObjectType("XML")
+            .withFilename("blubb.xml") // required!!
+            .withMimeType(MimeType.MIME_APPLICATION_XML)
+            .build();
+    List<LinkedDataFileResource> persisted =
+        repo.saveLinkedDataFileResources(digitalObject.getUuid(), List.of(linkedDataFileResource));
+
+    List<LinkedDataFileResource> actual =
+        repo.getLinkedDataFileResourcesForDigitalObjectUuid(digitalObject.getUuid());
+
+    assertThat(actual).isNotEmpty();
+    assertThat(actual).isEqualTo(persisted);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/DigitalObjectService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/DigitalObjectService.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.server.business.api.service.identifiable.entity;
 
+import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.Project;
@@ -47,11 +48,12 @@ public interface DigitalObjectService extends EntityService<DigitalObject> {
 
   List<LinkedDataFileResource> getLinkedDataFileResources(UUID digitalObjectUuid);
 
-  default List<FileResource> getRenderingResources(DigitalObject digitalObject) {
+  default List<FileResource> getRenderingResources(DigitalObject digitalObject)
+      throws CudamiServiceException {
     return getRenderingResources(digitalObject.getUuid());
   }
 
-  List<FileResource> getRenderingResources(UUID digitalObjectUuid);
+  List<FileResource> getRenderingResources(UUID digitalObjectUuid) throws CudamiServiceException;
 
   default Item getItem(DigitalObject digitalObject) {
     if (digitalObject == null) {
@@ -85,7 +87,8 @@ public interface DigitalObjectService extends EntityService<DigitalObject> {
   List<FileResource> saveFileResources(UUID digitalObjectUuid, List<FileResource> fileResources);
 
   default List<FileResource> saveRenderingResources(
-      DigitalObject digitalObject, List<FileResource> renderingResources) {
+      DigitalObject digitalObject, List<FileResource> renderingResources)
+      throws CudamiServiceException {
     if (renderingResources == null) {
       return null;
     }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/resource/DigitalObjectRenderingFileResourceService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/resource/DigitalObjectRenderingFileResourceService.java
@@ -1,0 +1,35 @@
+package de.digitalcollections.cudami.server.business.api.service.identifiable.resource;
+
+import de.digitalcollections.model.identifiable.entity.DigitalObject;
+import de.digitalcollections.model.identifiable.resource.FileResource;
+import java.util.List;
+import java.util.UUID;
+
+public interface DigitalObjectRenderingFileResourceService
+    extends FileResourceMetadataService<FileResource> {
+
+  default List<FileResource> saveForDigitalObject(
+      DigitalObject digitalObject, List<FileResource> renderingResources) {
+    if (digitalObject == null) {
+      // TODO Better throw an exception
+      return null;
+    }
+    if (renderingResources == null) {
+      return null;
+    }
+    return saveForDigitalObject(digitalObject.getUuid(), renderingResources);
+  }
+
+  List<FileResource> saveForDigitalObject(
+      UUID digitalObjectUuid, List<FileResource> renderingResources);
+
+  default List<FileResource> getForDigitalObject(DigitalObject digitalObject) {
+    if (digitalObject == null) {
+      // TODO Better throw an exception
+      return null;
+    }
+    return getForDigitalObject(digitalObject.getUuid());
+  }
+
+  List<FileResource> getForDigitalObject(UUID digitalObjectUuid);
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/resource/DigitalObjectRenderingFileResourceService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/resource/DigitalObjectRenderingFileResourceService.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.server.business.api.service.identifiable.resource;
 
+import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.resource.FileResource;
 import java.util.List;
@@ -9,10 +10,10 @@ public interface DigitalObjectRenderingFileResourceService
     extends FileResourceMetadataService<FileResource> {
 
   default List<FileResource> saveForDigitalObject(
-      DigitalObject digitalObject, List<FileResource> renderingResources) {
+      DigitalObject digitalObject, List<FileResource> renderingResources)
+      throws CudamiServiceException {
     if (digitalObject == null) {
-      // TODO Better throw an exception
-      return null;
+      throw new CudamiServiceException("DigitalObject must not be null");
     }
     if (renderingResources == null) {
       return null;
@@ -23,10 +24,10 @@ public interface DigitalObjectRenderingFileResourceService
   List<FileResource> saveForDigitalObject(
       UUID digitalObjectUuid, List<FileResource> renderingResources);
 
-  default List<FileResource> getForDigitalObject(DigitalObject digitalObject) {
+  default List<FileResource> getForDigitalObject(DigitalObject digitalObject)
+      throws CudamiServiceException {
     if (digitalObject == null) {
-      // TODO Better throw an exception
-      return null;
+      throw new CudamiServiceException("DigitalObject must not be null");
     }
     return getForDigitalObject(digitalObject.getUuid());
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/resource/LinkedDataFileResourceService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/resource/LinkedDataFileResourceService.java
@@ -1,7 +1,29 @@
 package de.digitalcollections.cudami.server.business.api.service.identifiable.resource;
 
 import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
+import java.util.List;
+import java.util.UUID;
 
 /** Service for LinkedDataFileResource handling. */
 public interface LinkedDataFileResourceService
-    extends FileResourceMetadataService<LinkedDataFileResource> {}
+    extends FileResourceMetadataService<LinkedDataFileResource> {
+
+  /**
+   * Returns the list of LinkedDataFileResources for a DigitalObject, identified by its UUID
+   *
+   * @param digitalObjectUuid the UUID of the DigitalObject
+   * @return list of LinkedDataFileResources
+   */
+  List<LinkedDataFileResource> getLinkedDataFileResourcesForDigitalObjectUuid(
+      UUID digitalObjectUuid);
+
+  /**
+   * Saves the list of LinkedDataFileResources for a DigitalObject, identified by its UUID
+   *
+   * @param digitalObjectUuid the UUID of the DigitalObject
+   * @param linkedDataFileResources list of LinkedDataFileResources to be persisted
+   * @return list of persisted LinkedDataFileResources
+   */
+  List<LinkedDataFileResource> saveLinkedDataFileResources(
+      UUID digitalObjectUuid, List<LinkedDataFileResource> linkedDataFileResources);
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -32,7 +32,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,21 +44,22 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
   private CudamiConfig cudamiConfig;
   protected IdentifierRepository identifierRepository;
 
-  @Autowired private LocaleService localeService;
+  private LocaleService localeService;
 
   protected IdentifiableRepository<I> repository;
 
   private UrlAliasService urlAliasService;
 
-  @Autowired
   public IdentifiableServiceImpl(
       @Qualifier("identifiableRepositoryImpl") IdentifiableRepository<I> repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
     this.repository = repository;
     this.identifierRepository = identifierRepository;
     this.urlAliasService = urlAliasService;
+    this.localeService = localeService;
     this.cudamiConfig = cudamiConfig;
   }
 
@@ -241,9 +241,11 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
       return savedIdentifiable;
     } catch (CudamiServiceException e) {
       LOGGER.error(String.format("Cannot save UrlAliases for: %s", identifiable), e);
+      e.printStackTrace();
       throw new IdentifiableServiceException(e.getMessage());
     } catch (Exception e) {
       LOGGER.error("Cannot save identifiable " + identifiable + ": " + e, e);
+      e.printStackTrace();
       throw new IdentifiableServiceException(e.getMessage());
     }
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -241,11 +241,9 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
       return savedIdentifiable;
     } catch (CudamiServiceException e) {
       LOGGER.error(String.format("Cannot save UrlAliases for: %s", identifiable), e);
-      e.printStackTrace();
       throw new IdentifiableServiceException(e.getMessage());
     } catch (Exception e) {
       LOGGER.error("Cannot save identifiable " + identifiable + ": " + e, e);
-      e.printStackTrace();
       throw new IdentifiableServiceException(e.getMessage());
     }
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/FamilyNameServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/FamilyNameServiceImpl.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.a
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.agent.FamilyNameRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.agent.FamilyNameService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
@@ -24,7 +25,8 @@ public class FamilyNameServiceImpl extends IdentifiableServiceImpl<FamilyName>
       FamilyNameRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(repository, identifierRepository, urlAliasService, localeService, cudamiConfig);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/GivenNameServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/GivenNameServiceImpl.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.a
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.agent.GivenNameRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.agent.GivenNameService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
@@ -24,7 +25,8 @@ public class GivenNameServiceImpl extends IdentifiableServiceImpl<GivenName>
       GivenNameRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(repository, identifierRepository, urlAliasService, localeService, cudamiConfig);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ArticleServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ArticleServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.ArticleRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ArticleService;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.Article;
 import de.digitalcollections.model.identifiable.entity.agent.Agent;
 import java.util.List;
@@ -14,7 +16,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Service for Article handling. */
@@ -24,13 +25,20 @@ public class ArticleServiceImpl extends EntityServiceImpl<Article> implements Ar
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArticleServiceImpl.class);
 
-  @Autowired
   public ArticleServiceImpl(
       ArticleRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
@@ -4,9 +4,11 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.NodeRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.CollectionRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.CollectionService;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.filter.Filtering;
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
@@ -21,7 +23,6 @@ import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -31,13 +32,20 @@ public class CollectionServiceImpl extends EntityServiceImpl<Collection>
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CollectionServiceImpl.class);
 
-  @Autowired
   public CollectionServiceImpl(
       CollectionRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/DigitalObjectServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/DigitalObjectServiceImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.DigitalObjectRepository;
 import de.digitalcollections.cudami.server.business.api.service.LocaleService;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
@@ -218,7 +219,11 @@ public class DigitalObjectServiceImpl extends EntityServiceImpl<DigitalObject>
     saveLinkedDataFileResources(digitalObject, linkedDataResources);
 
     // save the rendering resources
-    saveRenderingResources(digitalObject, renderingResources);
+    try {
+      saveRenderingResources(digitalObject, renderingResources);
+    } catch (CudamiServiceException e) {
+      throw new IdentifiableServiceException("Cannot update DigitalObject: " + e, e);
+    }
 
     return fillDigitalObject(digitalObject);
   }
@@ -237,19 +242,25 @@ public class DigitalObjectServiceImpl extends EntityServiceImpl<DigitalObject>
     saveLinkedDataFileResources(digitalObject, linkedDataResources);
 
     // save the rendering resources
-    saveRenderingResources(digitalObject, renderingResources);
+    try {
+      saveRenderingResources(digitalObject, renderingResources);
+    } catch (CudamiServiceException e) {
+      throw new IdentifiableServiceException("Cannot update DigitalObject: " + e, e);
+    }
 
     return fillDigitalObject(digitalObject);
   }
 
   @Override
-  public List<FileResource> getRenderingResources(DigitalObject digitalObject) {
+  public List<FileResource> getRenderingResources(DigitalObject digitalObject)
+      throws CudamiServiceException {
     return digitalObjectRenderingFileResourceService.getForDigitalObject(digitalObject);
   }
 
   @Override
   public List<FileResource> saveRenderingResources(
-      DigitalObject digitalObject, List<FileResource> renderingResources) {
+      DigitalObject digitalObject, List<FileResource> renderingResources)
+      throws CudamiServiceException {
     return digitalObjectRenderingFileResourceService.saveForDigitalObject(
         digitalObject, renderingResources);
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/EntityServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/EntityServiceImpl.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.EntityRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
@@ -27,7 +28,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -38,17 +38,19 @@ public class EntityServiceImpl<E extends Entity> extends IdentifiableServiceImpl
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EntityServiceImpl.class);
 
-  @Autowired protected HookProperties hookProperties;
+  protected HookProperties hookProperties;
 
   protected HttpClient httpClient = HttpClient.newHttpClient();
 
-  @Autowired
   public EntityServiceImpl(
       @Qualifier("entityRepositoryImpl") EntityRepository<E> repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(repository, identifierRepository, urlAliasService, localeService, cudamiConfig);
+    this.hookProperties = hookProperties;
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/HeadwordEntryServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/HeadwordEntryServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.HeadwordEntryRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.HeadwordEntryService;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.HeadwordEntry;
 import de.digitalcollections.model.identifiable.entity.agent.Agent;
 import java.util.List;
@@ -14,7 +16,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Service for HeadwordEntry handling. */
@@ -24,13 +25,20 @@ public class HeadwordEntryServiceImpl extends EntityServiceImpl<HeadwordEntry>
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HeadwordEntryServiceImpl.class);
 
-  @Autowired
   public HeadwordEntryServiceImpl(
       HeadwordEntryRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ProjectServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/ProjectServiceImpl.java
@@ -3,8 +3,10 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.ProjectRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ProjectService;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.Identifier;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.Project;
@@ -16,7 +18,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -25,13 +26,20 @@ public class ProjectServiceImpl extends EntityServiceImpl<Project> implements Pr
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProjectServiceImpl.class);
 
-  @Autowired
   public ProjectServiceImpl(
       ProjectRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/TopicServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/TopicServiceImpl.java
@@ -4,9 +4,11 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.NodeRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.TopicRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.TopicService;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.entity.Topic;
 import de.digitalcollections.model.identifiable.resource.FileResource;
@@ -20,7 +22,6 @@ import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Service for Topic handling. */
@@ -30,13 +31,20 @@ public class TopicServiceImpl extends EntityServiceImpl<Topic> implements TopicS
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TopicServiceImpl.class);
 
-  @Autowired
   public TopicServiceImpl(
       TopicRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/WebsiteServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/WebsiteServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.WebsiteRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.WebsiteService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.web.WebpageService;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.Website;
 import de.digitalcollections.model.identifiable.web.Webpage;
 import de.digitalcollections.model.paging.SearchPageRequest;
@@ -31,9 +33,17 @@ public class WebsiteServiceImpl extends EntityServiceImpl<Website> implements We
       WebsiteRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
       CudamiConfig cudamiConfig,
+      LocaleService localeService,
       WebpageService webpageService) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
     this.webpageService = webpageService;
   }
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/AgentServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/AgentServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.agent.AgentRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.AgentService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.EntityServiceImpl;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.agent.Agent;
 import de.digitalcollections.model.identifiable.entity.work.Work;
@@ -13,7 +15,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Service for Agent handling. */
@@ -23,13 +24,20 @@ public class AgentServiceImpl extends EntityServiceImpl<Agent> implements AgentS
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentServiceImpl.class);
 
-  @Autowired
   public AgentServiceImpl(
       AgentRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/CorporateBodyServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/CorporateBodyServiceImpl.java
@@ -4,17 +4,18 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.agent.CorporateBodyRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.agent.ExternalCorporateBodyRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.CorporateBodyService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.ImageFileResourceService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.EntityServiceImpl;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
 import de.digitalcollections.model.identifiable.resource.ImageFileResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -27,15 +28,22 @@ public class CorporateBodyServiceImpl extends EntityServiceImpl<CorporateBody>
   private final ExternalCorporateBodyRepository externalRepository;
   private final ImageFileResourceService imageFileResourceService;
 
-  @Autowired
   public CorporateBodyServiceImpl(
       CorporateBodyRepository repository,
       ExternalCorporateBodyRepository externalRepository,
       ImageFileResourceService imageFileResourceService,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
     this.externalRepository = externalRepository;
     this.imageFileResourceService = imageFileResourceService;
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/PersonServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/PersonServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.agent.PersonRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.PersonService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.EntityServiceImpl;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.filter.Filtering;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.agent.Person;
@@ -16,7 +18,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -25,13 +26,20 @@ public class PersonServiceImpl extends EntityServiceImpl<Person> implements Pers
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PersonServiceImpl.class);
 
-  @Autowired
   public PersonServiceImpl(
       PersonRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/GeoLocationServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/GeoLocationServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.geo.location.GeoLocationRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.geo.location.GeoLocationService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.EntityServiceImpl;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.geo.location.GeoLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +26,15 @@ public class GeoLocationServiceImpl extends EntityServiceImpl<GeoLocation>
       GeoLocationRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/HumanSettlementServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/geo/location/HumanSettlementServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.geo.location.HumanSettlementRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.geo.location.HumanSettlementService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.EntityServiceImpl;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +26,15 @@ public class HumanSettlementServiceImpl extends EntityServiceImpl<HumanSettlemen
       HumanSettlementRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/ItemServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/ItemServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.work.ItemRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.work.ItemService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.EntityServiceImpl;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.work.Item;
 import de.digitalcollections.model.identifiable.entity.work.Work;
@@ -27,8 +29,16 @@ public class ItemServiceImpl extends EntityServiceImpl<Item> implements ItemServ
       ItemRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/WorkServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/work/WorkServiceImpl.java
@@ -3,9 +3,11 @@ package de.digitalcollections.cudami.server.business.impl.service.identifiable.e
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.work.WorkRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.work.WorkService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.EntityServiceImpl;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.agent.Agent;
 import de.digitalcollections.model.identifiable.entity.work.Item;
 import de.digitalcollections.model.identifiable.entity.work.Work;
@@ -13,7 +15,6 @@ import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -22,13 +23,20 @@ public class WorkServiceImpl extends EntityServiceImpl<Work> implements WorkServ
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WorkServiceImpl.class);
 
-  @Autowired
   public WorkServiceImpl(
       WorkRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      HookProperties hookProperties,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        repository,
+        identifierRepository,
+        urlAliasService,
+        hookProperties,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ApplicationFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ApplicationFileResourceServiceImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.ApplicationFileResourceRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.ApplicationFileResourceService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
@@ -12,7 +13,6 @@ import de.digitalcollections.model.identifiable.resource.ApplicationFileResource
 import de.digitalcollections.model.identifiable.resource.FileResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -24,13 +24,18 @@ public class ApplicationFileResourceServiceImpl
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ApplicationFileResourceServiceImpl.class);
 
-  @Autowired
   public ApplicationFileResourceServiceImpl(
       ApplicationFileResourceRepository applicationFileResourceRepository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(applicationFileResourceRepository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        applicationFileResourceRepository,
+        identifierRepository,
+        urlAliasService,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/AudioFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/AudioFileResourceServiceImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.AudioFileResourceRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.AudioFileResourceService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
@@ -27,8 +28,14 @@ public class AudioFileResourceServiceImpl extends IdentifiableServiceImpl<AudioF
       AudioFileResourceRepository audioFileResourceRepository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(audioFileResourceRepository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        audioFileResourceRepository,
+        identifierRepository,
+        urlAliasService,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/DigitalObjectRenderingFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/DigitalObjectRenderingFileResourceServiceImpl.java
@@ -5,6 +5,8 @@ import de.digitalcollections.cudami.server.backend.api.repository.identifiable.I
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.DigitalObjectRenderingFileResourceRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
 import de.digitalcollections.cudami.server.business.api.service.LocaleService;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.ApplicationFileResourceService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.AudioFileResourceService;
@@ -13,13 +15,23 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.res
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.LinkedDataFileResourceService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.TextFileResourceService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.VideoFileResourceService;
+import de.digitalcollections.model.identifiable.resource.ApplicationFileResource;
+import de.digitalcollections.model.identifiable.resource.AudioFileResource;
 import de.digitalcollections.model.identifiable.resource.FileResource;
+import de.digitalcollections.model.identifiable.resource.ImageFileResource;
+import de.digitalcollections.model.identifiable.resource.TextFileResource;
+import de.digitalcollections.model.identifiable.resource.VideoFileResource;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
+/**
+ * This service persists all rendering resources (which can be of any type, derived from
+ * FileResource) of a DigitalObject
+ */
 public class DigitalObjectRenderingFileResourceServiceImpl extends FileResourceMetadataServiceImpl
     implements DigitalObjectRenderingFileResourceService {
 
@@ -59,8 +71,84 @@ public class DigitalObjectRenderingFileResourceServiceImpl extends FileResourceM
   @Override
   public List<FileResource> saveForDigitalObject(
       UUID digitalObjectUuid, List<FileResource> renderingResources) {
-    return renderingFileResourceRepository.saveForDigitalObjectUuid(
-        digitalObjectUuid, renderingResources);
+
+    // Remove the old rendering resources, if present
+    List<FileResource> existingRenderingResources = getForDigitalObject(digitalObjectUuid);
+    existingRenderingResources.forEach(
+        r -> {
+          try {
+            deleteRenderingResource(r);
+          } catch (IdentifiableServiceException e) {
+            throw new RuntimeException("Cannot save rendering resource=" + r + ": " + e, e);
+          }
+        });
+
+    // Remove the old relations
+    renderingFileResourceRepository.deleteRelatedRenderingResourcesForDigitalObjectUuid(
+        digitalObjectUuid);
+
+    // Persist the new rendering resources
+    if (renderingResources != null) {
+      // first save rendering resources
+      renderingResources =
+          renderingResources.stream()
+              .map(
+                  r -> {
+                    try {
+                      return saveRenderingResource(r);
+                    } catch (Exception e) {
+                      throw new RuntimeException(
+                          "Cannot save rendering resource=" + r + ": " + e, e);
+                    }
+                  })
+              .collect(Collectors.toList());
+
+      // Persist the new relations
+      renderingFileResourceRepository.saveRelatedRenderingResourcesForDigitalObjectUuid(
+          digitalObjectUuid, renderingResources);
+    }
+
+    return renderingResources;
+  }
+
+  private boolean deleteRenderingResource(FileResource renderingResource)
+      throws IdentifiableServiceException {
+    switch (renderingResource.getMimeType().getPrimaryType()) {
+      case "application":
+        return applicationFileResourceService.delete(renderingResource.getUuid());
+      case "audio":
+        return audioFileResourceService.delete(renderingResource.getUuid());
+      case "image":
+        return imageFileResourceService.delete(renderingResource.getUuid());
+      case "text":
+        return textFileResourceService.delete(renderingResource.getUuid());
+      case "video":
+        return videoFileResourceService.delete(renderingResource.getUuid());
+      default:
+        return delete(renderingResource.getUuid());
+    }
+  }
+
+  private FileResource saveRenderingResource(FileResource renderingResource)
+      throws ValidationException, IdentifiableServiceException {
+    if (renderingResource.getUuid() == null) {
+      switch (renderingResource.getMimeType().getPrimaryType()) {
+        case "application":
+          return applicationFileResourceService.save((ApplicationFileResource) renderingResource);
+        case "audio":
+          return audioFileResourceService.save((AudioFileResource) renderingResource);
+        case "image":
+          return imageFileResourceService.save((ImageFileResource) renderingResource);
+        case "text":
+          return textFileResourceService.save((TextFileResource) renderingResource);
+        case "video":
+          return videoFileResourceService.save((VideoFileResource) renderingResource);
+        default:
+          return save(renderingResource);
+      }
+    }
+
+    return renderingResource;
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/DigitalObjectRenderingFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/DigitalObjectRenderingFileResourceServiceImpl.java
@@ -84,8 +84,7 @@ public class DigitalObjectRenderingFileResourceServiceImpl extends FileResourceM
         });
 
     // Remove the old relations
-    renderingFileResourceRepository.deleteRelatedRenderingResourcesForDigitalObjectUuid(
-        digitalObjectUuid);
+    renderingFileResourceRepository.removeByDigitalObject(digitalObjectUuid);
 
     // Persist the new rendering resources
     if (renderingResources != null) {
@@ -104,8 +103,7 @@ public class DigitalObjectRenderingFileResourceServiceImpl extends FileResourceM
               .collect(Collectors.toList());
 
       // Persist the new relations
-      renderingFileResourceRepository.saveRelatedRenderingResourcesForDigitalObjectUuid(
-          digitalObjectUuid, renderingResources);
+      renderingFileResourceRepository.saveForDigitalObject(digitalObjectUuid, renderingResources);
     }
 
     return renderingResources;
@@ -153,6 +151,6 @@ public class DigitalObjectRenderingFileResourceServiceImpl extends FileResourceM
 
   @Override
   public List<FileResource> getForDigitalObject(UUID digitalObjectUuid) {
-    return renderingFileResourceRepository.getForDigitalObjectUuid(digitalObjectUuid);
+    return renderingFileResourceRepository.findByDigitalObject(digitalObjectUuid);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/DigitalObjectRenderingFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/DigitalObjectRenderingFileResourceServiceImpl.java
@@ -1,0 +1,70 @@
+package de.digitalcollections.cudami.server.business.impl.service.identifiable.resource;
+
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.DigitalObjectRenderingFileResourceRepository;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.ApplicationFileResourceService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.AudioFileResourceService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.DigitalObjectRenderingFileResourceService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.ImageFileResourceService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.LinkedDataFileResourceService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.TextFileResourceService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.VideoFileResourceService;
+import de.digitalcollections.model.identifiable.resource.FileResource;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DigitalObjectRenderingFileResourceServiceImpl extends FileResourceMetadataServiceImpl
+    implements DigitalObjectRenderingFileResourceService {
+
+  private final DigitalObjectRenderingFileResourceRepository renderingFileResourceRepository;
+
+  public DigitalObjectRenderingFileResourceServiceImpl(
+      @Qualifier("fileResourceMetadataRepositoryImpl")
+          FileResourceMetadataRepository<FileResource> metadataRepository,
+      @Qualifier("applicationFileResourceServiceImpl")
+          ApplicationFileResourceService applicationFileResourceService,
+      @Qualifier("audioFileResourceServiceImpl") AudioFileResourceService audioFileResourceService,
+      @Qualifier("imageFileResourceServiceImpl") ImageFileResourceService imageFileResourceService,
+      @Qualifier("linkedDataFileResourceServiceImpl")
+          LinkedDataFileResourceService linkedDataFileResourceService,
+      @Qualifier("textFileResourceServiceImpl") TextFileResourceService textFileResourceService,
+      @Qualifier("videoFileResourceServiceImpl") VideoFileResourceService videoFileResourceService,
+      DigitalObjectRenderingFileResourceRepository renderingFileResourceRepository,
+      IdentifierRepository identifierRepository,
+      UrlAliasService urlAliasService,
+      LocaleService localeService,
+      CudamiConfig cudamiConfig) {
+    super(
+        metadataRepository,
+        applicationFileResourceService,
+        audioFileResourceService,
+        imageFileResourceService,
+        linkedDataFileResourceService,
+        textFileResourceService,
+        videoFileResourceService,
+        localeService,
+        identifierRepository,
+        urlAliasService,
+        cudamiConfig);
+    this.renderingFileResourceRepository = renderingFileResourceRepository;
+  }
+
+  @Override
+  public List<FileResource> saveForDigitalObject(
+      UUID digitalObjectUuid, List<FileResource> renderingResources) {
+    return renderingFileResourceRepository.saveForDigitalObjectUuid(
+        digitalObjectUuid, renderingResources);
+  }
+
+  @Override
+  public List<FileResource> getForDigitalObject(UUID digitalObjectUuid) {
+    return renderingFileResourceRepository.getForDigitalObjectUuid(digitalObjectUuid);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
@@ -39,13 +39,13 @@ public class FileResourceMetadataServiceImpl extends IdentifiableServiceImpl<Fil
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FileResourceMetadataServiceImpl.class);
 
-  private final ApplicationFileResourceService applicationFileResourceService;
-  private final AudioFileResourceService audioFileResourceService;
-  private final ImageFileResourceService imageFileResourceService;
-  private final LinkedDataFileResourceService linkedDataFileResourceService;
+  protected final ApplicationFileResourceService applicationFileResourceService;
+  protected final AudioFileResourceService audioFileResourceService;
+  protected final ImageFileResourceService imageFileResourceService;
+  protected final LinkedDataFileResourceService linkedDataFileResourceService;
   private final LocaleService localeService;
-  private final TextFileResourceService textFileResourceService;
-  private final VideoFileResourceService videoFileResourceService;
+  protected final TextFileResourceService textFileResourceService;
+  protected final VideoFileResourceService videoFileResourceService;
 
   public FileResourceMetadataServiceImpl(
       @Qualifier("fileResourceMetadataRepositoryImpl")

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
@@ -28,7 +28,6 @@ import java.util.Locale;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -48,7 +47,6 @@ public class FileResourceMetadataServiceImpl extends IdentifiableServiceImpl<Fil
   private final TextFileResourceService textFileResourceService;
   private final VideoFileResourceService videoFileResourceService;
 
-  @Autowired
   public FileResourceMetadataServiceImpl(
       @Qualifier("fileResourceMetadataRepositoryImpl")
           FileResourceMetadataRepository<FileResource> metadataRepository,
@@ -64,7 +62,7 @@ public class FileResourceMetadataServiceImpl extends IdentifiableServiceImpl<Fil
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
       CudamiConfig cudamiConfig) {
-    super(metadataRepository, identifierRepository, urlAliasService, cudamiConfig);
+    super(metadataRepository, identifierRepository, urlAliasService, localeService, cudamiConfig);
     this.applicationFileResourceService = applicationFileResourceService;
     this.audioFileResourceService = audioFileResourceService;
     this.imageFileResourceService = imageFileResourceService;

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ImageFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ImageFileResourceServiceImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.ImageFileResourceRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.ImageFileResourceService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
@@ -12,7 +13,6 @@ import de.digitalcollections.model.identifiable.resource.FileResource;
 import de.digitalcollections.model.identifiable.resource.ImageFileResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -22,13 +22,18 @@ public class ImageFileResourceServiceImpl extends IdentifiableServiceImpl<ImageF
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ImageFileResourceServiceImpl.class);
 
-  @Autowired
   public ImageFileResourceServiceImpl(
       ImageFileResourceRepository imageFileResourceRepository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(imageFileResourceRepository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        imageFileResourceRepository,
+        identifierRepository,
+        urlAliasService,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImpl.java
@@ -4,15 +4,17 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.LinkedDataFileResourceRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.LinkedDataFileResourceService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
 import de.digitalcollections.model.file.MimeType;
 import de.digitalcollections.model.identifiable.resource.FileResource;
 import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
+import java.util.List;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
@@ -24,17 +26,36 @@ public class LinkedDataFileResourceServiceImpl
   private static final Logger LOGGER =
       LoggerFactory.getLogger(LinkedDataFileResourceServiceImpl.class);
 
-  @Autowired
   public LinkedDataFileResourceServiceImpl(
       LinkedDataFileResourceRepository linkedDataFileResourceRepository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(linkedDataFileResourceRepository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        linkedDataFileResourceRepository,
+        identifierRepository,
+        urlAliasService,
+        localeService,
+        cudamiConfig);
   }
 
   @Override
   public FileResource createByMimeType(MimeType mimeType) {
     return ((FileResourceMetadataRepository) repository).createByMimeType(mimeType);
+  }
+
+  @Override
+  public List<LinkedDataFileResource> getLinkedDataFileResourcesForDigitalObjectUuid(
+      UUID digitalObjectUuid) {
+    return ((LinkedDataFileResourceRepository) repository)
+        .getLinkedDataFileResourcesForDigitalObjectUuid(digitalObjectUuid);
+  }
+
+  @Override
+  public List<LinkedDataFileResource> saveLinkedDataFileResources(
+      UUID digitalObjectUuid, List<LinkedDataFileResource> linkedDataFileResources) {
+    return ((LinkedDataFileResourceRepository) repository)
+        .saveLinkedDataFileResources(digitalObjectUuid, linkedDataFileResources);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/TextFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/TextFileResourceServiceImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.TextFileResourceRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.TextFileResourceService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
@@ -27,8 +28,14 @@ public class TextFileResourceServiceImpl extends IdentifiableServiceImpl<TextFil
       TextFileResourceRepository textFileResourceRepository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(textFileResourceRepository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        textFileResourceRepository,
+        identifierRepository,
+        urlAliasService,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/VideoFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/VideoFileResourceServiceImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceMetadataRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.VideoFileResourceRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.VideoFileResourceService;
 import de.digitalcollections.cudami.server.business.impl.service.identifiable.IdentifiableServiceImpl;
@@ -27,8 +28,14 @@ public class VideoFileResourceServiceImpl extends IdentifiableServiceImpl<VideoF
       VideoFileResourceRepository videoFileResourceRepository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(videoFileResourceRepository, identifierRepository, urlAliasService, cudamiConfig);
+    super(
+        videoFileResourceRepository,
+        identifierRepository,
+        urlAliasService,
+        localeService,
+        cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.NodeRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.web.WebpageRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
@@ -40,8 +41,9 @@ public class WebpageServiceImpl extends IdentifiableServiceImpl<Webpage> impleme
       WebpageRepository repository,
       IdentifierRepository identifierRepository,
       UrlAliasService urlAliasService,
+      LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    super(repository, identifierRepository, urlAliasService, cudamiConfig);
+    super(repository, identifierRepository, urlAliasService, localeService, cudamiConfig);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifiableRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
@@ -54,8 +55,12 @@ class IdentifiableServiceImplTest {
     CudamiConfig.UrlAlias urlAliasConfig = new CudamiConfig.UrlAlias();
     urlAliasConfig.setGenerationExcludes(List.of(EntityType.DIGITAL_OBJECT));
     cudamiConfig.setUrlAlias(urlAliasConfig);
+
+    LocaleService localeService = mock(LocaleService.class);
+
     service =
-        new IdentifiableServiceImpl(repo, identifierRepository, urlAliasService, cudamiConfig);
+        new IdentifiableServiceImpl(
+            repo, identifierRepository, urlAliasService, localeService, cudamiConfig);
   }
 
   @DisplayName("can add related entities by delegating it to the repository")

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/DigitalObjectServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/DigitalObjectServiceImplTest.java
@@ -1,0 +1,250 @@
+package de.digitalcollections.cudami.server.business.impl.service.identifiable.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.digitalcollections.cudami.model.config.CudamiConfig;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.DigitalObjectRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
+import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.CollectionService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ProjectService;
+import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.LinkedDataFileResourceService;
+import de.digitalcollections.cudami.server.config.HookProperties;
+import de.digitalcollections.model.file.MimeType;
+import de.digitalcollections.model.identifiable.Identifier;
+import de.digitalcollections.model.identifiable.entity.DigitalObject;
+import de.digitalcollections.model.identifiable.entity.DigitalObjectBuilder;
+import de.digitalcollections.model.identifiable.entity.EntityType;
+import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
+import de.digitalcollections.model.identifiable.resource.LinkedDataFileResourceBuilder;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The DigitalObjectService")
+class DigitalObjectServiceImplTest {
+
+  private CollectionService collectionService;
+  private CudamiConfig cudamiConfig;
+  private DigitalObjectServiceImpl service;
+  private DigitalObjectRepository repo;
+  protected HookProperties hookProperties;
+  private IdentifierRepository identifierRepository;
+  private LinkedDataFileResourceService linkedDataFileResourceService;
+  private LocaleService localeService;
+  private ProjectService projectService;
+  private UrlAliasService urlAliasService;
+
+  @BeforeEach
+  public void beforeEach() throws CudamiServiceException {
+    repo = mock(DigitalObjectRepository.class);
+    collectionService = mock(CollectionService.class);
+    hookProperties = mock(HookProperties.class);
+    identifierRepository = mock(IdentifierRepository.class);
+    linkedDataFileResourceService = mock(LinkedDataFileResourceService.class);
+    localeService = mock(LocaleService.class);
+    when(localeService.getDefaultLanguage()).thenReturn("de");
+    projectService = mock(ProjectService.class);
+    urlAliasService = mock(UrlAliasService.class);
+
+    cudamiConfig = mock(CudamiConfig.class);
+    CudamiConfig.UrlAlias cudamiConfigUrlAlias = mock(CudamiConfig.UrlAlias.class);
+    when(cudamiConfigUrlAlias.getGenerationExcludes())
+        .thenReturn(List.of(EntityType.DIGITAL_OBJECT));
+    when(cudamiConfig.getUrlAlias()).thenReturn(cudamiConfigUrlAlias);
+
+    service =
+        new DigitalObjectServiceImpl(
+            repo,
+            collectionService,
+            projectService,
+            identifierRepository,
+            urlAliasService,
+            linkedDataFileResourceService,
+            hookProperties,
+            localeService,
+            cudamiConfig);
+  }
+
+  @Test
+  @DisplayName("can save LinkedDataFileResources for a DigitalObject")
+  void saveLinkedDataFileResources() throws ValidationException, IdentifiableServiceException {
+    LinkedDataFileResource linkedDataFileResource =
+        new LinkedDataFileResourceBuilder()
+            .withLabel(Locale.GERMAN, "Linked Data")
+            .withContext("https://foo.bar/blubb.xml")
+            .withObjectType("XML")
+            .withFilename("blubb.xml") // required!!
+            .withMimeType(MimeType.MIME_APPLICATION_XML)
+            .build();
+
+    Identifier identifier = new Identifier(null, "foo", "bar");
+
+    DigitalObject digitalObject =
+        new DigitalObjectBuilder()
+            .withLabel(Locale.GERMAN, "deutschsprachiges Label")
+            .withLabel(Locale.ENGLISH, "english label")
+            .withDescription(Locale.GERMAN, "Beschreibung")
+            .withDescription(Locale.ENGLISH, "description")
+            .withLinkedDataFileResource(linkedDataFileResource)
+            .build();
+
+    DigitalObject savedDigitalObject = digitalObject;
+    savedDigitalObject.setUuid(UUID.randomUUID());
+    when(repo.save(eq(digitalObject))).thenReturn(savedDigitalObject);
+    when(identifierRepository.save(eq(identifier))).thenReturn(identifier);
+
+    DigitalObject persisted = service.save(digitalObject);
+
+    assertThat(persisted.getLinkedDataResources()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("fills LinkedDataResources for a retrieved DigitalObject by uuid")
+  void fillLinkedDataResourcesForGetByUuidAndLocale() throws IdentifiableServiceException {
+    UUID uuid = UUID.randomUUID();
+    DigitalObject persistedDigitalObject =
+        new DigitalObjectBuilder()
+            .withUuid(uuid)
+            .withLabel(Locale.GERMAN, "deutschsprachiges Label")
+            .withLabel(Locale.ENGLISH, "english label")
+            .withDescription(Locale.GERMAN, "Beschreibung")
+            .withDescription(Locale.ENGLISH, "description")
+            .build();
+    when(repo.getByUuid(eq(uuid))).thenReturn(persistedDigitalObject);
+
+    LinkedDataFileResource persistedLinkedDataFileResource =
+        new LinkedDataFileResourceBuilder()
+            .withLabel(Locale.GERMAN, "Linked Data")
+            .withContext("https://foo.bar/blubb.xml")
+            .withObjectType("XML")
+            .withFilename("blubb.xml") // required!!
+            .withMimeType(MimeType.MIME_APPLICATION_XML)
+            .build();
+    when(linkedDataFileResourceService.getLinkedDataFileResourcesForDigitalObjectUuid(eq(uuid)))
+        .thenReturn(List.of(persistedLinkedDataFileResource));
+
+    DigitalObject actual = service.getByUuidAndLocale(uuid, Locale.ROOT);
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.getLinkedDataResources()).containsExactly(persistedLinkedDataFileResource);
+  }
+
+  /*
+
+  @Test
+  @DisplayName("can save and retrieve a DigitalObject with all of its embedded resources")
+  void saveDigitalObject() {
+    // Insert a license with uuid
+    ensureLicense(EXISTING_LICENSE);
+
+    // Insert a corporate body with UUID
+    CorporateBody creator =
+        new CorporateBodyBuilder()
+            .withUuid(UUID.randomUUID())
+            .withLabel(Locale.GERMAN, "Körperschaft")
+            .withLabel(Locale.ENGLISH, "Corporate Body")
+            .build();
+
+    CorporateBodyRepositoryImpl corporateBodyRepository =
+        new CorporateBodyRepositoryImpl(jdbi, cudamiConfig);
+    corporateBodyRepository.save(creator);
+
+    // Insert a geolocation with UUID
+    GeoLocation creationPlace =
+        new GeoLocationBuilder()
+            .withUuid(UUID.randomUUID())
+            .withLabel(Locale.GERMAN, "Ort")
+            .build();
+    GeoLocationRepositoryImpl geoLocationRepository =
+        new GeoLocationRepositoryImpl(jdbi, cudamiConfig);
+    geoLocationRepository.save(creationPlace);
+
+    // Insert a LinkedDataFileResource
+    LinkedDataFileResource linkedDataFileResource =
+        new LinkedDataFileResourceBuilder()
+            .withUuid(UUID.randomUUID())
+            .withLabel(Locale.GERMAN, "Linked Data")
+            .withContext("https://foo.bar/blubb.xml")
+            .withObjectType("XML")
+            .withFilename("blubb.xml") // required!!
+            .withMimeType(MimeType.MIME_APPLICATION_XML)
+            .build();
+
+    linkedDataFileResourceRepository.save(linkedDataFileResource);
+
+    // Insert a rendering FileResource
+    FileResource renderingResource = new FileResource();
+    renderingResource.setUri(URI.create("https://bla.bla/foo.jpg"));
+    renderingResource.setMimeType(MimeType.MIME_IMAGE);
+    renderingResource.setUuid(UUID.randomUUID());
+    renderingResource.setFilename("foo.jpg");
+    renderingResource.setLabel(new LocalizedText(Locale.GERMAN, "Zeichnung"));
+    FileResourceMetadataRepositoryImpl<FileResource> fileResourceMetadataRepository =
+        new FileResourceMetadataRepositoryImpl<FileResource>(jdbi, cudamiConfig);
+    fileResourceMetadataRepository.save(renderingResource);
+
+    // Build a CreationInfo object with the formerly persisted contents
+    CreationInfo creationInfo =
+        new CreationInfoBuilder()
+            .withCreator(creator)
+            .withDate("2022-02-25")
+            .withGeoLocation(creationPlace)
+            .build();
+
+    DigitalObject parent =
+        repo.save(new DigitalObjectBuilder().withLabel(Locale.GERMAN, "Parent").build());
+
+    DigitalObject digitalObject =
+        new DigitalObjectBuilder()
+            .withLabel(Locale.GERMAN, "deutschsprachiges Label")
+            .withLabel(Locale.ENGLISH, "english label")
+            .withDescription(Locale.GERMAN, "Beschreibung")
+            .withDescription(Locale.ENGLISH, "description")
+            .withLicense(EXISTING_LICENSE)
+            .withCreationInfo(creationInfo)
+            .withLinkedDataFileResource(linkedDataFileResource)
+            .withRenderingResource(renderingResource)
+            .withParent(parent)
+            .build();
+
+    // The "save" method internally retrieves the object by findOne
+    DigitalObject actual = repo.save(digitalObject);
+
+    assertThat(actual.getLabel().getText(Locale.GERMAN)).isEqualTo("deutschsprachiges Label");
+    assertThat(actual.getLabel().getText(Locale.ENGLISH)).isEqualTo("english label");
+    Paragraph paragraphDe =
+        (Paragraph) actual.getDescription().get(Locale.GERMAN).getContentBlocks().get(0);
+    assertThat(((Text) paragraphDe.getContentBlocks().get(0)).getText()).isEqualTo("Beschreibung");
+
+    assertThat(actual.getLicense()).isEqualTo(digitalObject.getLicense());
+
+    assertThat(actual.getCreationInfo().getCreator()).isEqualTo(creator);
+    assertThat(actual.getCreationInfo().getDate().format(DateTimeFormatter.ISO_DATE))
+        .isEqualTo("2022-02-25");
+    assertThat(actual.getCreationInfo().getGeoLocation()).isEqualTo(creationPlace);
+
+    assertThat(actual.getLinkedDataResources()).hasSize(1);
+    assertThat(actual.getLinkedDataResources().get(0)).isEqualTo(linkedDataFileResource);
+
+    assertThat(actual.getRenderingResources()).hasSize(1);
+    assertThat(actual.getRenderingResources().get(0)).isEqualTo(renderingResource);
+
+    assertThat(actual.getParent()).isNotNull();
+    assertThat(actual.getParent().getUuid()).isEqualTo(parent.getUuid());
+    assertThat(actual.getParent().getLabel()).isEqualTo(parent.getLabel());
+  }
+
+   */
+
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/CorporateBodyServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/agent/CorporateBodyServiceImplTest.java
@@ -12,10 +12,12 @@ import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.agent.CorporateBodyRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.agent.ExternalCorporateBodyRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.ImageFileResourceService;
+import de.digitalcollections.cudami.server.config.HookProperties;
 import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
 import de.digitalcollections.model.identifiable.resource.ImageFileResource;
 import java.net.MalformedURLException;
@@ -50,6 +52,10 @@ class CorporateBodyServiceImplTest {
 
     cudamiConfig = mock(CudamiConfig.class);
 
+    HookProperties hookProperties = mock(HookProperties.class);
+
+    LocaleService localeService = mock(LocaleService.class);
+
     corporateBodyService =
         new CorporateBodyServiceImpl(
             corporateBodyRepository,
@@ -57,6 +63,8 @@ class CorporateBodyServiceImplTest {
             imageFileResourceService,
             identifierRepository,
             urlAliasService,
+            hookProperties,
+            localeService,
             cudamiConfig);
   }
 

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImplTest.java
@@ -1,0 +1,3 @@
+package de.digitalcollections.cudami.server.business.impl.service.identifiable.resource;
+
+class LinkedDataFileResourceServiceImplTest {}

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImplTest.java
@@ -1,3 +1,0 @@
-package de.digitalcollections.cudami.server.business.impl.service.identifiable.resource;
-
-class LinkedDataFileResourceServiceImplTest {}

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifierRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.web.WebpageRepository;
+import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.CudamiServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.IdentifiableServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
@@ -50,7 +51,12 @@ class WebpageServiceImplTest {
     identifierRepository = mock(IdentifierRepository.class);
     urlAliasService = mock(UrlAliasService.class);
     cudamiConfig = mock(CudamiConfig.class);
-    service = new WebpageServiceImpl(repo, identifierRepository, urlAliasService, cudamiConfig);
+
+    LocaleService localeService = mock(LocaleService.class);
+
+    service =
+        new WebpageServiceImpl(
+            repo, identifierRepository, urlAliasService, localeService, cudamiConfig);
   }
 
   @Test

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceBinaryController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceBinaryController.java
@@ -19,6 +19,7 @@ import org.apache.tomcat.util.http.fileupload.FileItemStream;
 import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,7 +35,8 @@ public class FileResourceBinaryController {
 
   public FileResourceBinaryController(
       FileResourceBinaryService binaryService,
-      FileResourceMetadataService<FileResource> metadataService) {
+      @Qualifier("fileResourceMetadataService")
+          FileResourceMetadataService<FileResource> metadataService) {
     this.binaryService = binaryService;
     this.metadataService = metadataService;
   }


### PR DESCRIPTION
This refactoring moves the handling of LinkedDataFileResources and DownloadResources from the `DigitalObjectRepositoryImpl` into their specific repositories and services and lets `DigitalObjectServiceImpl`work with them.