### PR TITLE
Add migration to create missing identifier types

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V12.04.00__DML_add_missing_identifier_types.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V12.04.00__DML_add_missing_identifier_types.sql
@@ -1,0 +1,19 @@
+/* select the namespaces of existing identifiers */
+WITH existing_identifier_namespaces AS (
+  SELECT DISTINCT namespace, namespace FROM identifiers
+)
+INSERT INTO identifiertypes (label, namespace, pattern, uuid)
+SELECT
+  existing_identifier_namespaces.*,
+  /* this allows everything as id */
+  '.+',
+  /*
+   * nasty hack to generate a random UUID without loading an extension
+   * (see: https://stackoverflow.com/questions/12505158/generating-a-uuid-in-postgres-for-insert-statement/21327318#21327318)
+   * there is a native function "gen_random_uuid" in PostgreSQL >= 13, but we need to support version 12
+   * (see: https://www.postgresql.org/docs/current/functions-uuid.html)
+   */
+  uuid_in(md5(random()::text || random()::text)::cstring)
+FROM existing_identifier_namespaces
+/* do nothing, if the namespace is already defined */
+ON CONFLICT (namespace) DO NOTHING;


### PR DESCRIPTION
In #1837 a validation of the given identifiers was added - to avoid a breaking change, a migration was added to take all the namespaces of existing identifiers and create a corresponding identifier type with pattern `.+` (matching everything).