### PR TITLE
Added explicit .json suffixed endpoints for getByIdentifier, since Sp…

### DIFF
--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
@@ -104,8 +104,11 @@ public class IdentifiableController {
   @GetMapping(
       value = {
         "/v5/identifiables/identifier/{namespace}:{id}",
+            "/v5/identifiables/identifier/{namespace}:{id}.json",
         "/v2/identifiables/identifier/{namespace}:{id}",
-        "/latest/identifiables/identifier/{namespace}:{id}"
+            "/v2/identifiables/identifier/{namespace}:{id}.json",
+        "/latest/identifiables/identifier/{namespace}:{id}",
+            "/latest/identifiables/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Identifiable> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
@@ -104,11 +104,11 @@ public class IdentifiableController {
   @GetMapping(
       value = {
         "/v5/identifiables/identifier/{namespace}:{id}",
-            "/v5/identifiables/identifier/{namespace}:{id}.json",
+        "/v5/identifiables/identifier/{namespace}:{id}.json",
         "/v2/identifiables/identifier/{namespace}:{id}",
-            "/v2/identifiables/identifier/{namespace}:{id}.json",
+        "/v2/identifiables/identifier/{namespace}:{id}.json",
         "/latest/identifiables/identifier/{namespace}:{id}",
-            "/latest/identifiables/identifier/{namespace}:{id}.json"
+        "/latest/identifiables/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Identifiable> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
@@ -62,7 +62,10 @@ public class FamilyNameController {
 
   @Operation(summary = "Get a familyname by namespace and id")
   @GetMapping(
-      value = {"/v5/familynames/identifier/{namespace}:{id}"},
+      value = {
+        "/v5/familynames/identifier/{namespace}:{id}",
+        "/v5/familynames/identifier/{namespace}:{id}.json"
+      },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<FamilyName> getByIdentifier(
       @PathVariable String namespace, @PathVariable String id) throws IdentifiableServiceException {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
@@ -62,7 +62,10 @@ public class GivenNameController {
 
   @Operation(summary = "Get a givenname by namespace and id")
   @GetMapping(
-      value = {"/v5/givennames/identifier/{namespace}:{id}"},
+      value = {
+        "/v5/givennames/identifier/{namespace}:{id}",
+        "/v5/givennames/identifier/{namespace}:{id}.json"
+      },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<GivenName> getByIdentifier(
       @PathVariable String namespace, @PathVariable String id) throws IdentifiableServiceException {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
@@ -267,11 +267,11 @@ public class CollectionController {
   @GetMapping(
       value = {
         "/v5/collections/identifier/{namespace}:{id}",
-            "/v5/collections/identifier/{namespace}:{id}.json",
+        "/v5/collections/identifier/{namespace}:{id}.json",
         "/v2/collections/identifier/{namespace}:{id}",
-            "/v2/collections/identifier/{namespace}:{id}.json",
+        "/v2/collections/identifier/{namespace}:{id}.json",
         "/latest/collections/identifier/{namespace}:{id}",
-            "/latest/collections/identifier/{namespace}:{id}.json"
+        "/latest/collections/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public Collection getByIdentifier(@PathVariable String namespace, @PathVariable String id)

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
@@ -267,8 +267,11 @@ public class CollectionController {
   @GetMapping(
       value = {
         "/v5/collections/identifier/{namespace}:{id}",
+            "/v5/collections/identifier/{namespace}:{id}.json",
         "/v2/collections/identifier/{namespace}:{id}",
-        "/latest/collections/identifier/{namespace}:{id}"
+            "/v2/collections/identifier/{namespace}:{id}.json",
+        "/latest/collections/identifier/{namespace}:{id}",
+            "/latest/collections/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public Collection getByIdentifier(@PathVariable String namespace, @PathVariable String id)

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
@@ -162,11 +162,11 @@ public class DigitalObjectController {
   @GetMapping(
       value = {
         "/v5/digitalobjects/identifier/{namespace}:{id}",
-            "/v5/digitalobjects/identifier/{namespace}:{id}.json",
+        "/v5/digitalobjects/identifier/{namespace}:{id}.json",
         "/v2/digitalobjects/identifier/{namespace}:{id}",
-            "/v2/digitalobjects/identifier/{namespace}:{id}.json",
+        "/v2/digitalobjects/identifier/{namespace}:{id}.json",
         "/latest/digitalobjects/identifier/{namespace}:{id}",
-            "/latest/digitalobjects/identifier/{namespace}:{id}.json"
+        "/latest/digitalobjects/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public DigitalObject getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
@@ -162,8 +162,11 @@ public class DigitalObjectController {
   @GetMapping(
       value = {
         "/v5/digitalobjects/identifier/{namespace}:{id}",
+            "/v5/digitalobjects/identifier/{namespace}:{id}.json",
         "/v2/digitalobjects/identifier/{namespace}:{id}",
-        "/latest/digitalobjects/identifier/{namespace}:{id}"
+            "/v2/digitalobjects/identifier/{namespace}:{id}.json",
+        "/latest/digitalobjects/identifier/{namespace}:{id}",
+            "/latest/digitalobjects/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public DigitalObject getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
@@ -107,9 +107,10 @@ public class EntityController<E extends Entity> {
   @Operation(summary = "Get entity by namespace and id")
   @GetMapping(
       value = {
-        "/v5/entities/identifier/{namespace}:{id}", "/v5/entities/identifier/{namespace}:{id}.json",
+        "/v5/entities/identifier/{namespace}:{id}",
+        "/v5/entities/identifier/{namespace}:{id}.json",
         "/latest/entities/identifier/{namespace}:{id}",
-            "/latest/entities/identifier/{namespace}:{id}.json"
+        "/latest/entities/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public Entity getByIdentifier(@PathVariable String namespace, @PathVariable String id)

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
@@ -107,8 +107,9 @@ public class EntityController<E extends Entity> {
   @Operation(summary = "Get entity by namespace and id")
   @GetMapping(
       value = {
-        "/v5/entities/identifier/{namespace}:{id}",
-        "/latest/entities/identifier/{namespace}:{id}"
+        "/v5/entities/identifier/{namespace}:{id}", "/v5/entities/identifier/{namespace}:{id}.json",
+        "/latest/entities/identifier/{namespace}:{id}",
+            "/latest/entities/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public Entity getByIdentifier(@PathVariable String namespace, @PathVariable String id)

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/HeadwordEntryController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/HeadwordEntryController.java
@@ -81,7 +81,10 @@ public class HeadwordEntryController {
 
   @Operation(summary = "Get an headwordentry by namespace and id")
   @GetMapping(
-      value = {"/v5/headwordentries/identifier/{namespace}:{id}"},
+      value = {
+        "/v5/headwordentries/identifier/{namespace}:{id}",
+        "/v5/headwordentries/identifier/{namespace}:{id}.json"
+      },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public HeadwordEntry getByIdentifier(
       @Parameter(example = "", description = "Namespace of the identifier")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
@@ -139,9 +139,10 @@ public class ProjectController {
   @Operation(summary = "Get project by namespace and id")
   @GetMapping(
       value = {
-        "/v5/projects/identifier/{namespace}:{id}",
-        "/v3/projects/identifier/{namespace}:{id}",
-        "/latest/projects/identifier/{namespace}:{id}"
+        "/v5/projects/identifier/{namespace}:{id}", "/v5/projects/identifier/{namespace}:{id}.json",
+        "/v3/projects/identifier/{namespace}:{id}", "/v3/projects/identifier/{namespace}:{id}.json",
+        "/latest/projects/identifier/{namespace}:{id}",
+            "/latest/projects/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public Project getByIdentifier(@PathVariable String namespace, @PathVariable String id)

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
@@ -78,8 +78,11 @@ public class CorporateBodyController {
   @GetMapping(
       value = {
         "/v5/corporatebodies/identifier/{namespace}:{id}",
+            "/v5/corporatebodies/identifier/{namespace}:{id}.json",
         "/v3/corporatebodies/identifier/{namespace}:{id}",
-        "/latest/corporatebodies/identifier/{namespace}:{id}"
+            "/v3/corporatebodies/identifier/{namespace}:{id}.json",
+        "/latest/corporatebodies/identifier/{namespace}:{id}",
+            "/latest/corporatebodies/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public CorporateBody getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
@@ -78,11 +78,11 @@ public class CorporateBodyController {
   @GetMapping(
       value = {
         "/v5/corporatebodies/identifier/{namespace}:{id}",
-            "/v5/corporatebodies/identifier/{namespace}:{id}.json",
+        "/v5/corporatebodies/identifier/{namespace}:{id}.json",
         "/v3/corporatebodies/identifier/{namespace}:{id}",
-            "/v3/corporatebodies/identifier/{namespace}:{id}.json",
+        "/v3/corporatebodies/identifier/{namespace}:{id}.json",
         "/latest/corporatebodies/identifier/{namespace}:{id}",
-            "/latest/corporatebodies/identifier/{namespace}:{id}.json"
+        "/latest/corporatebodies/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public CorporateBody getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
@@ -89,9 +89,10 @@ public class PersonController {
   @Operation(summary = "Get a person by namespace and id")
   @GetMapping(
       value = {
-        "/v5/persons/identifier/{namespace}:{id}",
-        "/v2/persons/identifier/{namespace}:{id}",
-        "/latest/persons/identifier/{namespace}:{id}"
+        "/v5/persons/identifier/{namespace}:{id}", "/v5/persons/identifier/{namespace}:{id}.json",
+        "/v2/persons/identifier/{namespace}:{id}", "/v2/persons/identifier/{namespace}:{id}.json",
+        "/latest/persons/identifier/{namespace}:{id}",
+            "/latest/persons/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Person> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
@@ -77,8 +77,11 @@ public class GeoLocationController {
   @GetMapping(
       value = {
         "/v5/geolocations/identifier/{namespace}:{id}",
+            "/v5/geolocations/identifier/{namespace}:{id}.json",
         "/v2/geolocations/identifier/{namespace}:{id}",
-        "/latest/geolocations/identifier/{namespace}:{id}"
+            "/v2/geolocations/identifier/{namespace}:{id}.json",
+        "/latest/geolocations/identifier/{namespace}:{id}",
+            "/latest/geolocations/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<GeoLocation> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
@@ -77,11 +77,11 @@ public class GeoLocationController {
   @GetMapping(
       value = {
         "/v5/geolocations/identifier/{namespace}:{id}",
-            "/v5/geolocations/identifier/{namespace}:{id}.json",
+        "/v5/geolocations/identifier/{namespace}:{id}.json",
         "/v2/geolocations/identifier/{namespace}:{id}",
-            "/v2/geolocations/identifier/{namespace}:{id}.json",
+        "/v2/geolocations/identifier/{namespace}:{id}.json",
         "/latest/geolocations/identifier/{namespace}:{id}",
-            "/latest/geolocations/identifier/{namespace}:{id}.json"
+        "/latest/geolocations/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<GeoLocation> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
@@ -68,11 +68,11 @@ public class HumanSettlementController {
   @GetMapping(
       value = {
         "/v5/humansettlements/identifier/{namespace}:{id}",
-            "/v5/humansettlements/identifier/{namespace}:{id}.json",
+        "/v5/humansettlements/identifier/{namespace}:{id}.json",
         "/v2/humansettlements/identifier/{namespace}:{id}",
-            "/v2/humansettlements/identifier/{namespace}:{id}.json",
+        "/v2/humansettlements/identifier/{namespace}:{id}.json",
         "/latest/humansettlements/identifier/{namespace}:{id}",
-            "/latest/humansettlements/identifier/{namespace}:{id}.json"
+        "/latest/humansettlements/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<HumanSettlement> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
@@ -68,8 +68,11 @@ public class HumanSettlementController {
   @GetMapping(
       value = {
         "/v5/humansettlements/identifier/{namespace}:{id}",
+            "/v5/humansettlements/identifier/{namespace}:{id}.json",
         "/v2/humansettlements/identifier/{namespace}:{id}",
-        "/latest/humansettlements/identifier/{namespace}:{id}"
+            "/v2/humansettlements/identifier/{namespace}:{id}.json",
+        "/latest/humansettlements/identifier/{namespace}:{id}",
+            "/latest/humansettlements/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<HumanSettlement> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
@@ -102,9 +102,10 @@ public class ItemController {
   @Operation(summary = "Get an item by namespace and id")
   @GetMapping(
       value = {
-        "/v5/items/identifier/{namespace}:{id}",
-        "/v2/items/identifier/{namespace}:{id}",
-        "/latest/items/identifier/{namespace}:{id}"
+        "/v5/items/identifier/{namespace}:{id}", "/v5/items/identifier/{namespace}:{id}.json",
+        "/v2/items/identifier/{namespace}:{id}", "/v2/items/identifier/{namespace}:{id}.json",
+        "/latest/items/identifier/{namespace}:{id}",
+            "/latest/items/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Item> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
@@ -76,9 +76,10 @@ public class WorkController {
   @Operation(summary = "Get a work by namespace and id")
   @GetMapping(
       value = {
-        "/v5/works/identifier/{namespace}:{id}",
-        "/v2/works/identifier/{namespace}:{id}",
+        "/v5/works/identifier/{namespace}:{id}", "/v5/works/identifier/{namespace}:{id}.json",
+        "/v2/works/identifier/{namespace}:{id}", "/v2/works/identifier/{namespace}:{id}.json",
         "/latest/works/identifier/{namespace}:{id}",
+            "/latest/works/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Work> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
@@ -76,10 +76,12 @@ public class WorkController {
   @Operation(summary = "Get a work by namespace and id")
   @GetMapping(
       value = {
-        "/v5/works/identifier/{namespace}:{id}", "/v5/works/identifier/{namespace}:{id}.json",
-        "/v2/works/identifier/{namespace}:{id}", "/v2/works/identifier/{namespace}:{id}.json",
+        "/v5/works/identifier/{namespace}:{id}",
+        "/v5/works/identifier/{namespace}:{id}.json",
+        "/v2/works/identifier/{namespace}:{id}",
+        "/v2/works/identifier/{namespace}:{id}.json",
         "/latest/works/identifier/{namespace}:{id}",
-            "/latest/works/identifier/{namespace}:{id}.json"
+        "/latest/works/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Work> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
@@ -124,11 +124,11 @@ public class FileResourceMetadataController {
   @GetMapping(
       value = {
         "/v5/fileresources/identifier/{namespace}:{id}",
-            "/v5/fileresources/identifier/{namespace}:{id}.json",
+        "/v5/fileresources/identifier/{namespace}:{id}.json",
         "/v2/fileresources/identifier/{namespace}:{id}",
-            "/v2/fileresources/identifier/{namespace}:{id}.json",
+        "/v2/fileresources/identifier/{namespace}:{id}.json",
         "/latest/fileresources/identifier/{namespace}:{id}",
-            "/latest/fileresources/identifier/{namespace}:{id}.json"
+        "/latest/fileresources/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<FileResource> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
@@ -124,8 +124,11 @@ public class FileResourceMetadataController {
   @GetMapping(
       value = {
         "/v5/fileresources/identifier/{namespace}:{id}",
+            "/v5/fileresources/identifier/{namespace}:{id}.json",
         "/v2/fileresources/identifier/{namespace}:{id}",
-        "/latest/fileresources/identifier/{namespace}:{id}"
+            "/v2/fileresources/identifier/{namespace}:{id}.json",
+        "/latest/fileresources/identifier/{namespace}:{id}",
+            "/latest/fileresources/identifier/{namespace}:{id}.json"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<FileResource> getByIdentifier(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/V3WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/V3WebpageController.java
@@ -140,7 +140,7 @@ public class V3WebpageController {
                     }))
       })
   @GetMapping(
-      value = {"/v3/webpages/{uuid}"},
+      value = {"/v3/webpages/{uuid}", "/v3/webpages/{uuid}.xml"},
       produces = MediaType.APPLICATION_XML_VALUE)
   public ResponseEntity<String> getWebpageXml(
       @Parameter(


### PR DESCRIPTION
Added explicit `.json` suffixed endpoints for getByIdentifier, since Spring Boot 2.6.6 ignores the `.json` suffix by default, but the existing java client uses them.