### PR TITLE
Refactor server side configuration and null-return handling to 404

### DIFF
--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/advice/GlobalControllerAdvice.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/advice/GlobalControllerAdvice.java
@@ -36,8 +36,18 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(ResourceNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public String handleResourceNotFoundException(Model model) {
+    /*
+    unsuitable for REST APIs. For such cases it is
+    preferable to use a ResponseEntity as
+    a return type and avoid the use of @ResponseStatus altogether.
+    */
     return "error/404";
   }
+
+  //  @ExceptionHandler(ResourceNotFoundException.class)
+  //  public ResponseEntity handleResourceNotFoundException(Model model) {
+  //    return ResponseEntity.notFound().build();
+  //  }
 
   @InitBinder
   public void registerCustomEditors(WebDataBinder binder, WebRequest request) {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiClient.java
@@ -33,6 +33,7 @@ import de.digitalcollections.cudami.client.legal.CudamiLicensesClient;
 import de.digitalcollections.cudami.client.relation.CudamiPredicatesClient;
 import de.digitalcollections.cudami.client.security.CudamiUsersClient;
 import de.digitalcollections.cudami.client.semantic.CudamiHeadwordsClient;
+import de.digitalcollections.cudami.client.semantic.CudamiTagsClient;
 import de.digitalcollections.cudami.client.view.CudamiRenderingTemplatesClient;
 import de.digitalcollections.model.identifiable.Identifiable;
 import java.net.http.HttpClient;

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiLocalesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiLocalesClient.java
@@ -5,6 +5,7 @@ import static de.digitalcollections.cudami.client.CudamiRestClient.API_VERSION_P
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.client.BaseRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
@@ -31,10 +32,18 @@ public class CudamiLocalesClient extends BaseRestClient<Locale> {
   }
 
   public Locale getDefaultLanguage() throws TechnicalException {
-    return doGetRequestForObject(API_VERSION_PREFIX + "/languages/default");
+    try {
+      return doGetRequestForObject(API_VERSION_PREFIX + "/languages/default");
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public String getDefaultLocale() throws TechnicalException {
-    return doGetRequestForString(baseEndpoint + "/default");
+    try {
+      return doGetRequestForString(baseEndpoint + "/default");
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiRestClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/CudamiRestClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.client.BaseRestClient;
 import de.digitalcollections.model.UniqueObject;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import java.net.http.HttpClient;
@@ -32,7 +33,10 @@ public class CudamiRestClient<T extends UniqueObject> extends BaseRestClient<T> 
   }
 
   public void deleteByUuid(UUID uuid) throws TechnicalException {
-    doDeleteRequestForString(String.format("%s/%s", baseEndpoint, uuid));
+    try {
+      doDeleteRequestForString(String.format("%s/%s", baseEndpoint, uuid));
+    } catch (ResourceNotFoundException e) {
+    }
   }
 
   public PageResponse<T> find(PageRequest pageRequest) throws TechnicalException {
@@ -44,7 +48,11 @@ public class CudamiRestClient<T extends UniqueObject> extends BaseRestClient<T> 
   }
 
   public T getByUuid(UUID uuid) throws TechnicalException {
-    return doGetRequestForObject(String.format("%s/%s", baseEndpoint, uuid));
+    try {
+      return doGetRequestForObject(String.format("%s/%s", baseEndpoint, uuid));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public T save(T object) throws TechnicalException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.identifiable;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.CudamiRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
 import de.digitalcollections.model.list.filtering.FilterCriterion;
@@ -133,11 +134,15 @@ public class CudamiIdentifiablesClient<I extends Identifiable> extends CudamiRes
                   .collect(Collectors.joining("&"));
     }
 
-    return doGetRequestForObject(
-        String.format(
-            baseEndpoint + "/identifier/%s%s",
-            encodedNamespaceAndId,
-            expandedAdditionalParameters));
+    try {
+      return doGetRequestForObject(
+          String.format(
+              baseEndpoint + "/identifier/%s%s",
+              encodedNamespaceAndId,
+              expandedAdditionalParameters));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   /**
@@ -157,7 +162,11 @@ public class CudamiIdentifiablesClient<I extends Identifiable> extends CudamiRes
   }
 
   public I getByUuidAndLocale(UUID uuid, String locale) throws TechnicalException {
-    return doGetRequestForObject(String.format(baseEndpoint + "/%s?locale=%s", uuid, locale));
+    try {
+      return doGetRequestForObject(String.format(baseEndpoint + "/%s?locale=%s", uuid, locale));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public List<Locale> getLanguages() throws TechnicalException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifierTypesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifierTypesClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.identifiable;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.CudamiRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.IdentifierType;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -23,10 +24,18 @@ public class CudamiIdentifierTypesClient extends CudamiRestClient<IdentifierType
   }
 
   public IdentifierType getByNamespace(String namespace) throws TechnicalException {
-    return doGetRequestForObject(String.format(baseEndpoint + "/namespace/%s", namespace));
+    try {
+      return doGetRequestForObject(String.format(baseEndpoint + "/namespace/%s", namespace));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public IdentifierType getByUuidAndLocale(UUID uuid, String locale) throws TechnicalException {
-    return doGetRequestForObject(String.format(baseEndpoint + "/%s?locale=%s", uuid, locale));
+    try {
+      return doGetRequestForObject(String.format(baseEndpoint + "/%s?locale=%s", uuid, locale));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/alias/CudamiUrlAliasClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/alias/CudamiUrlAliasClient.java
@@ -5,6 +5,7 @@ import static de.digitalcollections.cudami.client.CudamiRestClient.API_VERSION_P
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.client.BaseRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
 import de.digitalcollections.model.identifiable.alias.UrlAlias;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -37,41 +38,53 @@ public class CudamiUrlAliasClient extends BaseRestClient<UrlAlias> {
       throw new TechnicalException("generateSlug", e);
     }
 
-    if (websiteUuid == null) {
+    try {
+      if (websiteUuid == null) {
+        return doGetRequestForString(
+            String.format(baseEndpoint + "/slug/%s/%s", locale, encodedLabel));
+      }
       return doGetRequestForString(
-          String.format(baseEndpoint + "/slug/%s/%s", locale, encodedLabel));
+          String.format(baseEndpoint + "/slug/%s/%s/%s", locale, encodedLabel, websiteUuid));
+    } catch (ResourceNotFoundException e) {
+      return null;
     }
-    return doGetRequestForString(
-        String.format(baseEndpoint + "/slug/%s/%s/%s", locale, encodedLabel, websiteUuid));
   }
 
   public LocalizedUrlAliases getPrimaryLinks(UUID websiteUuid, String slug)
       throws TechnicalException {
-    if (websiteUuid == null) {
+    try {
+      if (websiteUuid == null) {
+        return (LocalizedUrlAliases)
+            doGetRequestForObject(
+                String.format(baseEndpoint + "/primary/%s", slug), LocalizedUrlAliases.class);
+      }
+
       return (LocalizedUrlAliases)
           doGetRequestForObject(
-              String.format(baseEndpoint + "/primary/%s", slug), LocalizedUrlAliases.class);
+              String.format(baseEndpoint + "/primary/%s/%s", slug, websiteUuid),
+              LocalizedUrlAliases.class);
+    } catch (ResourceNotFoundException e) {
+      return null;
     }
-
-    return (LocalizedUrlAliases)
-        doGetRequestForObject(
-            String.format(baseEndpoint + "/primary/%s/%s", slug, websiteUuid),
-            LocalizedUrlAliases.class);
   }
 
   public LocalizedUrlAliases getPrimaryLinksForLocale(UUID websiteUuid, String slug, Locale pLocale)
       throws TechnicalException {
-    if (websiteUuid == null) {
+    try {
+      if (websiteUuid == null) {
+        return (LocalizedUrlAliases)
+            doGetRequestForObject(
+                String.format(baseEndpoint + "/primary/%s?pLocale=%s", slug, pLocale),
+                LocalizedUrlAliases.class);
+      }
+
       return (LocalizedUrlAliases)
           doGetRequestForObject(
-              String.format(baseEndpoint + "/primary/%s?pLocale=%s", slug, pLocale),
+              String.format(baseEndpoint + "/primary/%s/%s?pLocale=%s", slug, websiteUuid, pLocale),
               LocalizedUrlAliases.class);
+    } catch (ResourceNotFoundException e) {
+      return null;
     }
-
-    return (LocalizedUrlAliases)
-        doGetRequestForObject(
-            String.format(baseEndpoint + "/primary/%s/%s?pLocale=%s", slug, websiteUuid, pLocale),
-            LocalizedUrlAliases.class);
   }
 
   public boolean isPrimary(UUID websiteUuid, String slug) throws TechnicalException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiArticlesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiArticlesClient.java
@@ -2,6 +2,7 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.Article;
 import java.net.http.HttpClient;
 import java.util.Locale;
@@ -14,10 +15,14 @@ public class CudamiArticlesClient extends CudamiEntitiesClient<Article> {
   }
 
   public Article getByUuid(UUID uuid, Locale locale) throws TechnicalException {
-    if (locale != null) {
-      return doGetRequestForObject(String.format(baseEndpoint + "/%s?pLocale=%s", uuid, locale));
-    } else {
-      return doGetRequestForObject(String.format(baseEndpoint + "/%s", uuid));
+    try {
+      if (locale != null) {
+        return doGetRequestForObject(String.format(baseEndpoint + "/%s?pLocale=%s", uuid, locale));
+      } else {
+        return doGetRequestForObject(String.format(baseEndpoint + "/%s", uuid));
+      }
+    } catch (ResourceNotFoundException e) {
+      return null;
     }
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiCollectionsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiCollectionsClient.java
@@ -2,6 +2,7 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
@@ -22,32 +23,46 @@ public class CudamiCollectionsClient extends CudamiEntitiesClient<Collection> {
 
   public boolean addDigitalObject(UUID collectionUuid, UUID digitalObjectUuid)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPostRequestForString(
-            String.format(
-                baseEndpoint + "/%s/digitalobjects/%s", collectionUuid, digitalObjectUuid)));
+    try {
+      doPostRequestForString(
+          String.format(baseEndpoint + "/%s/digitalobjects/%s", collectionUuid, digitalObjectUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public boolean addDigitalObjects(UUID collectionUuid, List<DigitalObject> digitalObjects)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPostRequestForString(
-            String.format(baseEndpoint + "/%s/digitalobjects", collectionUuid), digitalObjects));
+    try {
+      doPostRequestForString(
+          String.format(baseEndpoint + "/%s/digitalobjects", collectionUuid), digitalObjects);
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public boolean addSubcollection(UUID collectionUuid, UUID subcollectionUuid)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPostRequestForString(
-            String.format(
-                baseEndpoint + "/%s/subcollections/%s", collectionUuid, subcollectionUuid)));
+    try {
+      doPostRequestForString(
+          String.format(baseEndpoint + "/%s/subcollections/%s", collectionUuid, subcollectionUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public boolean addSubcollections(UUID collectionUuid, List<Collection> subcollections)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPostRequestForString(
-            String.format(baseEndpoint + "/%s/subcollections", collectionUuid), subcollections));
+    try {
+      doPostRequestForString(
+          String.format(baseEndpoint + "/%s/subcollections", collectionUuid), subcollections);
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public PageResponse<Collection> findActive(PageRequest pageRequest) throws TechnicalException {
@@ -96,14 +111,22 @@ public class CudamiCollectionsClient extends CudamiEntitiesClient<Collection> {
   }
 
   public Collection getActiveByUuid(UUID uuid, Locale locale) throws TechnicalException {
-    return doGetRequestForObject(
-        String.format(baseEndpoint + "/%s?active=true&pLocale=%s", uuid, locale));
+    try {
+      return doGetRequestForObject(
+          String.format(baseEndpoint + "/%s?active=true&pLocale=%s", uuid, locale));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public BreadcrumbNavigation getBreadcrumbNavigation(UUID uuid) throws TechnicalException {
-    return (BreadcrumbNavigation)
-        doGetRequestForObject(
-            String.format(baseEndpoint + "/%s/breadcrumb", uuid), BreadcrumbNavigation.class);
+    try {
+      return (BreadcrumbNavigation)
+          doGetRequestForObject(
+              String.format(baseEndpoint + "/%s/breadcrumb", uuid), BreadcrumbNavigation.class);
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public List<Locale> getLanguagesOfTopCollections() throws TechnicalException {
@@ -121,18 +144,24 @@ public class CudamiCollectionsClient extends CudamiEntitiesClient<Collection> {
 
   public boolean removeDigitalObject(UUID collectionUuid, UUID digitalObjectUuid)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doDeleteRequestForString(
-            String.format(
-                baseEndpoint + "/%s/digitalobjects/%s", collectionUuid, digitalObjectUuid)));
+    try {
+      doDeleteRequestForString(
+          String.format(baseEndpoint + "/%s/digitalobjects/%s", collectionUuid, digitalObjectUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public boolean removeSubcollection(UUID collectionUuid, UUID subcollectionUuid)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doDeleteRequestForString(
-            String.format(
-                baseEndpoint + "/%s/subcollections/%s", collectionUuid, subcollectionUuid)));
+    try {
+      doDeleteRequestForString(
+          String.format(baseEndpoint + "/%s/subcollections/%s", collectionUuid, subcollectionUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public Collection saveWithParentCollection(Collection collection, UUID parentCollectionUuid)
@@ -143,11 +172,14 @@ public class CudamiCollectionsClient extends CudamiEntitiesClient<Collection> {
 
   public boolean setDigitalObjects(UUID collectionUuid, List<DigitalObject> digitalObjects)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        (String)
-            doPutRequestForObject(
-                String.format(baseEndpoint + "/%s/digitalobjects", collectionUuid),
-                digitalObjects,
-                String.class));
+    try {
+      doPutRequestForObject(
+          String.format(baseEndpoint + "/%s/digitalobjects", collectionUuid),
+          digitalObjects,
+          String.class);
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiEntitiesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiEntitiesClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.identifiable.CudamiIdentifiablesClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.entity.relation.EntityRelation;
 import de.digitalcollections.model.identifiable.resource.FileResource;
@@ -53,7 +54,11 @@ public class CudamiEntitiesClient<E extends Entity> extends CudamiIdentifiablesC
   }
 
   public E getByRefId(long refId) throws TechnicalException {
-    return doGetRequestForObject(String.format("%s/%d", baseEndpoint, refId));
+    try {
+      return doGetRequestForObject(String.format("%s/%d", baseEndpoint, refId));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public List getRandomEntities(int count) throws TechnicalException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiProjectsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiProjectsClient.java
@@ -2,6 +2,7 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.Project;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -18,17 +19,24 @@ public class CudamiProjectsClient extends CudamiEntitiesClient<Project> {
 
   public boolean addDigitalObject(UUID projectUuid, UUID digitalObjectUuid)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPostRequestForString(
-            String.format(
-                "%s/%s/digitalobjects/%s", baseEndpoint, projectUuid, digitalObjectUuid)));
+    try {
+      doPostRequestForString(
+          String.format("%s/%s/digitalobjects/%s", baseEndpoint, projectUuid, digitalObjectUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public boolean addDigitalObjects(UUID projectUuid, List<DigitalObject> digitalObjects)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPostRequestForString(
-            String.format("%s/%s/digitalobjects", baseEndpoint, projectUuid), digitalObjects));
+    try {
+      doPostRequestForString(
+          String.format("%s/%s/digitalobjects", baseEndpoint, projectUuid), digitalObjects);
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public PageResponse<DigitalObject> findDigitalObjects(UUID projectUuid, PageRequest pageRequest)
@@ -41,19 +49,25 @@ public class CudamiProjectsClient extends CudamiEntitiesClient<Project> {
 
   public boolean removeDigitalObject(UUID projectUuid, UUID digitalObjectUuid)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doDeleteRequestForString(
-            String.format(
-                "%s/%s/digitalobjects/%s", baseEndpoint, projectUuid, digitalObjectUuid)));
+    try {
+      doDeleteRequestForString(
+          String.format("%s/%s/digitalobjects/%s", baseEndpoint, projectUuid, digitalObjectUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public boolean setDigitalObjects(UUID projectUuid, List<DigitalObject> digitalObjects)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        (String)
-            doPutRequestForObject(
-                String.format("%s/%s/digitalobjects", baseEndpoint, projectUuid),
-                digitalObjects,
-                String.class));
+    try {
+      doPutRequestForObject(
+          String.format("%s/%s/digitalobjects", baseEndpoint, projectUuid),
+          digitalObjects,
+          String.class);
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiTopicsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiTopicsClient.java
@@ -2,6 +2,7 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.entity.Topic;
 import de.digitalcollections.model.identifiable.resource.FileResource;
@@ -53,9 +54,13 @@ public class CudamiTopicsClient extends CudamiEntitiesClient<Topic> {
   }
 
   public BreadcrumbNavigation getBreadcrumbNavigation(UUID uuid) throws TechnicalException {
-    return (BreadcrumbNavigation)
-        doGetRequestForObject(
-            String.format("%s/%s/breadcrumb", baseEndpoint, uuid), BreadcrumbNavigation.class);
+    try {
+      return (BreadcrumbNavigation)
+          doGetRequestForObject(
+              String.format("%s/%s/breadcrumb", baseEndpoint, uuid), BreadcrumbNavigation.class);
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public List<Topic> getChildren(UUID uuid) throws TechnicalException {
@@ -89,14 +94,22 @@ public class CudamiTopicsClient extends CudamiEntitiesClient<Topic> {
   }
 
   public boolean removeChild(UUID parentUuid, UUID childUuid) throws TechnicalException {
-    return Boolean.parseBoolean(
-        doDeleteRequestForString(
-            String.format("%s/%s/children/%s", baseEndpoint, parentUuid, childUuid)));
+    try {
+      doDeleteRequestForString(
+          String.format("%s/%s/children/%s", baseEndpoint, parentUuid, childUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public Topic saveWithParentTopic(Topic subtopic, UUID parentTopicUuid) throws TechnicalException {
-    return doPostRequestForObject(
-        String.format("%s/%s/subtopic", baseEndpoint, parentTopicUuid), subtopic);
+    try {
+      return doPostRequestForObject(
+          String.format("%s/%s/subtopic", baseEndpoint, parentTopicUuid), subtopic);
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public List<Entity> setEntities(UUID uuid, List entities) throws TechnicalException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiWebsitesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/CudamiWebsitesClient.java
@@ -2,6 +2,7 @@ package de.digitalcollections.cudami.client.identifiable.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.Website;
 import de.digitalcollections.model.identifiable.web.Webpage;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -24,8 +25,11 @@ public class CudamiWebsitesClient extends CudamiEntitiesClient<Website> {
 
   public boolean updateRootWebpagesOrder(UUID websiteUuid, List<Webpage> rootpages)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPutRequestForString(
-            String.format("%s/%s/rootpages", baseEndpoint, websiteUuid), rootpages));
+    try {
+      doPutRequestForString(String.format("%s/%s/rootpages", baseEndpoint, websiteUuid), rootpages);
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiCorporateBodiesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/agent/CudamiCorporateBodiesClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.identifiable.entity.agent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.identifiable.entity.CudamiEntitiesClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
 import java.net.http.HttpClient;
 
@@ -13,6 +14,10 @@ public class CudamiCorporateBodiesClient extends CudamiEntitiesClient<CorporateB
   }
 
   public CorporateBody fetchAndSaveByGndId(String gndId) throws TechnicalException {
-    return doPostRequestForObject(String.format("%s/gnd/%s", baseEndpoint, gndId));
+    try {
+      return doPostRequestForObject(String.format("%s/gnd/%s", baseEndpoint, gndId));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/semantic/CudamiSubjectsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/semantic/CudamiSubjectsClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.identifiable.entity.semantic;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.CudamiRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.semantic.Subject;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
@@ -28,8 +29,12 @@ public class CudamiSubjectsClient extends CudamiRestClient<Subject> {
     String encodedNamespaceAndId =
         Base64.encodeBase64URLSafeString(namespaceAndId.getBytes(StandardCharsets.UTF_8));
 
-    return doGetRequestForObject(
-        String.format(baseEndpoint + "/identifier/%s", encodedNamespaceAndId));
+    try {
+      return doGetRequestForObject(
+          String.format(baseEndpoint + "/identifier/%s", encodedNamespaceAndId));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   /**
@@ -48,7 +53,11 @@ public class CudamiSubjectsClient extends CudamiRestClient<Subject> {
     String encodedTypeAndNamespaceAndId =
         Base64.encodeBase64URLSafeString(typeAndNamespaceAndId.getBytes(StandardCharsets.UTF_8));
 
-    return doGetRequestForObject(
-        String.format(baseEndpoint + "/identifier/%s", encodedTypeAndNamespaceAndId));
+    try {
+      return doGetRequestForObject(
+          String.format(baseEndpoint + "/identifier/%s", encodedTypeAndNamespaceAndId));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/work/CudamiItemsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/entity/work/CudamiItemsClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.identifiable.entity.work;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.identifiable.entity.CudamiEntitiesClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.item.Item;
 import de.digitalcollections.model.identifiable.entity.work.Work;
@@ -21,17 +22,23 @@ public class CudamiItemsClient extends CudamiEntitiesClient<Item> {
     super(http, serverUrl, Item.class, mapper, API_VERSION_PREFIX + "/items");
   }
 
-  public Boolean addDigitalObject(UUID itemUuid, UUID digitalObjectUuid) throws TechnicalException {
-    return (Boolean)
-        doPostRequestForObject(
-            String.format("%s/%s/digitalobjects/%s", baseEndpoint, itemUuid, digitalObjectUuid),
-            Boolean.class);
+  public boolean addDigitalObject(UUID itemUuid, UUID digitalObjectUuid) throws TechnicalException {
+    try {
+      doPostRequestForObject(
+          String.format("%s/%s/digitalobjects/%s", baseEndpoint, itemUuid, digitalObjectUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public boolean addWork(UUID itemUuid, UUID workUuid) throws TechnicalException {
-    return (boolean)
-        doPostRequestForObject(
-            String.format("%s/%s/works/%s", baseEndpoint, itemUuid, workUuid), Boolean.class);
+    try {
+      doPostRequestForObject(String.format("%s/%s/works/%s", baseEndpoint, itemUuid, workUuid));
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   public PageResponse<DigitalObject> findDigitalObjects(UUID uuid, PageRequest pageRequest)

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/web/CudamiWebpagesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/web/CudamiWebpagesClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.identifiable.web;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.identifiable.CudamiIdentifiablesClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.entity.Website;
 import de.digitalcollections.model.identifiable.resource.FileResource;
 import de.digitalcollections.model.identifiable.web.Webpage;
@@ -57,9 +58,13 @@ public class CudamiWebpagesClient extends CudamiIdentifiablesClient<Webpage> {
   }
 
   public BreadcrumbNavigation getBreadcrumbNavigation(UUID uuid) throws TechnicalException {
-    return (BreadcrumbNavigation)
-        doGetRequestForObject(
-            String.format("%s/%s/breadcrumb", baseEndpoint, uuid), BreadcrumbNavigation.class);
+    try {
+      return (BreadcrumbNavigation)
+          doGetRequestForObject(
+              String.format("%s/%s/breadcrumb", baseEndpoint, uuid), BreadcrumbNavigation.class);
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public List<Webpage> getChildren(UUID uuid) throws TechnicalException {
@@ -99,8 +104,11 @@ public class CudamiWebpagesClient extends CudamiIdentifiablesClient<Webpage> {
 
   public boolean updateChildrenOrder(UUID webpageUuid, List<Webpage> children)
       throws TechnicalException {
-    return Boolean.parseBoolean(
-        doPutRequestForString(
-            String.format("%s/%s/children", baseEndpoint, webpageUuid), children));
+    try {
+      doPutRequestForString(String.format("%s/%s/children", baseEndpoint, webpageUuid), children);
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/legal/CudamiLicensesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/legal/CudamiLicensesClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.legal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.CudamiRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.legal.License;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -39,8 +40,12 @@ public class CudamiLicensesClient extends CudamiRestClient<License> {
   }
 
   public License getByUrl(String url) throws TechnicalException {
-    return doGetRequestForObject(
-        String.format("%s?url=%s", baseEndpoint, URLEncoder.encode(url, StandardCharsets.UTF_8)));
+    try {
+      return doGetRequestForObject(
+          String.format("%s?url=%s", baseEndpoint, URLEncoder.encode(url, StandardCharsets.UTF_8)));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public License getByUrl(URL url) throws TechnicalException {
@@ -48,6 +53,6 @@ public class CudamiLicensesClient extends CudamiRestClient<License> {
   }
 
   public List<Locale> getLanguages() throws TechnicalException {
-    return this.doGetRequestForObjectList(baseEndpoint + "/languages", Locale.class);
+    return doGetRequestForObjectList(baseEndpoint + "/languages", Locale.class);
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/relation/CudamiPredicatesClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.relation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.CudamiRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.relation.Predicate;
@@ -33,8 +34,12 @@ public class CudamiPredicatesClient extends CudamiRestClient<Predicate> {
   }
 
   public Predicate getByValue(String value) throws TechnicalException {
-    return doGetRequestForObject(
-        String.format("%s/%s", baseEndpoint, URLEncoder.encode(value, StandardCharsets.UTF_8)));
+    try {
+      return doGetRequestForObject(
+          String.format("%s/%s", baseEndpoint, URLEncoder.encode(value, StandardCharsets.UTF_8)));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 
   public List<Locale> getLanguages() throws TechnicalException {

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/security/CudamiUsersClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/security/CudamiUsersClient.java
@@ -3,6 +3,7 @@ package de.digitalcollections.cudami.client.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.CudamiRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.security.User;
 import java.net.http.HttpClient;
 import java.util.List;
@@ -23,6 +24,10 @@ public class CudamiUsersClient extends CudamiRestClient<User> {
   }
 
   public User getByEmail(String email) throws TechnicalException {
-    return doGetRequestForObject(String.format("%s?email=%s", baseEndpoint, email));
+    try {
+      return doGetRequestForObject(String.format("%s?email=%s", baseEndpoint, email));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 }

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/semantic/CudamiTagsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/semantic/CudamiTagsClient.java
@@ -1,7 +1,11 @@
-package de.digitalcollections.cudami.client;
+package de.digitalcollections.cudami.client.semantic;
+
+import static de.digitalcollections.cudami.client.CudamiRestClient.API_VERSION_PREFIX;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.digitalcollections.cudami.client.CudamiRestClient;
 import de.digitalcollections.model.exception.TechnicalException;
+import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.semantic.Tag;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
@@ -29,7 +33,11 @@ public class CudamiTagsClient extends CudamiRestClient<Tag> {
     String encodedNamespaceAndId =
         Base64.encodeBase64URLSafeString(namespaceAndId.getBytes(StandardCharsets.UTF_8));
 
-    return doGetRequestForObject(
-        String.format(baseEndpoint + "/identifier/%s", encodedNamespaceAndId));
+    try {
+      return doGetRequestForObject(
+          String.format(baseEndpoint + "/identifier/%s", encodedNamespaceAndId));
+    } catch (ResourceNotFoundException e) {
+      return null;
+    }
   }
 }

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClientTest.java
@@ -36,17 +36,17 @@ public class CudamiIdentifiablesClientTest
   @Test
   @DisplayName("params for label filtering are treated different")
   public void testLabelParams() {
-    var fcLabel =
+    FilterCriterion fcLabel =
         FilterCriterion.builder().withExpression("label").contains("something special").build();
-    var expLabel = "label=something+special";
+    String expLabel = "label=something+special";
 
-    var fcLabelWithLanguage =
+    FilterCriterion fcLabelWithLanguage =
         FilterCriterion.builder().withExpression("label.en").contains("something").build();
-    var expLabelWithLanguage = "label=something&labelLanguage=en";
+    String expLabelWithLanguage = "label=something&labelLanguage=en";
 
-    var fcLabelEquals =
+    FilterCriterion fcLabelEquals =
         FilterCriterion.builder().withExpression("label").isEquals("something special").build();
-    var expLabelEquals = "label=%22something+special%22";
+    String expLabelEquals = "label=%22something+special%22";
 
     assertThat(client.filterCriterionToUrlParam(fcLabel)).isEqualTo(expLabel);
     assertThat(client.filterCriterionToUrlParam(fcLabelWithLanguage))
@@ -54,9 +54,10 @@ public class CudamiIdentifiablesClientTest
     assertThat(client.filterCriterionToUrlParam(fcLabelEquals)).isEqualTo(expLabelEquals);
 
     // normal case
-    var date = LocalDate.now();
-    var fcDate = FilterCriterion.builder().withExpression("lastModified").isEquals(date).build();
-    var expDate = String.format("lastModified=eq:%s", date.toString());
+    LocalDate date = LocalDate.now();
+    FilterCriterion fcDate =
+        FilterCriterion.builder().withExpression("lastModified").isEquals(date).build();
+    String expDate = String.format("lastModified=eq:%s", date.toString());
 
     assertThat(client.filterCriterionToUrlParam(fcDate)).isEqualTo(expDate);
   }
@@ -64,17 +65,17 @@ public class CudamiIdentifiablesClientTest
   @Test
   @DisplayName("params for name filtering are treated different")
   public void testNameParams() {
-    var fcLabel =
+    FilterCriterion fcLabel =
         FilterCriterion.builder().withExpression("name").contains("something special").build();
-    var expLabel = "name=something+special";
+    String expLabel = "name=something+special";
 
-    var fcLabelWithLanguage =
+    FilterCriterion fcLabelWithLanguage =
         FilterCriterion.builder().withExpression("name.en").contains("something").build();
-    var expLabelWithLanguage = "name=something&nameLanguage=en";
+    String expLabelWithLanguage = "name=something&nameLanguage=en";
 
-    var fcLabelEquals =
+    FilterCriterion fcLabelEquals =
         FilterCriterion.builder().withExpression("name").isEquals("something special").build();
-    var expLabelEquals = "name=%22something+special%22";
+    String expLabelEquals = "name=%22something+special%22";
 
     assertThat(client.filterCriterionToUrlParam(fcLabel)).isEqualTo(expLabel);
     assertThat(client.filterCriterionToUrlParam(fcLabelWithLanguage))

--- a/dc-cudami-model/src/main/java/de/digitalcollections/cudami/model/config/CudamiConfig.java
+++ b/dc-cudami-model/src/main/java/de/digitalcollections/cudami/model/config/CudamiConfig.java
@@ -36,7 +36,8 @@ public class CudamiConfig {
       throw new IllegalStateException(
           "Required `cudami.repositoryFolderPath` configuration missing.");
     }
-    this.repositoryFolderPath = repositoryFolderPath.replace("~", System.getProperty("user.home"));
+    this.repositoryFolderPath =
+        repositoryFolderPath.replace("~/", System.getProperty("user.home") + "/");
     this.typeDeclarations = typeDeclarations;
     this.urlAlias = urlAlias;
   }

--- a/dc-cudami-model/src/main/java/de/digitalcollections/cudami/model/config/CudamiConfig.java
+++ b/dc-cudami-model/src/main/java/de/digitalcollections/cudami/model/config/CudamiConfig.java
@@ -7,12 +7,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import org.springframework.util.StringUtils;
 
 public class CudamiConfig {
+
   private Defaults defaults;
-  private UrlAlias urlAlias;
   private int offsetForAlternativePaging = 0;
+  private String repositoryFolderPath;
   private TypeDeclarations typeDeclarations;
+  private UrlAlias urlAlias;
 
   @SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -20,25 +23,34 @@ public class CudamiConfig {
   @JsonCreator(mode = Mode.PROPERTIES)
   public CudamiConfig(
       @JsonProperty(value = "defaults") Defaults defaults,
-      @JsonProperty(value = "urlAlias") UrlAlias urlAlias,
       @JsonProperty(value = "offsetForAlternativePaging") int offsetForAlternativePaging,
-      @JsonProperty(value = "typeDeclarations") TypeDeclarations typeDeclarations) {
+      @JsonProperty(value = "repositoryFolderPath") String repositoryFolderPath,
+      @JsonProperty(value = "typeDeclarations") TypeDeclarations typeDeclarations,
+      @JsonProperty(value = "urlAlias") UrlAlias urlAlias) {
+    if (defaults == null) {
+      throw new IllegalStateException("Required `cudami.defaults` configuration missing.");
+    }
     this.defaults = defaults;
-    this.urlAlias = urlAlias;
     this.offsetForAlternativePaging = offsetForAlternativePaging;
+    if (!StringUtils.hasText(repositoryFolderPath)) {
+      throw new IllegalStateException(
+          "Required `cudami.repositoryFolderPath` configuration missing.");
+    }
+    this.repositoryFolderPath = repositoryFolderPath.replace("~", System.getProperty("user.home"));
     this.typeDeclarations = typeDeclarations;
+    this.urlAlias = urlAlias;
   }
 
   public Defaults getDefaults() {
     return defaults;
   }
 
-  public UrlAlias getUrlAlias() {
-    return urlAlias;
-  }
-
   public int getOffsetForAlternativePaging() {
     return offsetForAlternativePaging;
+  }
+
+  public String getRepositoryFolderPath() {
+    return repositoryFolderPath;
   }
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "partially filled at runtime")
@@ -46,7 +58,12 @@ public class CudamiConfig {
     return typeDeclarations;
   }
 
+  public UrlAlias getUrlAlias() {
+    return urlAlias;
+  }
+
   public static class Defaults {
+
     private String language;
     private Locale locale;
 
@@ -54,7 +71,14 @@ public class CudamiConfig {
     public Defaults(
         @JsonProperty(value = "language") String language,
         @JsonProperty(value = "locale") Locale locale) {
+      if (!StringUtils.hasText(language)) {
+        throw new IllegalStateException(
+            "Required `cudami.defaults.language` configuration missing.");
+      }
       this.language = language;
+      if (!StringUtils.hasText(locale.getLanguage())) {
+        throw new IllegalStateException("Required `cudami.defaults.locale` configuration missing.");
+      }
       this.locale = locale;
     }
 
@@ -68,6 +92,7 @@ public class CudamiConfig {
   }
 
   public static class UrlAlias {
+
     private static final int DB_MAX_LENGTH = 256;
 
     private List<String> generationExcludes;

--- a/dc-cudami-server/dc-cudami-server-backend-file/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-file/pom.xml
@@ -15,6 +15,10 @@
   <dependencies>
     <dependency>
       <groupId>de.digitalcollections.cudami</groupId>
+      <artifactId>dc-cudami-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.digitalcollections.cudami</groupId>
       <artifactId>dc-cudami-server-backend-api</artifactId>
     </dependency>
     <dependency>

--- a/dc-cudami-server/dc-cudami-server-backend-file/src/main/java/de/digitalcollections/cudami/server/backend/impl/file/identifiable/resource/FileResourceBinaryRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-file/src/main/java/de/digitalcollections/cudami/server/backend/impl/file/identifiable/resource/FileResourceBinaryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.server.backend.impl.file.identifiable.resource;
 
+import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.resource.FileResourceBinaryRepository;
 import de.digitalcollections.model.exception.ResourceNotFoundException;
 import de.digitalcollections.model.exception.TechnicalException;
@@ -63,13 +64,13 @@ public class FileResourceBinaryRepositoryImpl implements FileResourceBinaryRepos
 
   @Autowired
   public FileResourceBinaryRepositoryImpl(
-      @Value("${cudami.repositoryFolderPath}") String folderPath,
+      CudamiConfig cudamiConfig,
       @Value("${iiif.image.baseUrl:#{null}}") URL iiifImageBaseUrl,
       @Value("${media.video.baseUrl:#{null}}") URL mediaVideoBaseUrl,
       ResourceLoader resourceLoader) {
     this.iiifImageBaseUrl = iiifImageBaseUrl;
     this.mediaVideoBaseUrl = mediaVideoBaseUrl;
-    this.repositoryFolderPath = folderPath.replace("~", System.getProperty("user.home"));
+    this.repositoryFolderPath = cudamiConfig.getRepositoryFolderPath();
     this.resourceLoader = resourceLoader;
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-file/src/test/java/de/digitalcollections/cudami/server/backend/impl/file/identifiable/resource/FileResourceBinaryRepositoryTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-file/src/test/java/de/digitalcollections/cudami/server/backend/impl/file/identifiable/resource/FileResourceBinaryRepositoryTest.java
@@ -1,7 +1,9 @@
 package de.digitalcollections.cudami.server.backend.impl.file.identifiable.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.model.file.MimeType;
 import java.net.URI;
 import java.util.UUID;
@@ -18,7 +20,9 @@ public class FileResourceBinaryRepositoryTest {
   @BeforeAll
   public static void setUp() {
     ResourceLoader rl = Mockito.mock(ResourceLoader.class);
-    repository = new FileResourceBinaryRepositoryImpl(FOLDER_PATH, null, null, rl);
+    CudamiConfig cudamiConfig = Mockito.mock(CudamiConfig.class);
+    when(cudamiConfig.getRepositoryFolderPath()).thenReturn(FOLDER_PATH);
+    repository = new FileResourceBinaryRepositoryImpl(cudamiConfig, null, null, rl);
   }
 
   @Test

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/pom.xml
@@ -88,6 +88,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/database/config/SpringConfigBackendTestDatabase.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/database/config/SpringConfigBackendTestDatabase.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.cudami.server.backend.impl.database.config;
 
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.commons.jdbi.DcCommonsJdbiPlugin;
 import de.digitalcollections.cudami.model.config.CudamiConfig;
@@ -12,6 +14,7 @@ import org.flywaydb.core.Flyway;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.postgres.PostgresPlugin;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -93,7 +96,8 @@ public class SpringConfigBackendTestDatabase {
   @Bean
   @Primary
   CudamiConfig testCudamiConfig() {
-    var cudamiConfig = new CudamiConfig(null, null, 5000, null);
+    CudamiConfig cudamiConfig = Mockito.mock(CudamiConfig.class);
+    when(cudamiConfig.getOffsetForAlternativePaging()).thenReturn(5000);
     return cudamiConfig;
   }
 }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
@@ -179,9 +179,9 @@ class IdentifiableRepositoryImplTest {
   @Test
   @DisplayName("test string splitting method")
   void testSplitter() {
-    var in =
+    String in =
         "A funny text with comma, a hyphen-separated word (unusual in English though) and some other stuff...";
-    final var expected =
+    final String[] expected =
         new String[] {
           "hyphen",
           "separated",
@@ -206,7 +206,7 @@ class IdentifiableRepositoryImplTest {
     assertThat(out).containsExactly(expected);
 
     in = "\"Here we have quotes and a word-with-two hyphens!\"";
-    final var expected1 =
+    final String[] expected1 =
         new String[] {
           "word",
           "with",
@@ -224,12 +224,12 @@ class IdentifiableRepositoryImplTest {
     assertThat(out).containsExactly(expected1);
 
     in = "something easy";
-    final var expected2 = new String[] {"something", "easy"};
+    final String[] expected2 = new String[] {"something", "easy"};
     out = IdentifiableRepository.splitToArray(in);
     assertThat(out).containsExactly(expected2);
 
     in = "one";
-    final var expected3 = new String[] {"one"};
+    final String[] expected3 = new String[] {"one"};
     out = IdentifiableRepository.splitToArray(in);
     assertThat(out).containsExactly(expected3);
   }
@@ -264,9 +264,9 @@ class IdentifiableRepositoryImplTest {
     String[] expected = {
       "bayerische", "staatsbibliothek", "münchen", "bavarian", "state", "library", "munich"
     };
-    var label = new LocalizedText(Locale.GERMAN, "Bayerische Staatsbibliothek, München");
+    LocalizedText label = new LocalizedText(Locale.GERMAN, "Bayerische Staatsbibliothek, München");
     label.put(Locale.ENGLISH, "Bavarian State Library, Munich");
-    var actual = repo.splitToArray(label);
+    String[] actual = repo.splitToArray(label);
     assertThat(actual).containsExactly(expected);
   }
 
@@ -308,7 +308,7 @@ class IdentifiableRepositoryImplTest {
             });
 
     // test update method
-    var label = new LocalizedText();
+    LocalizedText label = new LocalizedText();
     label.setText(Locale.ENGLISH, "An English label, no. 1");
     label.setText(Locale.GERMAN, "Ein deutsches Label, nr. 2");
     savedDigitalObject.setLabel(label);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/WebsiteRepositoryImplTest.java
@@ -76,14 +76,14 @@ class WebsiteRepositoryImplTest {
   @Test
   @DisplayName("save a website with notes")
   void saveWebsiteWithNotes() {
-    var noteContent1 = new StructuredContent();
+    StructuredContent noteContent1 = new StructuredContent();
     noteContent1.addContentBlock(new Text("eine Bemerkung"));
-    var note1 = new LocalizedStructuredContent();
+    LocalizedStructuredContent note1 = new LocalizedStructuredContent();
     note1.put(Locale.GERMAN, noteContent1);
 
-    var noteContent2 = new StructuredContent();
+    StructuredContent noteContent2 = new StructuredContent();
     noteContent2.addContentBlock(new Text("zweite Bemerkung"));
-    var note2 = new LocalizedStructuredContent();
+    LocalizedStructuredContent note2 = new LocalizedStructuredContent();
     note2.put(Locale.GERMAN, noteContent2);
     Website website =
         Website.builder()

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelper.java
@@ -244,7 +244,7 @@ public class IdentifiableUrlAliasAlignHelper<I extends Identifiable> {
       // there are only primary aliases: conflicting ones in DB must be unset
       // conflicting aliases: equal websiteUuid & targetLanguage
       LocalizedUrlAliases urlAliasesToUpdate = actualIdentifiable.getLocalizedUrlAliases();
-      // only primary aliases (as the var name suggests)
+      // only primary aliases (as the variable name suggests)
       List<UrlAlias> allPrimariesFromDb =
           getPrimaryUrlAliases(identifiableInDatabase.getLocalizedUrlAliases(), null);
       // now we check whether any primary from the DB conflict with the new ones

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImplTest.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 @DisplayName("The Identifiable Service")
 class IdentifiableServiceImplTest {
@@ -60,7 +61,10 @@ class IdentifiableServiceImplTest {
     when(urlAliasService.generateSlug(any(), eq("label"), eq(null))).thenReturn("label");
     identifierService = mock(IdentifierService.class);
     CudamiConfig.UrlAlias urlAliasConfig = new CudamiConfig.UrlAlias(List.of("DigitalObject"), 0);
-    CudamiConfig cudamiConfig = new CudamiConfig(null, urlAliasConfig, 5000, null);
+
+    CudamiConfig cudamiConfig = Mockito.mock(CudamiConfig.class);
+    when(cudamiConfig.getOffsetForAlternativePaging()).thenReturn(5000);
+    when(cudamiConfig.getUrlAlias()).thenReturn(urlAliasConfig);
 
     LocaleService localeService = mock(LocaleService.class);
 
@@ -122,7 +126,7 @@ class IdentifiableServiceImplTest {
   public void exceptionOnSaveWhenRepoFails() {
     when(repo.save(any(Identifiable.class))).thenThrow(new NullPointerException("boo"));
 
-    var identifiable = Identifiable.builder().label("label").build();
+    Identifiable identifiable = Identifiable.builder().label("label").build();
     assertThrows(
         IdentifiableServiceException.class,
         () -> {
@@ -177,7 +181,7 @@ class IdentifiableServiceImplTest {
   public void exceptionOnUpdateWhenRepoFails() {
     when(repo.update(any(Identifiable.class))).thenThrow(new NullPointerException("boo"));
 
-    var identifiable = Identifiable.builder().label("label").build();
+    Identifiable identifiable = Identifiable.builder().label("label").build();
     assertThrows(
         IdentifiableServiceException.class,
         () -> {

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelperTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableUrlAliasAlignHelperTest.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 @DisplayName("Identifiable-UrlAlias-Align-Helper tests")
 public class IdentifiableUrlAliasAlignHelperTest {
@@ -43,7 +44,9 @@ public class IdentifiableUrlAliasAlignHelperTest {
   public void setup() {
     CudamiConfig.UrlAlias urlAliasConfig =
         new CudamiConfig.UrlAlias(List.of(IdentifiableObjectType.DIGITAL_OBJECT.toString()), 0);
-    cudamiConfig = new CudamiConfig(null, urlAliasConfig, 5000, null);
+    cudamiConfig = Mockito.mock(CudamiConfig.class);
+    when(cudamiConfig.getOffsetForAlternativePaging()).thenReturn(5000);
+    when(cudamiConfig.getUrlAlias()).thenReturn(urlAliasConfig);
 
     slugGeneratorService = mock(IdentifiableUrlAliasAlignHelper.SlugGeneratorService.class);
   }
@@ -830,7 +833,7 @@ public class IdentifiableUrlAliasAlignHelperTest {
 
   private LocalizedUrlAliases createAliases(UUID target, SlugPrimaryTuple... slugTuples) {
     LocalizedUrlAliases aliases = new LocalizedUrlAliases();
-    for (var tuple : slugTuples) {
+    for (SlugPrimaryTuple tuple : slugTuples) {
       UrlAlias alias = new UrlAlias();
       alias.setSlug(tuple.slug);
       alias.setPrimary(tuple.isPrimary);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/config/CudamiServerConfig.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/config/CudamiServerConfig.java
@@ -11,9 +11,10 @@ public class CudamiServerConfig extends CudamiConfig {
 
   public CudamiServerConfig(
       Defaults defaults,
-      UrlAlias urlAlias,
       int offsetForAlternativePaging,
-      TypeDeclarations typeDeclarations) {
-    super(defaults, urlAlias, offsetForAlternativePaging, typeDeclarations);
+      String repositoryFolderPath,
+      TypeDeclarations typeDeclarations,
+      UrlAlias urlAlias) {
+    super(defaults, offsetForAlternativePaging, repositoryFolderPath, typeDeclarations, urlAlias);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/LocaleController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/LocaleController.java
@@ -1,11 +1,14 @@
 package de.digitalcollections.cudami.server.controller;
 
 import de.digitalcollections.cudami.server.business.api.service.LocaleService;
+import de.digitalcollections.model.exception.ResourceNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Locale;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,8 +31,12 @@ public class LocaleController {
         "/latest/languages/default"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Locale getDefaultLanguage() {
-    return new Locale(localeService.getDefaultLanguage());
+  public ResponseEntity<Locale> getDefaultLanguage() throws ResourceNotFoundException {
+    String defaultLanguage = localeService.getDefaultLanguage();
+    if (defaultLanguage == null) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+    return new ResponseEntity<>(new Locale(defaultLanguage), HttpStatus.OK);
   }
 
   @Operation(summary = "Get default locale")
@@ -42,8 +49,10 @@ public class LocaleController {
         "/latest/locales/default"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Locale getDefaultLocale() {
-    return localeService.getDefaultLocale();
+  public ResponseEntity<Locale> getDefaultLocale() throws ResourceNotFoundException {
+    Locale defaultLocale = localeService.getDefaultLocale();
+    return new ResponseEntity<>(
+        defaultLocale, defaultLocale != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all supported languages")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifiableController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Valid
 import de.digitalcollections.cudami.server.business.api.service.identifiable.IdentifiableService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
+import de.digitalcollections.model.exception.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
 import io.swagger.v3.oas.annotations.Operation;
@@ -74,7 +75,7 @@ public class IdentifiableController extends AbstractIdentifiableController<Ident
       throws CudamiControllerException {
 
     try {
-      if (getByUuid(uuid) == null) {
+      if (identifiableService.getByUuid(uuid) == null) {
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
       }
     } catch (Exception e) {
@@ -100,6 +101,7 @@ public class IdentifiableController extends AbstractIdentifiableController<Ident
         "/latest/identifiables/identifier/**"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Override
   public ResponseEntity<Identifiable> getByIdentifier(HttpServletRequest request)
       throws IdentifiableServiceException, ValidationException {
     return super.getByIdentifier(request);
@@ -114,7 +116,10 @@ public class IdentifiableController extends AbstractIdentifiableController<Ident
         "/latest/identifiables/{uuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Identifiable getByUuid(@PathVariable UUID uuid) {
-    return identifiableService.getByUuid(uuid);
+  public ResponseEntity<Identifiable> getByUuid(@PathVariable UUID uuid)
+      throws ResourceNotFoundException {
+    Identifiable identifiable = identifiableService.getByUuid(uuid);
+    return new ResponseEntity<>(
+        identifiable, identifiable != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifierTypeController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/IdentifierTypeController.java
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -52,8 +54,10 @@ public class IdentifierTypeController {
   @GetMapping(
       value = {"/v6/identifiertypes/namespace/{namespace}"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public IdentifierType getByNamespace(@PathVariable String namespace) {
-    return identifierTypeService.getByNamespace(namespace);
+  public ResponseEntity<IdentifierType> getByNamespace(@PathVariable String namespace) {
+    IdentifierType identifierType = identifierTypeService.getByNamespace(namespace);
+    return new ResponseEntity<>(
+        identifierType, identifierType != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get identifier type by uuid")
@@ -65,8 +69,10 @@ public class IdentifierTypeController {
         "/latest/identifiertypes/{uuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public IdentifierType getByUuid(@PathVariable UUID uuid) {
-    return identifierTypeService.getByUuid(uuid);
+  public ResponseEntity<IdentifierType> getByUuid(@PathVariable UUID uuid) {
+    IdentifierType identifierType = identifierTypeService.getByUuid(uuid);
+    return new ResponseEntity<>(
+        identifierType, identifierType != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "save a newly created identifier type")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/FamilyNameController.java
@@ -70,6 +70,7 @@ public class FamilyNameController extends AbstractIdentifiableController<FamilyN
   @GetMapping(
       value = {"/v6/familynames/identifier/**", "/v5/familynames/identifier/**"},
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Override
   public ResponseEntity<FamilyName> getByIdentifier(HttpServletRequest request)
       throws IdentifiableServiceException, ValidationException {
     return super.getByIdentifier(request);
@@ -114,7 +115,7 @@ public class FamilyNameController extends AbstractIdentifiableController<FamilyN
     } else {
       result = familyNameService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "save a newly created family")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/GivenNameController.java
@@ -70,6 +70,7 @@ public class GivenNameController extends AbstractIdentifiableController<GivenNam
   @GetMapping(
       value = {"/v6/givennames/identifier/**", "/v5/givennames/identifier/**"},
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Override
   public ResponseEntity<GivenName> getByIdentifier(HttpServletRequest request)
       throws IdentifiableServiceException, ValidationException {
     return super.getByIdentifier(request);
@@ -114,7 +115,7 @@ public class GivenNameController extends AbstractIdentifiableController<GivenNam
     } else {
       result = givenNameService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "save a newly created givenname")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/alias/UrlAliasController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/alias/UrlAliasController.java
@@ -150,11 +150,8 @@ public class UrlAliasController {
       throw new CudamiControllerException(e);
     }
 
-    if (result == null) {
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    }
-
-    return new ResponseEntity<>(JSONObject.quote(result), HttpStatus.OK);
+    return new ResponseEntity<>(
+        JSONObject.quote(result), result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get an UrlAlias by uuid")
@@ -179,11 +176,7 @@ public class UrlAliasController {
       throw new CudamiControllerException(e);
     }
 
-    if (result == null) {
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    }
-
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(
@@ -221,11 +214,7 @@ public class UrlAliasController {
       throw new CudamiControllerException(e);
     }
 
-    if (result == null) {
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    }
-
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "update an UrlAlias")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/alias/UrlAliasController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/alias/UrlAliasController.java
@@ -81,11 +81,9 @@ public class UrlAliasController {
       throw new CudamiControllerException(e);
     }
 
-    if (!isDeleted) {
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    }
-
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    return isDeleted
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ArticleController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ArticleController.java
@@ -97,7 +97,7 @@ public class ArticleController {
     } else {
       article = articleService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(article, HttpStatus.OK);
+    return new ResponseEntity<>(article, article != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all articles")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
@@ -82,8 +82,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     digitalObject.setUuid(digitalObjectUuid);
 
     boolean successful = collectionService.addDigitalObject(collection, digitalObject);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add existing digital objects to an existing collection")
@@ -104,8 +105,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     collection.setUuid(collectionUuid);
 
     boolean successful = collectionService.addDigitalObjects(collection, digitalObjects);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add an existing collection to an existing collection")
@@ -130,8 +132,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     subcollection.setUuid(subcollectionUuid);
 
     boolean successful = collectionService.addChild(collection, subcollection);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add existing collections to an existing collection")
@@ -152,8 +155,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     collection.setUuid(uuid);
 
     boolean successful = collectionService.addChildren(collection, subcollections);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get count of collections")
@@ -186,7 +190,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(
@@ -420,9 +426,8 @@ public class CollectionController extends AbstractIdentifiableController<Collect
         "/latest/collections/{uuid}/parent"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<Collection> getParent(@PathVariable UUID uuid) {
-    Collection parent = collectionService.getParent(uuid);
-    return new ResponseEntity<>(parent, parent != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+  public Collection getParent(@PathVariable UUID uuid) {
+    return collectionService.getParent(uuid);
   }
 
   @Operation(summary = "Get parent collections")
@@ -475,8 +480,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     digitalObject.setUuid(digitalObjectUuid);
 
     boolean successful = collectionService.removeDigitalObject(collection, digitalObject);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Remove an existing collection from an existing collection")
@@ -501,8 +507,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     subcollection.setUuid(subcollectionUuid);
 
     boolean successful = collectionService.removeChild(collection, subcollection);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created collection")
@@ -532,8 +539,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     collection.setUuid(collectionUuid);
 
     boolean successful = collectionService.saveDigitalObjects(collection, digitalObjects);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created collection with parent collection")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionController.java
@@ -83,10 +83,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
 
     boolean successful = collectionService.addDigitalObject(collection, digitalObject);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add existing digital objects to an existing collection")
@@ -108,10 +105,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
 
     boolean successful = collectionService.addDigitalObjects(collection, digitalObjects);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add an existing collection to an existing collection")
@@ -137,10 +131,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
 
     boolean successful = collectionService.addChild(collection, subcollection);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add existing collections to an existing collection")
@@ -162,10 +153,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
 
     boolean successful = collectionService.addChildren(collection, subcollections);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get count of collections")
@@ -198,10 +186,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(
@@ -359,6 +344,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
         "/latest/collections/identifier/**"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Override
   public ResponseEntity<Collection> getByIdentifier(HttpServletRequest request)
       throws IdentifiableServiceException, ValidationException {
     return super.getByIdentifier(request);
@@ -421,7 +407,8 @@ public class CollectionController extends AbstractIdentifiableController<Collect
         collection = collectionService.getByUuidAndLocale(uuid, pLocale);
       }
     }
-    return new ResponseEntity<>(collection, HttpStatus.OK);
+    return new ResponseEntity<>(
+        collection, collection != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get the first created parent of a collection")
@@ -433,8 +420,9 @@ public class CollectionController extends AbstractIdentifiableController<Collect
         "/latest/collections/{uuid}/parent"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Collection getParent(@PathVariable UUID uuid) {
-    return collectionService.getParent(uuid);
+  public ResponseEntity<Collection> getParent(@PathVariable UUID uuid) {
+    Collection parent = collectionService.getParent(uuid);
+    return new ResponseEntity<>(parent, parent != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get parent collections")
@@ -488,10 +476,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
 
     boolean successful = collectionService.removeDigitalObject(collection, digitalObject);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Remove an existing collection from an existing collection")
@@ -517,10 +502,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
 
     boolean successful = collectionService.removeChild(collection, subcollection);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created collection")
@@ -551,10 +533,7 @@ public class CollectionController extends AbstractIdentifiableController<Collect
 
     boolean successful = collectionService.saveDigitalObjects(collection, digitalObjects);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created collection with parent collection")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
@@ -86,10 +86,7 @@ public class DigitalObjectController extends AbstractIdentifiableController<Digi
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(
@@ -182,8 +179,10 @@ public class DigitalObjectController extends AbstractIdentifiableController<Digi
   @GetMapping(
       value = {"/v5/digitalobjects/{refId:[0-9]+}"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public DigitalObject getByRefId(@PathVariable long refId) {
-    return digitalObjectService.getByRefId(refId);
+  public ResponseEntity<DigitalObject> getByRefId(@PathVariable long refId) {
+    DigitalObject digitalObject = digitalObjectService.getByRefId(refId);
+    return new ResponseEntity<>(
+        digitalObject, digitalObject != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get a digital object by uuid")
@@ -195,8 +194,10 @@ public class DigitalObjectController extends AbstractIdentifiableController<Digi
         "/latest/digitalobjects/{uuid:" + ParameterHelper.UUID_PATTERN + "}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public DigitalObject getByUuid(@PathVariable UUID uuid) {
-    return digitalObjectService.getByUuid(uuid);
+  public ResponseEntity<DigitalObject> getByUuid(@PathVariable UUID uuid) {
+    DigitalObject digitalObject = digitalObjectService.getByUuid(uuid);
+    return new ResponseEntity<>(
+        digitalObject, digitalObject != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get (active or all) paged collections of a digital objects")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/DigitalObjectController.java
@@ -86,7 +86,9 @@ public class DigitalObjectController extends AbstractIdentifiableController<Digi
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/EntityController.java
@@ -119,11 +119,9 @@ public class EntityController<E extends Entity> extends AbstractIdentifiableCont
         "/latest/entities/{refId:[0-9]+}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Entity getByRefId(@PathVariable long refId) {
+  public ResponseEntity<Entity> getByRefId(@PathVariable long refId) {
     Entity entity = entityService.getByRefId(refId);
-    if (entity == null) {
-      return null;
-    }
+    return new ResponseEntity<>(entity, entity != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
     // routing should be done in frontend webapp (second call will be sent on entity type)
     //    EntityType entityType = entity.getEntityType();
     //    UUID uuid = entity.getUuid();
@@ -131,7 +129,6 @@ public class EntityController<E extends Entity> extends AbstractIdentifiableCont
     //      case PERSON:
     //        return personService.getByIdentifier(uuid);
     //    }
-    return entity;
   }
 
   @Operation(summary = "Get entity by uuid")
@@ -143,8 +140,9 @@ public class EntityController<E extends Entity> extends AbstractIdentifiableCont
         "/latest/entities/{uuid:" + ParameterHelper.UUID_PATTERN + "}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Entity getByUuid(@PathVariable UUID uuid) {
-    return entityService.getByUuid(uuid);
+  public ResponseEntity<Entity> getByUuid(@PathVariable UUID uuid) {
+    Entity entity = entityService.getByUuid(uuid);
+    return new ResponseEntity<>(entity, entity != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Find limited amount of random entites")
@@ -170,7 +168,7 @@ public class EntityController<E extends Entity> extends AbstractIdentifiableCont
         "/latest/entities/{uuid}/related/fileresources"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  List<FileResource> getRelatedFileResources(@PathVariable UUID uuid) {
+  public List<FileResource> getRelatedFileResources(@PathVariable UUID uuid) {
     return entityService.getRelatedFileResources(uuid);
   }
 
@@ -183,7 +181,7 @@ public class EntityController<E extends Entity> extends AbstractIdentifiableCont
         "/latest/entities/relations/{uuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  List<EntityRelation> getRelations(@PathVariable UUID uuid) {
+  public List<EntityRelation> getRelations(@PathVariable UUID uuid) {
     return entityRelationService.getBySubject(uuid);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/HeadwordEntryController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/HeadwordEntryController.java
@@ -125,7 +125,8 @@ public class HeadwordEntryController extends AbstractIdentifiableController<Head
     } else {
       headwordEntry = headwordEntryService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(headwordEntry, HttpStatus.OK);
+    return new ResponseEntity<>(
+        headwordEntry, headwordEntry != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all headwordentries")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
@@ -70,10 +70,7 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
 
     boolean successful = projectService.addDigitalObject(project, digitalObject);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add existing digital objects to an existing project")
@@ -95,10 +92,7 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
 
     boolean successful = projectService.addDigitalObjects(project, digitalObjects);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(
@@ -121,10 +115,7 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all projects as (sorted, paged) list")
@@ -206,7 +197,7 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
     } else {
       project = projectService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(project, HttpStatus.OK);
+    return new ResponseEntity<>(project, project != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all projects")
@@ -245,10 +236,7 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
 
     boolean successful = projectService.removeDigitalObject(project, digitalObject);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created project")
@@ -279,10 +267,7 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
 
     boolean successful = projectService.setDigitalObjects(project, digitalObjects);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Update an project")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/ProjectController.java
@@ -69,8 +69,9 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
     digitalObject.setUuid(digitalObjectUuid);
 
     boolean successful = projectService.addDigitalObject(project, digitalObject);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add existing digital objects to an existing project")
@@ -91,8 +92,9 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
     project.setUuid(projectUuid);
 
     boolean successful = projectService.addDigitalObjects(project, digitalObjects);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(
@@ -115,7 +117,9 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all projects as (sorted, paged) list")
@@ -235,8 +239,9 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
     digitalObject.setUuid(digitalObjectUuid);
 
     boolean successful = projectService.removeDigitalObject(project, digitalObject);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created project")
@@ -266,8 +271,9 @@ public class ProjectController extends AbstractIdentifiableController<Project> {
     project.setUuid(projectUuid);
 
     boolean successful = projectService.setDigitalObjects(project, digitalObjects);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Update an project")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
@@ -71,8 +71,9 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
           UUID subtopicUuid)
       throws IdentifiableServiceException {
     boolean successful = topicService.addChild(parentTopicUuid, subtopicUuid);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get count of topics")
@@ -375,7 +376,9 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
       @Parameter(name = "subtopicUuid", description = "The uuid of the subtopic") @PathVariable
           UUID subtopicUuid) {
     boolean successful = topicService.removeChild(parentTopicUuid, subtopicUuid);
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created topic")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/TopicController.java
@@ -72,10 +72,7 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
       throws IdentifiableServiceException {
     boolean successful = topicService.addChild(parentTopicUuid, subtopicUuid);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get count of topics")
@@ -251,7 +248,7 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
     } else {
       topic = topicService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(topic, HttpStatus.OK);
+    return new ResponseEntity<>(topic, topic != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get subtopics of topic")
@@ -263,7 +260,7 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
         "/latest/topics/{uuid}/children"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  List<Topic> getChildren(@PathVariable UUID uuid) {
+  public List<Topic> getChildren(@PathVariable UUID uuid) {
     return topicService.getChildren(uuid);
   }
 
@@ -309,7 +306,7 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
         "/latest/topics/{uuid}/parent"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  Topic getParent(@PathVariable UUID uuid) {
+  public Topic getParent(@PathVariable UUID uuid) {
     return topicService.getParent(uuid);
   }
 
@@ -317,7 +314,7 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
   @GetMapping(
       value = {"/v2/topics/{uuid}/subtopics"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  ResponseEntity<String> getSubtopics(@PathVariable UUID uuid) {
+  public ResponseEntity<String> getSubtopics(@PathVariable UUID uuid) {
     return new ResponseEntity<>(
         "no longer supported. use '/v3/topics/{uuid}/children' endpoint, returning list of child-topics",
         HttpStatus.GONE);
@@ -345,7 +342,7 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
         "/latest/topics/entity/{uuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  List<Topic> getTopicsOfEntity(@PathVariable UUID uuid) {
+  public List<Topic> getTopicsOfEntity(@PathVariable UUID uuid) {
     return topicService.getTopicsOfEntity(uuid);
   }
 
@@ -358,7 +355,7 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
         "/latest/topics/fileresource/{uuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  List<Topic> getTopicsOfFileResource(@PathVariable UUID uuid) {
+  public List<Topic> getTopicsOfFileResource(@PathVariable UUID uuid) {
     return topicService.getTopicsOfFileResource(uuid);
   }
 
@@ -371,17 +368,14 @@ public class TopicController extends AbstractIdentifiableController<Topic> {
         "/latest/topics/{parentTopicUuid}/children/{subtopicUuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  ResponseEntity<Boolean> removeChild(
+  public ResponseEntity<Boolean> removeChild(
       @Parameter(name = "parentTopicUuid", description = "The uuid of the parent topic")
           @PathVariable
           UUID parentTopicUuid,
       @Parameter(name = "subtopicUuid", description = "The uuid of the subtopic") @PathVariable
           UUID subtopicUuid) {
     boolean successful = topicService.removeChild(parentTopicUuid, subtopicUuid);
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created topic")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
@@ -197,12 +197,7 @@ public class WebsiteController extends AbstractIdentifiableController<Website> {
           UUID uuid)
       throws JsonProcessingException {
     Website website = websiteService.getByUuid(uuid);
-
-    if (website == null) {
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    }
-
-    return new ResponseEntity<>(website, HttpStatus.OK);
+    return new ResponseEntity<>(website, website != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(
@@ -314,10 +309,7 @@ public class WebsiteController extends AbstractIdentifiableController<Website> {
 
     boolean successful = websiteService.updateRootWebpagesOrder(website, rootPages);
 
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   // ----------------- Helper classes for Swagger Annotations only, since Swagger Annotations

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/WebsiteController.java
@@ -308,8 +308,9 @@ public class WebsiteController extends AbstractIdentifiableController<Website> {
     website.setUuid(uuid);
 
     boolean successful = websiteService.updateRootWebpagesOrder(website, rootPages);
-
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   // ----------------- Helper classes for Swagger Annotations only, since Swagger Annotations

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
@@ -58,7 +58,9 @@ public class CorporateBodyController extends AbstractIdentifiableController<Corp
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/CorporateBodyController.java
@@ -58,10 +58,7 @@ public class CorporateBodyController extends AbstractIdentifiableController<Corp
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Override
@@ -77,7 +74,7 @@ public class CorporateBodyController extends AbstractIdentifiableController<Corp
         "/v3/corporatebodies/gnd/{gndId}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public CorporateBody fetchAndSaveByGndId(
+  public ResponseEntity<CorporateBody> fetchAndSaveByGndId(
       @Parameter(
               example = "",
               description = "GND-ID of the corporate body, e.g. <tt>2007744-0</tt>")
@@ -87,7 +84,9 @@ public class CorporateBodyController extends AbstractIdentifiableController<Corp
     if (!GNDID_PATTERN.matcher(gndId).matches()) {
       throw new IllegalArgumentException("Invalid GND ID: " + gndId);
     }
-    return corporateBodyService.fetchAndSaveByGndId(gndId);
+    CorporateBody corporateBody = corporateBodyService.fetchAndSaveByGndId(gndId);
+    return new ResponseEntity<>(
+        corporateBody, corporateBody != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all corporate bodies")
@@ -134,10 +133,12 @@ public class CorporateBodyController extends AbstractIdentifiableController<Corp
         "/latest/corporatebodies/{refId:[0-9]+}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public CorporateBody getByRefId(
+  public ResponseEntity<CorporateBody> getByRefId(
       @Parameter(example = "", description = "reference id") @PathVariable("refId") long refId)
       throws IdentifiableServiceException {
-    return corporateBodyService.getByRefId(refId);
+    CorporateBody corporateBody = corporateBodyService.getByRefId(refId);
+    return new ResponseEntity<>(
+        corporateBody, corporateBody != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get a corporate body by uuid")
@@ -170,7 +171,8 @@ public class CorporateBodyController extends AbstractIdentifiableController<Corp
     } else {
       corporateBody = corporateBodyService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(corporateBody, HttpStatus.OK);
+    return new ResponseEntity<>(
+        corporateBody, corporateBody != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all corporatebodies")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
@@ -84,7 +84,9 @@ public class PersonController extends AbstractIdentifiableController<Person> {
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all persons")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonController.java
@@ -84,10 +84,7 @@ public class PersonController extends AbstractIdentifiableController<Person> {
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all persons")
@@ -228,7 +225,7 @@ public class PersonController extends AbstractIdentifiableController<Person> {
     } else {
       result = personService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get a person's digital objects")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
@@ -77,7 +77,9 @@ public class GeoLocationController extends AbstractIdentifiableController<GeoLoc
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all geo locations")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/GeoLocationController.java
@@ -77,10 +77,7 @@ public class GeoLocationController extends AbstractIdentifiableController<GeoLoc
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all geo locations")
@@ -167,7 +164,7 @@ public class GeoLocationController extends AbstractIdentifiableController<GeoLoc
     } else {
       result = geoLocationService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all geolocations")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
@@ -65,7 +65,9 @@ public class HumanSettlementController extends AbstractIdentifiableController<Hu
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all human settlements")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/HumanSettlementController.java
@@ -65,10 +65,7 @@ public class HumanSettlementController extends AbstractIdentifiableController<Hu
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all human settlements")
@@ -155,7 +152,7 @@ public class HumanSettlementController extends AbstractIdentifiableController<Hu
     } else {
       result = humanSettlementService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "save a newly created human settlement")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/semantic/SubjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/semantic/SubjectController.java
@@ -83,8 +83,9 @@ public class SubjectController {
   @GetMapping(
       value = {"/v6/subjects/{uuid}"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Subject getByUuid(@PathVariable UUID uuid) {
-    return service.getByUuid(uuid);
+  public ResponseEntity<Subject> getByUuid(@PathVariable UUID uuid) {
+    Subject subject = service.getByUuid(uuid);
+    return new ResponseEntity<>(subject, subject != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created subject")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
@@ -105,10 +105,7 @@ public class ItemController extends AbstractIdentifiableController<Item> {
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all items")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ItemController.java
@@ -63,7 +63,7 @@ public class ItemController extends AbstractIdentifiableController<Item> {
         "/latest/items/{uuid}/digitalobjects/{digitalObjectUuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public boolean addDigitalObject(
+  public ResponseEntity addDigitalObject(
       @Parameter(name = "uuid", description = "UUID of the item") @PathVariable UUID uuid,
       @Parameter(name = "digitalObjectUuid", description = "UUID of the digital object")
           @PathVariable
@@ -71,17 +71,23 @@ public class ItemController extends AbstractIdentifiableController<Item> {
       throws ValidationException, ConflictException, IdentifiableServiceException {
 
     Item item = itemService.getByUuid(uuid);
-    return digitalObjectService.addItemToDigitalObject(item, digitalObjectUuid);
+    boolean successful = digitalObjectService.addItemToDigitalObject(item, digitalObjectUuid);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Add work to an item")
   @PostMapping(
       value = {"/latest/items/{uuid}/works/{workUuid}", "/v2/items/{uuid}/works/{workUuid}"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public boolean addWork(
+  public ResponseEntity addWork(
       @Parameter(name = "uuid", description = "UUID of the item") @PathVariable UUID uuid,
       @Parameter(name = "workUuid", description = "UUID of the work") @PathVariable UUID workUuid) {
-    return itemService.addWork(uuid, workUuid);
+    boolean successful = itemService.addWork(uuid, workUuid);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "count all items")
@@ -105,7 +111,9 @@ public class ItemController extends AbstractIdentifiableController<Item> {
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "get all items")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ManifestationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ManifestationController.java
@@ -66,7 +66,9 @@ public class ManifestationController extends AbstractIdentifiableController<Mani
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all manifestations")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ManifestationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/ManifestationController.java
@@ -66,10 +66,7 @@ public class ManifestationController extends AbstractIdentifiableController<Mani
     } catch (IdentifiableServiceException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all manifestations")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/WorkController.java
@@ -139,7 +139,7 @@ public class WorkController extends AbstractIdentifiableController<Work> {
     } else {
       result = workService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get creators of a work")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/FileResourceMetadataController.java
@@ -155,6 +155,7 @@ public class FileResourceMetadataController extends AbstractIdentifiableControll
         "/latest/fileresources/identifier/**"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Override
   public ResponseEntity<FileResource> getByIdentifier(HttpServletRequest request)
       throws IdentifiableServiceException, ValidationException {
     return super.getByIdentifier(request);
@@ -183,13 +184,13 @@ public class FileResourceMetadataController extends AbstractIdentifiableControll
           @RequestParam(name = "pLocale", required = false)
           Locale pLocale)
       throws IdentifiableServiceException {
-    FileResource fileResource;
+    FileResource result;
     if (pLocale == null) {
-      fileResource = metadataService.getByUuid(uuid);
+      result = metadataService.getByUuid(uuid);
     } else {
-      fileResource = metadataService.getByUuidAndLocale(uuid, pLocale);
+      result = metadataService.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(fileResource, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all websites")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/ImageFileResourceController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/ImageFileResourceController.java
@@ -88,6 +88,7 @@ public class ImageFileResourceController extends AbstractIdentifiableController<
   @GetMapping(
       value = {"/v6/imagefileresources/identifier/**"},
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Override
   public ResponseEntity<ImageFileResource> getByIdentifier(HttpServletRequest request)
       throws IdentifiableServiceException, ValidationException {
     return super.getByIdentifier(request);
@@ -111,13 +112,13 @@ public class ImageFileResourceController extends AbstractIdentifiableController<
           @RequestParam(name = "pLocale", required = false)
           Locale pLocale)
       throws IdentifiableServiceException {
-    ImageFileResource imageFileResource;
+    ImageFileResource result;
     if (pLocale == null) {
-      imageFileResource = service.getByUuid(uuid);
+      result = service.getByUuid(uuid);
     } else {
-      imageFileResource = service.getByUuidAndLocale(uuid, pLocale);
+      result = service.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(imageFileResource, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created ImageFileResource")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/LinkedDataFileResourceController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/LinkedDataFileResourceController.java
@@ -134,13 +134,13 @@ public class LinkedDataFileResourceController
           @RequestParam(name = "pLocale", required = false)
           Locale pLocale)
       throws IdentifiableServiceException {
-    LinkedDataFileResource linkedDataFileResource;
+    LinkedDataFileResource result;
     if (pLocale == null) {
-      linkedDataFileResource = service.getByUuid(uuid);
+      result = service.getByUuid(uuid);
     } else {
-      linkedDataFileResource = service.getByUuidAndLocale(uuid, pLocale);
+      result = service.getByUuidAndLocale(uuid, pLocale);
     }
-    return new ResponseEntity<>(linkedDataFileResource, HttpStatus.OK);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created linkedDataFileResource")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/versioning/VersionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/versioning/VersionController.java
@@ -6,7 +6,9 @@ import de.digitalcollections.model.identifiable.versioning.Version;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,8 +35,9 @@ public class VersionController {
         "/latest/versions/{uuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Version getByUuid(@PathVariable UUID uuid) {
-    return versionService.getByUuid(uuid);
+  public ResponseEntity<Version> getByUuid(@PathVariable UUID uuid) {
+    Version version = versionService.getByUuid(uuid);
+    return new ResponseEntity<>(version, version != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Update the version status")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/WebpageController.java
@@ -194,7 +194,7 @@ public class WebpageController extends AbstractIdentifiableController<Webpage> {
         webpage = webpageService.getByUuidAndLocale(uuid, pLocale);
       }
     }
-    return new ResponseEntity<>(webpage, HttpStatus.OK);
+    return new ResponseEntity<>(webpage, webpage != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get (active or all) children of a webpage recursivly as JSON")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/WebpageController.java
@@ -333,10 +333,8 @@ public class WebpageController extends AbstractIdentifiableController<Webpage> {
       @Parameter(example = "", description = "List of the children") @RequestBody
           List<Webpage> rootPages) {
     boolean successful = webpageService.updateChildrenOrder(uuid, rootPages);
-
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/legal/LicenseController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/legal/LicenseController.java
@@ -143,9 +143,10 @@ public class LicenseController {
       value = {"/v6/licenses", "/v5/licenses"},
       params = "url",
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public License getByUrl(@RequestParam(name = "url", required = true) URL url)
+  public ResponseEntity<License> getByUrl(@RequestParam(name = "url", required = true) URL url)
       throws MalformedURLException {
-    return service.getByUrl(url);
+    License license = service.getByUrl(url);
+    return new ResponseEntity<>(license, license != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get a license by uuid")
@@ -155,8 +156,9 @@ public class LicenseController {
         "/v5/licenses/{uuid:" + ParameterHelper.UUID_PATTERN + "}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public License getByUuid(@PathVariable UUID uuid) {
-    return service.getByUuid(uuid);
+  public ResponseEntity<License> getByUuid(@PathVariable UUID uuid) {
+    License license = service.getByUuid(uuid);
+    return new ResponseEntity<>(license, license != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all licenses")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/relation/PredicateController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/relation/PredicateController.java
@@ -53,7 +53,9 @@ public class PredicateController {
           @PathVariable("uuid")
           UUID uuid) {
     boolean successful = predicateService.delete(uuid);
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all predicates as (sorted, paged) list")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/relation/PredicateController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/relation/PredicateController.java
@@ -53,10 +53,7 @@ public class PredicateController {
           @PathVariable("uuid")
           UUID uuid) {
     boolean successful = predicateService.delete(uuid);
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.NO_CONTENT);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all predicates as (sorted, paged) list")
@@ -88,12 +85,16 @@ public class PredicateController {
   @GetMapping(
       value = {"/v6/predicates/{valueOrUuid:.+}"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Predicate getByValueOrUUID(@PathVariable("valueOrUuid") String valueOrUuid) {
+  public ResponseEntity<Predicate> getByValueOrUUID(
+      @PathVariable("valueOrUuid") String valueOrUuid) {
+    Predicate result;
     if (valueOrUuid.matches(ParameterHelper.UUID_PATTERN)) {
       UUID uuid = UUID.fromString(valueOrUuid);
-      return predicateService.getByUuid(uuid);
+      result = predicateService.getByUuid(uuid);
+    } else {
+      result = predicateService.getByValue(valueOrUuid);
     }
-    return predicateService.getByValue(valueOrUuid);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all predicates")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/security/UserController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/security/UserController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -65,16 +67,18 @@ public class UserController {
       value = {"/v6/users", "/v5/users", "/v2/users", "/latest/users"},
       params = {"email"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public User getByUsername(@RequestParam(name = "email") String email) {
-    return userService.getByUsername(email);
+  public ResponseEntity<User> getByUsername(@RequestParam(name = "email") String email) {
+    User result = userService.getByUsername(email);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get user by uuid")
   @GetMapping(
       value = {"/v6/users/{uuid}", "/v5/users/{uuid}", "/v2/users/{uuid}", "/latest/users/{uuid}"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public User getByUuid(@PathVariable UUID uuid) {
-    return userService.getByUuid(uuid);
+  public ResponseEntity<User> getByUuid(@PathVariable UUID uuid) {
+    User result = userService.getByUuid(uuid);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created user")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/HeadwordController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/HeadwordController.java
@@ -64,7 +64,9 @@ public class HeadwordController {
       @Parameter(example = "", description = "UUID of the headword") @PathVariable("uuid")
           UUID uuid) {
     boolean successful = headwordService.delete(uuid);
-    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
+    return successful
+        ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+        : new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all headwords as (filtered, sorted, paged) list")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/HeadwordController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/HeadwordController.java
@@ -64,11 +64,7 @@ public class HeadwordController {
       @Parameter(example = "", description = "UUID of the headword") @PathVariable("uuid")
           UUID uuid) {
     boolean successful = headwordService.delete(uuid);
-
-    if (successful) {
-      return new ResponseEntity<>(successful, HttpStatus.OK);
-    }
-    return new ResponseEntity<>(successful, HttpStatus.NOT_FOUND);
+    return new ResponseEntity<>(successful, successful ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get all headwords as (filtered, sorted, paged) list")
@@ -186,8 +182,9 @@ public class HeadwordController {
         "/v5/headwords/{uuid:" + ParameterHelper.UUID_PATTERN + "}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Headword getByUuid(@PathVariable UUID uuid) {
-    return headwordService.getByUuid(uuid);
+  public ResponseEntity<Headword> getByUuid(@PathVariable UUID uuid) {
+    Headword result = headwordService.getByUuid(uuid);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Find limited amount of random headwords")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/TagController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/TagController.java
@@ -82,8 +82,9 @@ public class TagController {
   @GetMapping(
       value = {"/v6/tags/{uuid}"},
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Tag getByUuid(@PathVariable UUID uuid) {
-    return service.getByUuid(uuid);
+  public ResponseEntity<Tag> getByUuid(@PathVariable UUID uuid) {
+    Tag result = service.getByUuid(uuid);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Save a newly created tag")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/view/RenderingTemplateController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/view/RenderingTemplateController.java
@@ -12,7 +12,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,8 +60,9 @@ public class RenderingTemplateController {
         "/latest/renderingtemplates/{uuid}"
       },
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public RenderingTemplate getByUuid(@PathVariable UUID uuid) {
-    return renderingTemplateService.getByUuid(uuid);
+  public ResponseEntity<RenderingTemplate> getByUuid(@PathVariable UUID uuid) {
+    RenderingTemplate result = renderingTemplateService.getByUuid(uuid);
+    return new ResponseEntity<>(result, result != null ? HttpStatus.OK : HttpStatus.NOT_FOUND);
   }
 
   @Operation(summary = "Get languages of all rendering templates")

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/BaseControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/BaseControllerTest.java
@@ -322,14 +322,4 @@ public abstract class BaseControllerTest {
   protected void testDeleteSuccessful(String path) throws Exception {
     mockMvc.perform(delete(path)).andExpect(status().is(HttpStatus.NO_CONTENT.value())); // 204
   }
-
-  /**
-   * Verifies, that an HTTP DELETE request was successful and returns the OK state (code 200)
-   *
-   * @param path the path of the HTTP DELETE request
-   * @thries Exception in case of an error
-   */
-  protected void testDeleteSuccessfulOK(String path) throws Exception {
-    mockMvc.perform(delete(path)).andExpect(status().is(HttpStatus.OK.value())); // 204
-  }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/CollectionControllerTest.java
@@ -111,7 +111,7 @@ class CollectionControllerTest extends BaseControllerTest {
     UUID uuid = UUID.fromString("09baa24e-0918-4b96-8ab1-f496b02af73a");
     when(collectionService.delete(eq(uuid))).thenReturn(true);
 
-    testDeleteSuccessfulOK(path);
+    testDeleteSuccessful(path);
 
     verify(collectionService, times(1)).delete(eq(uuid));
   }


### PR DESCRIPTION
- Move repositoryFolderPath config from `@Value` to `CudamiConfig`
- Mock CudamiConfig as constructor now does null checks breaking test instances of config
- Replace usage of `var` with explicit typed variables
- Replace null return value with 404 ResponseEntity 
- Delete now return NO_CONTENT (204) if successful. Added proper handling in client, too.