### PR TITLE
Fix retrieval of numberOfBinaryResources

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -99,12 +99,6 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
               digitalObject.setCreationInfo(creationInfo);
             }
 
-            // Fill further attributes
-            Integer numberOfBinaryResources =
-                rowView.getColumn(MAPPING_PREFIX + "_number_binaryresources", Integer.class);
-            digitalObject.setNumberOfBinaryResources(
-                numberOfBinaryResources != null ? numberOfBinaryResources : 0);
-
             // set item UUID only
             UUID itemUuid = rowView.getColumn(MAPPING_PREFIX + "_item_uuid", UUID.class);
             if (itemUuid != null) {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v5/digitalobjects/filtered_by_parent.json
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v5/digitalobjects/filtered_by_parent.json
@@ -35,7 +35,6 @@
       "refId": 72,
       "fileResources": [],
       "linkedDataResources": [],
-      "numberOfBinaryResources": 0,
       "parent": {
         "uuid": "1c419226-8d61-4efa-923a-7fbaf961eb9d",
         "identifiers": [],
@@ -44,7 +43,6 @@
         "refId": 0,
         "fileResources": [],
         "linkedDataResources": [],
-        "numberOfBinaryResources": 0,
         "renderingResources": []
       },
       "renderingResources": []

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v6/digitalobjects/filtered_by_parent.json
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v6/digitalobjects/filtered_by_parent.json
@@ -35,7 +35,6 @@
       "refId": 72,
       "fileResources": [],
       "linkedDataResources": [],
-      "numberOfBinaryResources": 0,
       "parent": {
         "uuid": "1c419226-8d61-4efa-923a-7fbaf961eb9d",
         "identifiers": [],
@@ -44,7 +43,6 @@
         "refId": 0,
         "fileResources": [],
         "linkedDataResources": [],
-        "numberOfBinaryResources": 0,
         "renderingResources": []
       },
       "renderingResources": []

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v6/items/1c72ae9a-94e1-45b1-848f-da1303000924_digitalobjects.json
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v6/items/1c72ae9a-94e1-45b1-848f-da1303000924_digitalobjects.json
@@ -12,7 +12,6 @@
       "refId": 0,
       "fileResources": [],
       "linkedDataResources": [],
-      "numberOfBinaryResources": 0,
       "renderingResources": [],
       "entityType": "DIGITAL_OBJECT"
     }


### PR DESCRIPTION
This PR fixes the retrieval of `numberOfBinaryResources` for `DigitalObject` (the type has changed in https://github.com/dbmdz/digitalcollections-model/pull/355).