### PR TITLE
Allow creation of predicates in the standard way

### DIFF
--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClient.java
@@ -20,10 +20,18 @@ public class CudamiPredicatesClient extends CudamiRestClient<Predicate> {
   }
 
   public Predicate save(Predicate predicate) throws TechnicalException {
+    if (predicate.getUuid() == null) {
+      // create
+      return super.save(predicate);
+    }
+
+    // update by uuid
     return doPutRequestForObject(
-        String.format(
-            "%s/%s", baseEndpoint, URLEncoder.encode(predicate.getValue(), StandardCharsets.UTF_8)),
-        predicate);
+        String.format("%s/%s", baseEndpoint, predicate.getUuid()), predicate);
+  }
+
+  public Predicate create(Predicate predicate) throws TechnicalException {
+    return super.save(predicate);
   }
 
   public Predicate getByValue(String value) throws TechnicalException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClient.java
@@ -19,19 +19,17 @@ public class CudamiPredicatesClient extends CudamiRestClient<Predicate> {
     return doGetRequestForObjectList(baseEndpoint, Predicate.class);
   }
 
-  public Predicate save(Predicate predicate) throws TechnicalException {
+  public Predicate update(Predicate predicate) throws TechnicalException {
     if (predicate.getUuid() == null) {
-      // create
-      return super.save(predicate);
+      // Old consumers don't set the UUID, we must provide the value in the request path
+      return doPutRequestForObject(
+          String.format(
+              "%s/%s",
+              baseEndpoint, URLEncoder.encode(predicate.getValue(), StandardCharsets.UTF_8)),
+          predicate);
     }
 
-    // update by uuid
-    return doPutRequestForObject(
-        String.format("%s/%s", baseEndpoint, predicate.getUuid()), predicate);
-  }
-
-  public Predicate create(Predicate predicate) throws TechnicalException {
-    return super.save(predicate);
+    return super.update(predicate.getUuid(), predicate);
   }
 
   public Predicate getByValue(String value) throws TechnicalException {

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClientTest.java
@@ -1,0 +1,38 @@
+package de.digitalcollections.cudami.client.relation;
+
+import de.digitalcollections.cudami.client.BaseCudamiRestClientTest;
+import de.digitalcollections.model.relation.Predicate;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The PredicatesClient")
+class CudamiPredicatesClientTest
+    extends BaseCudamiRestClientTest<Predicate, CudamiPredicatesClient> {
+
+  @Test
+  @DisplayName("can update without uuid (old behaviour)")
+  public void testUpdateWithoutUuid() throws Exception {
+    Predicate predicate = Predicate.builder().value("foo").build();
+    client.update(predicate);
+
+    verifyHttpRequestByMethodRelativeUrlAndRequestBody("put", "/foo", predicate);
+  }
+
+  @Test
+  @DisplayName("can update with uuid")
+  public void testUpdateWithUuid() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    Predicate predicate = Predicate.builder().value("foo").uuid(uuid).build();
+    client.update(uuid, predicate);
+
+    verifyHttpRequestByMethodRelativeUrlAndRequestBody("put", "/" + uuid, predicate);
+  }
+
+  @Test
+  @DisplayName("can find all")
+  public void testFindAll() throws Exception {
+    client.getAll();
+    verifyHttpRequestByMethodAndRelativeURL("get", "");
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/alias/UrlAliasServiceImpl.java
@@ -351,7 +351,11 @@ public class UrlAliasServiceImpl implements UrlAliasService {
                 + ", website="
                 + u.getWebsite()
                 + ", target="
-                + u.getTargetUuid());
+                + u.getTargetUuid()
+                + " in "
+                + tuples
+                + " of "
+                + localizedUrlAliases);
       } else {
         tuples.add(key);
       }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/relation/PredicateController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/relation/PredicateController.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -56,6 +57,18 @@ public class PredicateController {
               + value
               + " does not match value of predicate="
               + (predicate != null ? predicate.getValue() : "null"));
+    }
+
+    return predicateService.save(predicate);
+  }
+
+  @Operation(summary = "create a predicate")
+  @PostMapping(
+      value = {"/v6/predicates", "/v5/predicates", "/v3/predicates", "/latest/predicates"},
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public Predicate create(@RequestBody Predicate predicate) throws PredicatesServiceException {
+    if (predicate == null || predicate.getValue() == null) {
+      throw new IllegalArgumentException("Invalid predicate: " + predicate);
     }
 
     return predicateService.save(predicate);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/resources/application-typedeclarations.yml
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/resources/application-typedeclarations.yml
@@ -22,6 +22,7 @@ cudami:
       - TOPIC
 
     tagTypes:
+      - GENRE
       - IDENTIFIER
       - SHELFGROUP
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/relation/PredicateControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/relation/PredicateControllerTest.java
@@ -1,0 +1,41 @@
+package de.digitalcollections.cudami.server.controller.relation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import de.digitalcollections.cudami.server.business.api.service.relation.PredicateService;
+import de.digitalcollections.cudami.server.controller.BaseControllerTest;
+import de.digitalcollections.model.relation.Predicate;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.Locale;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(PredicateController.class)
+@DisplayName("The PredicateController")
+class PredicateControllerTest extends BaseControllerTest {
+
+  @MockBean private PredicateService predicateService;
+
+  @DisplayName("can create a predicate")
+  @Test
+  public void create() throws Exception {
+    UUID uuid = UUID.fromString("bb5885f6-fd24-48e9-99f6-1f1a49d239bf");
+    Predicate predicate =
+        Predicate.builder()
+            .value("foo")
+            .label(new LocalizedText(Locale.ROOT, "bar"))
+            .uuid(uuid)
+            .build();
+
+    String jsonBody =
+        "{\"objectType\":\"PREDICATE\",\"value\":\"foo\",\"label\": {" + "\"\": \"bar\"" + "}}";
+
+    when(predicateService.save(any(Predicate.class))).thenReturn(predicate);
+
+    testPostJson("/v6/predicates", jsonBody, "/v6/relation/predicates/predicates_response.json");
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/relation/PredicateControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/relation/PredicateControllerTest.java
@@ -20,9 +20,9 @@ class PredicateControllerTest extends BaseControllerTest {
 
   @MockBean private PredicateService predicateService;
 
-  @DisplayName("can create a predicate")
+  @DisplayName("can save a predicate without UUID")
   @Test
-  public void create() throws Exception {
+  public void save() throws Exception {
     UUID uuid = UUID.fromString("bb5885f6-fd24-48e9-99f6-1f1a49d239bf");
     Predicate predicate =
         Predicate.builder()
@@ -31,11 +31,85 @@ class PredicateControllerTest extends BaseControllerTest {
             .uuid(uuid)
             .build();
 
+    // We save a predicate without UUID
     String jsonBody =
         "{\"objectType\":\"PREDICATE\",\"value\":\"foo\",\"label\": {" + "\"\": \"bar\"" + "}}";
 
     when(predicateService.save(any(Predicate.class))).thenReturn(predicate);
 
     testPostJson("/v6/predicates", jsonBody, "/v6/relation/predicates/predicates_response.json");
+    testPostJson("/v5/predicates", jsonBody, "/v6/relation/predicates/predicates_response.json");
+    testPostJson("/v3/predicates", jsonBody, "/v6/relation/predicates/predicates_response.json");
+    testPostJson(
+        "/latest/predicates", jsonBody, "/v6/relation/predicates/predicates_response.json");
+  }
+
+  @DisplayName(
+      "can save a predicate without UUID but with value in path (old style, where save and update were equal)")
+  @Test
+  public void saveWithValueInPath() throws Exception {
+    UUID uuid = UUID.fromString("bb5885f6-fd24-48e9-99f6-1f1a49d239bf");
+    Predicate predicate =
+        Predicate.builder()
+            .value("foo")
+            .label(new LocalizedText(Locale.ROOT, "bar"))
+            .uuid(uuid)
+            .build();
+
+    // We save a predicate without UUID
+    String jsonBody =
+        "{\"objectType\":\"PREDICATE\",\"value\":\"foo\",\"label\": {" + "\"\": \"bar\"" + "}}";
+
+    when(predicateService.save(any(Predicate.class))).thenReturn(predicate);
+
+    // Yes, it really works with put!
+    testPutJson("/v6/predicates/foo", jsonBody, "/v6/relation/predicates/predicates_response.json");
+    testPutJson("/v5/predicates/foo", jsonBody, "/v6/relation/predicates/predicates_response.json");
+    testPutJson("/v3/predicates/foo", jsonBody, "/v6/relation/predicates/predicates_response.json");
+    testPutJson(
+        "/latest/predicates/foo", jsonBody, "/v6/relation/predicates/predicates_response.json");
+  }
+
+  @DisplayName("can update a predicate by its value, without uuid (used by old clients)")
+  @Test
+  public void updateByValueWithoutUuid() throws Exception {
+    UUID uuid = UUID.fromString("bb5885f6-fd24-48e9-99f6-1f1a49d239bf");
+    Predicate predicate =
+        Predicate.builder()
+            .value("foo")
+            .label(new LocalizedText(Locale.ROOT, "bar"))
+            .uuid(uuid)
+            .build();
+
+    // We update a predicate without UUID
+    String jsonBody =
+        "{\"objectType\":\"PREDICATE\",\"value\":\"foo\",\"label\": {" + "\"\": \"bar\"" + "}}";
+    when(predicateService.save(any(Predicate.class))).thenReturn(predicate);
+
+    testPutJson("/v6/predicates/foo", jsonBody, "/v6/relation/predicates/predicates_response.json");
+  }
+
+  @DisplayName("can update a predicate by its uuid")
+  @Test
+  public void updateByUuid() throws Exception {
+    UUID uuid = UUID.fromString("bb5885f6-fd24-48e9-99f6-1f1a49d239bf");
+    Predicate predicate =
+        Predicate.builder()
+            .value("foo")
+            .label(new LocalizedText(Locale.ROOT, "bar"))
+            .uuid(uuid)
+            .build();
+
+    // We update a predicate without UUID
+    String jsonBody =
+        "{\"uuid\":\""
+            + uuid
+            + "\",\"objectType\":\"PREDICATE\",\"value\":\"foo\",\"label\": {"
+            + "\"\": \"bar\""
+            + "}}";
+    when(predicateService.save(any(Predicate.class))).thenReturn(predicate);
+
+    testPutJson(
+        "/v6/predicates/" + uuid, jsonBody, "/v6/relation/predicates/predicates_response.json");
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v6/relation/predicates/predicates_response.json
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v6/relation/predicates/predicates_response.json
@@ -1,0 +1,8 @@
+{
+  "objectType": "PREDICATE",
+  "uuid": "bb5885f6-fd24-48e9-99f6-1f1a49d239bf",
+  "label": {
+    "": "bar"
+  },
+  "value": "foo"
+}


### PR DESCRIPTION
Allow creation of predicates in the standard way (POST-only without `value` in the path)