### PR TITLE
Fix editor copy&paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Updated multiple dependencies
 - Normalize method names: `getBy` for returning one object, `findBy` for returning a list of objects, "set" for saving a list after deleting previous list
 - Set default case sensitivity for sorting to `ignoreCase`
+- Fixed copy&paste of `iframe`, `image` and `video` blocks in the editor
 
 ### Removed
 

--- a/dc-cudami-editor/src/config/README.md
+++ b/dc-cudami-editor/src/config/README.md
@@ -1,1 +1,1 @@
-Most of the code in this directory was taken from [here](https://github.com/hubgit/react-prosemirror/tree/master/react-prosemirror-config-default), because it was needed to add some [custom](./custom) stuff.
+Most of the code in this directory was taken from [here](https://github.com/hubgit/react-prosemirror/tree/%40aeaton/react-prosemirror%400.22.1/react-prosemirror-config-default), because it was needed to add some [custom](./custom) stuff.

--- a/dc-cudami-editor/src/config/custom/IframeNode.js
+++ b/dc-cudami-editor/src/config/custom/IframeNode.js
@@ -1,3 +1,5 @@
+import {getAttributes} from '../utils'
+
 export default {
   attrs: {
     height: {default: '150px'},
@@ -8,6 +10,12 @@ export default {
   draggable: true,
   group: 'block',
   inline: false,
-  parseDOM: [{tag: 'prosemirror-iframe'}],
-  toDOM: () => ['prosemirror-iframe'],
+  parseDOM: [
+    {
+      tag: 'prosemirror-iframe',
+      getAttrs: (dom) =>
+        getAttributes(['height', 'src', 'title', 'width'], dom),
+    },
+  ],
+  toDOM: (node) => ['prosemirror-iframe', node.attrs],
 }

--- a/dc-cudami-editor/src/config/custom/ImageNode.js
+++ b/dc-cudami-editor/src/config/custom/ImageNode.js
@@ -1,3 +1,5 @@
+import {getAttributes} from '../utils'
+
 export default {
   attrs: {
     alignment: {default: null},
@@ -13,6 +15,25 @@ export default {
   draggable: true,
   group: 'block',
   inline: false,
-  parseDOM: [{tag: 'prosemirror-image'}],
-  toDOM: () => ['prosemirror-image'],
+  parseDOM: [
+    {
+      tag: 'prosemirror-image',
+      getAttrs: (dom) =>
+        getAttributes(
+          [
+            'alignment',
+            'altText',
+            'caption',
+            'linkNewTab',
+            'linkUrl',
+            'resourceId',
+            'title',
+            'url',
+            'width',
+          ],
+          dom,
+        ),
+    },
+  ],
+  toDOM: (node) => ['prosemirror-image', node.attrs],
 }

--- a/dc-cudami-editor/src/config/custom/LinkMark.js
+++ b/dc-cudami-editor/src/config/custom/LinkMark.js
@@ -1,3 +1,5 @@
+import {getAttributes} from '../utils'
+
 export default {
   attrs: {
     href: {default: null},
@@ -7,16 +9,8 @@ export default {
   parseDOM: [
     {
       tag: 'a[href]',
-      getAttrs(dom) {
-        return {
-          href: dom.getAttribute('href'),
-          title: dom.getAttribute('title'),
-        }
-      },
+      getAttrs: (dom) => getAttributes(['href', 'title'], dom),
     },
   ],
-  toDOM(node) {
-    let {href, title} = node.attrs
-    return ['a', {href, title}, 0]
-  },
+  toDOM: (node) => ['a', node.attrs],
 }

--- a/dc-cudami-editor/src/config/custom/VideoNode.js
+++ b/dc-cudami-editor/src/config/custom/VideoNode.js
@@ -1,3 +1,5 @@
+import {getAttributes} from '../utils'
+
 export default {
   attrs: {
     alignment: {default: null},
@@ -12,6 +14,24 @@ export default {
   draggable: true,
   group: 'block',
   inline: false,
-  parseDOM: [{tag: 'prosemirror-video'}],
-  toDOM: () => ['prosemirror-video'],
+  parseDOM: [
+    {
+      tag: 'prosemirror-video',
+      getAttrs: (dom) =>
+        getAttributes(
+          [
+            'alignment',
+            'caption',
+            'previewUrl',
+            'previewResourceId',
+            'resourceId',
+            'title',
+            'url',
+            'width',
+          ],
+          dom,
+        ),
+    },
+  ],
+  toDOM: (node) => ['prosemirror-video', node.attrs],
 }

--- a/dc-cudami-editor/src/config/utils.js
+++ b/dc-cudami-editor/src/config/utils.js
@@ -1,3 +1,6 @@
+export const getAttributes = (attrs, dom) =>
+  Object.fromEntries(attrs.map((attr) => [attr, dom.getAttribute(attr)]))
+
 export const markActive = (type) => (state) => {
   const {from, $from, to, empty} = state.selection
 


### PR DESCRIPTION
This PR fixes copy&paste of `iframe`, `image` and `video` blocks in the editor.