### PR TITLE
Fix for Mockito 4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.assertj-core>3.22.0</version.assertj-core>
+    <version.byte-buddy>1.12.8</version.byte-buddy>
     <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <version.commons-lang3>3.12.0</version.commons-lang3>
     <version.dc-model>9.2.0</version.dc-model>
@@ -83,7 +84,7 @@
     <version.javax.servlet-api>4.0.1</version.javax.servlet-api>
     <version.junit>5.8.2</version.junit>
     <version.logstash-logback-encoder>7.1.1</version.logstash-logback-encoder>
-    <version.mockito-core>4.4.0</version.mockito-core>
+    <version.mockito-core>4.5.1</version.mockito-core>
     <version.openjson>1.0.12</version.openjson>
     <version.passay>1.6.1</version.passay>
     <version.postgresql>42.3.3</version.postgresql>
@@ -198,6 +199,12 @@
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${version.javax.servlet-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>${version.byte-buddy}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
Mockito 4.5. benötigt ByteBuddy als explizite Dependency in der `pom.xml`