### PR TITLE
Refactoring of view pages of admin section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - for `Articles` list (to proof preview image rendering)
   - for `DigitalObjects` list (to proof fixing of too many tabs)
   - for `Collections` list
+- Switch language of displayed multilanguage data fields now using a select drop doen instead tabs
 
 ## [6.2.0](https://github.com/dbmdz/cudami/releases/tag/6.2.0) - 2022-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - for `Articles` list (to proof preview image rendering)
   - for `DigitalObjects` list (to proof fixing of too many tabs)
   - for `Collections` list
-- Switch language of displayed multilanguage data fields now using a select drop doen instead tabs
+- Switch language of displayed multilanguage data fields now using a select drop down instead of tabs
 
 ## [6.2.0](https://github.com/dbmdz/cudami/releases/tag/6.2.0) - 2022-11-25
 

--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/legal/LicensesController.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/legal/LicensesController.java
@@ -87,7 +87,10 @@ public class LicensesController {
   }
 
   @GetMapping("/licenses/{uuid}")
-  public String view(@PathVariable UUID uuid, Model model)
+  public String view(
+      @PathVariable UUID uuid,
+      @RequestParam(name = "dataLanguage", required = false) String targetDataLanguage,
+      Model model)
       throws TechnicalException, ResourceNotFoundException {
     License license = service.getByUuid(uuid);
     if (license == null) {
@@ -98,14 +101,18 @@ public class LicensesController {
     LocalizedText label = license.getLabel();
     if (!CollectionUtils.isEmpty(label)) {
       Locale displayLocale = LocaleContextHolder.getLocale();
-      existingLanguages =
-          languageSortingHelper.sortLanguages(displayLocale, license.getLabel().getLocales());
+      existingLanguages = languageSortingHelper.sortLanguages(displayLocale, label.getLocales());
+    }
+
+    String dataLanguage = targetDataLanguage;
+    if (dataLanguage == null && localeService != null) {
+      dataLanguage = localeService.getDefaultLanguage().getLanguage();
     }
 
     model
         .addAttribute("license", license)
         .addAttribute("existingLanguages", existingLanguages)
-        .addAttribute("url", license.getUrl());
+        .addAttribute("dataLanguage", dataLanguage);
     return "licenses/view";
   }
 }

--- a/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/relation/PredicatesController.java
+++ b/dc-cudami-admin/src/main/java/de/digitalcollections/cudami/admin/controller/relation/PredicatesController.java
@@ -246,7 +246,10 @@ public class PredicatesController extends AbstractController {
   }
 
   @GetMapping("/predicates/{uuid}")
-  public String view(@PathVariable UUID uuid, Model model)
+  public String view(
+      @PathVariable UUID uuid,
+      @RequestParam(name = "dataLanguage", required = false) String targetDataLanguage,
+      Model model)
       throws TechnicalException, ResourceNotFoundException {
     Predicate predicate = service.getByUuid(uuid);
     if (predicate == null) {
@@ -257,14 +260,19 @@ public class PredicatesController extends AbstractController {
     LocalizedText label = predicate.getLabel();
     if (!CollectionUtils.isEmpty(label)) {
       Locale displayLocale = LocaleContextHolder.getLocale();
-      existingLanguages =
-          languageSortingHelper.sortLanguages(displayLocale, predicate.getLabel().getLocales());
+      existingLanguages = languageSortingHelper.sortLanguages(displayLocale, label.getLocales());
+    }
+
+    String dataLanguage = targetDataLanguage;
+    if (dataLanguage == null && localeService != null) {
+      dataLanguage = localeService.getDefaultLanguage().getLanguage();
     }
 
     model
         .addAttribute("predicate", predicate)
         .addAttribute("existingLanguages", existingLanguages)
-        .addAttribute("value", predicate.getValue());
+        .addAttribute("dataLanguage", dataLanguage);
+
     return "predicates/view";
   }
 }

--- a/dc-cudami-admin/src/main/resources/static/css/main.css
+++ b/dc-cudami-admin/src/main/resources/static/css/main.css
@@ -42,6 +42,10 @@ a[href^="http"]:not(.no-external):after {
   background-color: #FFF;
 }
 
+div.multilanguage {
+  border-right: solid 5px #f7d093;
+}
+
 .error {
   color: rgb(220, 53, 69);
 }
@@ -55,11 +59,16 @@ a[href^="http"]:not(.no-external):after {
   color: rgb(220, 53, 69);
 }
 
-.global-action {
-  background-color: #fef5e7;
+label {
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+.language-selection {
+  background-color: #f7d093;
   border: solid 1px #ccc;
   margin-bottom: 1em;
-  padding: 1em;
+  padding: 0.5em;
   text-align: center;
 }
 .nav-tabs .nav-tab {

--- a/dc-cudami-admin/src/main/resources/static/js/index.js
+++ b/dc-cudami-admin/src/main/resources/static/js/index.js
@@ -15,21 +15,6 @@ function activatePopovers() {
   $('[data-toggle="popover"]').popover()
 }
 
-function addLanguageChangeHandler() {
-  $('.language-switcher').on('click', function () {
-    // get the href attribute and cut off the leading hash to get the selected language
-    var selectedLanguage = $(this).attr('href').slice(1)
-    var editUrl = $('#edit-button').attr('href').split('?')
-    var urlParams =
-            editUrl.length > 1
-            ? new URLSearchParams(editUrl[1])
-            : new URLSearchParams('')
-    urlParams.set('activeLanguage', selectedLanguage)
-    editUrl = [editUrl[0], urlParams.toString()]
-    $('#edit-button, #sticky-edit-button').attr('href', editUrl.join('?'))
-  })
-}
-
 function appendQueryParameters() {
   var existingQueryParameters = window.location.search
   if (existingQueryParameters) {
@@ -44,47 +29,31 @@ function appendQueryParameters() {
   }
 }
 
-function moveEditButtonToNavbar() {
-  var navbar = document.querySelector('.navbar')
-  var editButton = document.getElementById('edit-button')
-  var editButtonInNavbar = document.createElement('li')
-  editButtonInNavbar.classList.add('border-left', 'ml-2', 'nav-item', 'pl-3')
-  editButtonInNavbar.innerHTML = `<a class="border border-white btn btn-primary btn-sm" id="sticky-edit-button">${editButton.innerText}</a>`
-  var observer = new IntersectionObserver(
-          (entry, _) => {
-    var inView = entry[0].isIntersecting && entry[0].intersectionRatio >= 1
-    if (inView) {
-      editButton.classList.add('visible')
-      editButton.classList.remove('invisible')
-      editButtonInNavbar.remove()
-    } else {
-      editButton.classList.add('invisible')
-      editButton.classList.remove('visible')
-      editButtonInNavbar
-              .querySelector('a')
-              .setAttribute('href', editButton.getAttribute('href'))
-      navbar.querySelector('.navbar-nav').appendChild(editButtonInNavbar)
-    }
-  },
-          {
-            rootMargin: `-${navbar.offsetHeight}px 0px 0px 0px`,
-            threshold: 1,
-          },
-          )
-  observer.observe(editButton)
-}
+/* v7 functions: */
 
-function bindTabEvents() {
-  $('.nav-tabs a').on('shown.bs.tab', function (event) {
-    let targetNavItem = $(event.target).parent();
-    let targetNavTabs = $(targetNavItem).parent();
-
-    $(targetNavTabs).children(".nav-tab").removeClass("active");
-    $(targetNavItem).addClass("active");
+function addDataLanguageChangeHandler() {
+  $("#data-languages").change(function () {
+    var url = window.location.href.split('?')[0];
+    let dataLanguage = $("#data-languages").val();
+    window.location.href = url + '?dataLanguage=' + dataLanguage;
   });
 }
 
-/* v7 functions: */
+function addLanguageChangeHandler() {
+  /* used in view pages to switch language tabs */
+  $('.language-switcher').on('click', function () {
+    // get the href attribute and cut off the leading hash to get the selected language
+    var selectedLanguage = $(this).attr('href').slice(1);
+    var editUrl = $('#edit-button').attr('href').split('?');
+    var urlParams =
+            editUrl.length > 1
+            ? new URLSearchParams(editUrl[1])
+            : new URLSearchParams('');
+    urlParams.set('activeLanguage', selectedLanguage);
+    editUrl = [editUrl[0], urlParams.toString()];
+    $('#edit-button, #sticky-edit-button').attr('href', editUrl.join('?'));
+  });
+}
 
 function addUserStatusChangeHandler(url) {
   /* used in users/view.html */
@@ -120,7 +89,18 @@ function addUserStatusChangeHandler(url) {
   }
 }
 
+function bindTabEvents() {
+  $('.nav-tabs a').on('shown.bs.tab', function (event) {
+    let targetNavItem = $(event.target).parent();
+    let targetNavTabs = $(targetNavItem).parent();
+
+    $(targetNavTabs).children(".nav-tab").removeClass("active");
+    $(targetNavItem).addClass("active");
+  });
+}
+
 function formatDate(date, locale, onlyDate = false) {
+  /* used to output a date or date with time */
   if (!date) {
     return null;
   }
@@ -143,6 +123,7 @@ function formatDate(date, locale, onlyDate = false) {
 }
 
 function formatStringArray(value) {
+  /* used to output a list of strings as comma separated list */
   let html = '';
   for (var i = 0; i < value.length; i++) {
     html = html + value[i];
@@ -153,6 +134,38 @@ function formatStringArray(value) {
   return html;
 }
 
+function moveEditButtonToNavbar() {
+  /* used in view pages to move edit button to navbar if page is scrollable */
+  var navbar = document.querySelector('.navbar');
+  var editButton = document.getElementById('edit-button');
+  var editButtonInNavbar = document.createElement('li');
+  editButtonInNavbar.classList.add('border-left', 'ml-2', 'nav-item', 'pl-3');
+  editButtonInNavbar.innerHTML = `<a class="border border-white btn btn-primary btn-sm" id="sticky-edit-button">${editButton.innerText}</a>`;
+  var observer = new IntersectionObserver(
+          (entry, _) => {
+    var inView = entry[0].isIntersecting && entry[0].intersectionRatio >= 1;
+    if (inView) {
+      editButton.classList.add('visible');
+      editButton.classList.remove('invisible');
+      editButtonInNavbar.remove();
+    } else {
+      editButton.classList.add('invisible');
+      editButton.classList.remove('visible');
+      editButtonInNavbar
+              .querySelector('a')
+              .setAttribute('href', editButton.getAttribute('href'));
+      navbar.querySelector('.navbar-nav').appendChild(editButtonInNavbar);
+    }
+  },
+          {
+            rootMargin: `-${navbar.offsetHeight}px 0px 0px 0px`,
+            threshold: 1
+          }
+  );
+  observer.observe(editButton);
+}
+
 function prependErrorIcon(element) {
+  /* used in form pages to mark tabs with erroneous input */
   $(element).prepend('<i class="fas fa-exclamation-circle error mr-2"></i>');
 }

--- a/dc-cudami-admin/src/main/resources/templates/fragments/uniqueobject.html
+++ b/dc-cudami-admin/src/main/resources/templates/fragments/uniqueobject.html
@@ -5,12 +5,12 @@
 
   <th:block th:fragment="renderFields(uniqueObject)">
     <div class="row">
-      <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{id}">ID</label></div>
+      <div class="col-md-3"><label th:text="#{id}">ID</label></div>
       <div class="col-md-9"><span th:text="${uniqueObject.uuid}">b7a245fe-da46-4d7d-a8e4-a7ee8f24f840</span></div>
     </div>
     <div class="row">
       <div class="col-md-3">
-        <label class="font-weight-bold mb-0">
+        <label>
           <span class="mr-1" th:text="#{created}"></span>
           /
           <span class="ml-1" th:text="#{last_modified}"></span>
@@ -28,7 +28,7 @@
     <section class="mb-3 rows-striped">
       <div class="row">
         <div class="col-md-3 mb-1">
-          <label class="font-weight-bold mb-0">
+          <label>
             <span class="mr-1" th:text="#{created}"></span>
             /
             <span class="ml-1" th:text="#{last_modified}"></span>

--- a/dc-cudami-admin/src/main/resources/templates/identifiertypes/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/identifiertypes/view.html
@@ -11,11 +11,9 @@
     <div class="content-header">
       <div class="container-fluid">
         <div class="row">
-          
           <div class="col-sm-6">
             <h1 th:text="|#{lbl.identifier_type} &quot;${identifierType.namespace}&quot;|">...</h1>
           </div>
-          
           <div class="col-sm-6">
             <div class="float-right">
               <a class="btn btn-primary" id="edit-button" th:href="@{*{uuid} + '/edit'}" th:text="#{edit}">edit</a>
@@ -32,16 +30,18 @@
 
         <th:block th:insert="fragments/uniqueobject::renderFields(${identifierType})"></th:block>
 
+        <hr/>
+
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{lbl.label}">Label</label></div>
+          <div class="col-md-3"><label th:text="#{lbl.label}">Label</label></div>
           <div class="col-md-9"><span th:text="*{label}">bla bla</span></div>
         </div>
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{lbl.namespace}">Namespace</label></div>
+          <div class="col-md-3"><label th:text="#{lbl.namespace}">Namespace</label></div>
           <div class="col-md-9"><span th:text="*{namespace}">gnd</span></div>
         </div>
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{lbl.pattern}">Pattern</label></div>
+          <div class="col-md-3"><label th:text="#{lbl.pattern}">Pattern</label></div>
           <div class="col-md-9"><span th:text="*{pattern}">xyz[0-9]*</span></div>
         </div>
 

--- a/dc-cudami-admin/src/main/resources/templates/identifiertypes/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/identifiertypes/view.html
@@ -12,7 +12,7 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-sm-6">
-            <h1 th:text="|#{lbl.identifier_type} &quot;${identifierType.namespace}&quot;|">...</h1>
+            <h1 th:text="|#{lbl.identifier_type} &quot;*{namespace}&quot;|">...</h1>
           </div>
           <div class="col-sm-6">
             <div class="float-right">

--- a/dc-cudami-admin/src/main/resources/templates/licenses/list.html
+++ b/dc-cudami-admin/src/main/resources/templates/licenses/list.html
@@ -59,9 +59,9 @@
                 <tr>
                   <th data-field="index" data-formatter="formatRowNumber" data-halign="right" data-align="right" th:text="#{lbl.row_number}">#</th>
                   <th data-field="label" data-sortable="true" data-formatter="formatLabel" th:text="#{lbl.label}">Label</th>
-                  <th data-field="acronym" data-sortable="true" th:text="#{lbl.acronym}">Acronym</th>
+                  <th data-field="acronym" data-sortable="true" data-formatter="formatAcronym" th:text="#{lbl.acronym}">Acronym</th>
                   <th data-field="url" data-sortable="true" data-formatter="formatUrl" th:text="#{lbl.url}">URL</th>
-                  
+
                   <th data-field="lastModified" data-sortable="true" data-formatter="renderDateTime" th:text="#{lbl.last_modified}">last modified</th>
                   <th data-field="created" data-sortable="true" data-formatter="renderDateTime" th:text="#{lbl.created}">created</th>
                   <th data-field="actions" data-formatter="formatActions" th:text="#{lbl.actions}">Actions</th>
@@ -71,12 +71,12 @@
 
           </div>
         </div>
-        
-        
+
+
       </div>
     </div>
   </th:block>
-  
+
   <th:block layout:fragment="beforeBodyEnds">
     <div th:replace="fragments/modals/confirm-yes-no :: confirm-yes-no-dialog"></div>
 
@@ -122,6 +122,14 @@
           }
         };
       }
+
+      function formatAcronym(value, row) {
+        /*[+
+         const baseUrl = [[@{'/licenses'}]] + '/' + row.uuid;
+         +]*/
+        return '<a href="' + baseUrl + '">' + value + '</a>';
+      }
+
       function formatActions(value, row) {
         /*[+
          const baseUrl = [[@{'/licenses'}]] + '/' + row.uuid;
@@ -131,17 +139,14 @@
           renderEditAction(baseUrl)
         ].join(' ');
       }
-      
+
       function formatLabel(value, row) {
         const itemLocale = $("#licenses-locales").val();
         return renderLocalizedText(value, itemLocale);
       }
-      
+
       function formatUrl(value, row) {
-        /*[+
-         const baseUrl = [[@{'/licenses'}]] + '/' + row.uuid;
-         +]*/
-        return '<a href="' + baseUrl + '">' + value + '</a>';
+        return '<a href="' + value + '" target="_blank">' + value + '</a>';
       }
       /*]]>*/
     </script>

--- a/dc-cudami-admin/src/main/resources/templates/licenses/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/licenses/view.html
@@ -4,7 +4,7 @@
       xmlns:data="https://github.com/mxab/thymeleaf-extras-data-attribute"
       layout:decorate="~{base}">
   <head>
-    <title th:text="|#{licenses}: #{license} &quot;${url}&quot;|">...</title>
+    <title th:text="|#{page.title.licenses}: #{license} &quot;${url}&quot;|">...</title>
   </head>
   <body>
   <th:block layout:fragment="content" th:object="${license}">
@@ -26,64 +26,36 @@
 
     <!-- Main content -->
     <div class="content">
-      <div class="container-fluid">
+      <div class="container-fluid rows-striped">
+        <!-- TODO it always contains "und" undefined language? -->
+        <th:block th:if="${not #lists.isEmpty(existingLanguages)}">
+          <div class="language-selection">
+            <span th:text="#{lbl.itemlocale}">Show language dependent values in</span>&nbsp;
+            <select name="locales" id="data-languages">
+              <th:block th:each="locale : ${existingLanguages}">
+                <option th:value="${locale.language}" th:text="${locale.getDisplayLanguage(#locale)}" th:selected="${#strings.equals(locale.language, dataLanguage)}">English</option>
+              </th:block>
+            </select>
+          </div>
+        </th:block>
+
+        <th:block th:insert="fragments/uniqueobject::renderFields(${license})"></th:block>
+
+        <hr/>
+
         <div class="row">
-          <div class="col-sm-12">
-            <div class="mb-3 rows-striped">
-              <div class="row">
-                <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{id}">ID</label></div>
-                <div class="col-md-9"><span th:text="*{uuid}">b7a245fe-da46-4d7d-a8e4-a7ee8f24f840</span></div>
-              </div>
-            </div>
+          <div class="col-md-3 multilanguage"><label th:text="#{lbl.label}">Label</label></div>
+          <div class="col-md-9">
+            <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(*{label}, ${dataLanguage})"></th:block>
           </div>
         </div>
-
-        <th:block th:insert="fragments/uniqueobject::renderDates(${license})"></th:block>
-
-        <div class="row">
-          <div class="col-sm-12">
-            <ul class="nav nav-tabs" role="tablist">
-              <li class="nav-item" th:each="language,iter : ${existingLanguages}">
-                <a
-                  class="language-switcher nav-link"
-                  data-toggle="tab"
-                  role="tab"
-                  th:classappend="${iter.index} == 0 ? active"
-                  th:href="${'#' + language}"
-                  th:text="${#strings.isEmpty(languageToDisplay)} ? #{language_not_specified} : ${languageToDisplay}"
-                  th:with="languageToDisplay=${language.getDisplayName(#locale)}"
-                >
-                  language
-                </a>
-              </li>
-            </ul>
-            <div class="tab-content">
-              <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
-                <div class="card">
-                  <div class="card-body bg-light">
-                    <label class="font-weight-bold">
-                      <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(${license.label}, ${language})"></th:block>
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div class="row" th:if="*{url}">
+          <div class="col-md-3"><label th:text="#{url}">URL</label></div>
+          <div class="col-md-9"><a th:href="*{url}" th:text="*{url}" target="_blank">http://www.example.de/</a></div>
         </div>
-
-        <div class="row">
-          <div class="col-sm-12">
-            <div class="rows-striped">
-              <div class="row" th:if="*{url}">
-                <div class="col-md-3"><label class="font-weight-bold" th:text="#{url}">URL</label></div>
-                <div class="col-md-9"><a th:href="*{url}" th:text="*{url}" target="_blank">http://www.example.de/</a></div>
-              </div>
-              <div class="row" th:if="*{acronym}">
-                <div class="col-md-3"><label class="font-weight-bold" th:text="#{acronym}">...</label></div>
-                <div class="col-md-9"><span th:text="*{acronym}">...</span></div>
-              </div>
-            </div>
-          </div>
+        <div class="row" th:if="*{acronym}">
+          <div class="col-md-3"><label th:text="#{acronym}">...</label></div>
+          <div class="col-md-9"><span th:text="*{acronym}">...</span></div>
         </div>
       </div>
     </div>
@@ -91,9 +63,9 @@
 
   <section layout:fragment="beforeBodyEnds">
     <script>
-      addLanguageChangeHandler()
-      moveEditButtonToNavbar()
+      $(addDataLanguageChangeHandler());
+      $(moveEditButtonToNavbar());
     </script>
   </section>
-  </body>
+</body>
 </html>

--- a/dc-cudami-admin/src/main/resources/templates/licenses/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/licenses/view.html
@@ -12,7 +12,7 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-sm-6">
-            <h1 th:text="|#{license} &quot;${url}&quot;|">...</h1>
+            <h1 th:text="|#{license} &quot;*{url}&quot;|">...</h1>
           </div>
           <div class="col-sm-6">
             <div class="float-right">

--- a/dc-cudami-admin/src/main/resources/templates/predicates/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/predicates/view.html
@@ -12,7 +12,7 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-sm-6">
-            <h1 th:text="|#{predicate} &quot;${predicate.value}&quot;|">...</h1>
+            <h1 th:text="|#{predicate} &quot;*{value}&quot;|">...</h1>
           </div>
           <div class="col-sm-6">
             <div class="float-right">

--- a/dc-cudami-admin/src/main/resources/templates/predicates/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/predicates/view.html
@@ -4,7 +4,7 @@
       xmlns:data="https://github.com/mxab/thymeleaf-extras-data-attribute"
       layout:decorate="~{base}">
   <head>
-    <title th:text="|#{predicates}: #{predicate} &quot;${predicate.value}&quot;|">...</title>
+    <title th:text="|#{page.title.predicates}: #{predicate} &quot;${predicate.value}&quot;|">...</title>
   </head>
   <body>
   <th:block layout:fragment="content" th:object="${predicate}">
@@ -28,49 +28,36 @@
     <!-- Main content -->
     <div class="content">
       <div class="container-fluid rows-striped">
-
-        <div class="row" th:if="${existingLanguages} and not ${#lists.isEmpty(existingLanguages)}">
-          <div class="col-sm-12">
-            <ul class="nav nav-tabs" role="tablist">
-              <li class="nav-tab" th:each="language,iter : ${existingLanguages}" th:classappend="${iter.index} == 0 ? active">
-                <a
-                  class="language-switcher nav-link"
-                  data-toggle="tab"
-                  role="tab"
-                  th:classappend="${iter.index} == 0 ? active"
-                  th:href="${'#' + language}"
-                  th:text="${#strings.isEmpty(languageToDisplay)} ? #{language_not_specified} : ${languageToDisplay}"
-                  th:with="languageToDisplay=${language.getDisplayName(#locale)}"
-                  >
-                  language
-                </a>
-              </li>
-            </ul>
-            <div class="tab-content">
-              <div th:each="language,iter : ${existingLanguages}" th:id="${language}" class="tab-pane" th:classappend="${iter.index} == 0 ? active">
-                <div class="card">
-                  <div class="card-body bg-light">
-                    <div class="row">
-                      <div class="col-sm-12">
-                        <label class="font-weight-bold">
-                          <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(${predicate.label}, ${language})"></th:block>
-                        </label>
-                        <th:block th:if="${predicate.description?.containsKey(language)}">
-                          <div th:insert="cudami/fragments/structuredcontent::renderLocalizedStructuredContent(${predicate.description}, ${language})"></div>
-                        </th:block>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+        <!-- TODO it always contains "und" undefined language? -->
+        <th:block th:if="${not #lists.isEmpty(existingLanguages)}">
+          <div class="language-selection">
+            <span th:text="#{lbl.itemlocale}">Show language dependent values in</span>&nbsp;
+            <select name="locales" id="data-languages">
+              <th:block th:each="locale : ${existingLanguages}">
+                <option th:value="${locale.language}" th:text="${locale.getDisplayLanguage(#locale)}" th:selected="${#strings.equals(locale.language, dataLanguage)}">English</option>
+              </th:block>
+            </select>
           </div>
-        </div>
+        </th:block>
 
         <th:block th:insert="fragments/uniqueobject::renderFields(${predicate})"></th:block>
 
+        <hr/>
+
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{lbl.value}">Value</label></div>
+          <div class="col-md-3 multilanguage"><label th:text="#{lbl.label}">Label</label></div>
+          <div class="col-md-9">
+            <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(*{label}, ${dataLanguage})"></th:block>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-3 multilanguage"><label th:text="#{lbl.description}">Abstract</label></div>
+          <div class="col-md-9">
+            <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(*{description}, ${dataLanguage})"></th:block>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-3"><label th:text="#{lbl.value}">Value</label></div>
           <div class="col-md-9"><span th:text="*{value}">is_author_of</span></div>
         </div>
 
@@ -80,9 +67,10 @@
 
   <section layout:fragment="beforeBodyEnds">
     <div th:replace="fragments/modals/confirm-yes-no :: confirm-yes-no-dialog"></div>
-    <script>
-      addLanguageChangeHandler()
-      moveEditButtonToNavbar()
+    
+    <script type="text/javascript">
+      $(addDataLanguageChangeHandler());
+      $(moveEditButtonToNavbar());
     </script>
   </section>
 </body>

--- a/dc-cudami-admin/src/main/resources/templates/renderingtemplates/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/renderingtemplates/view.html
@@ -12,7 +12,7 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-sm-6">
-            <h1 th:text="|#{lbl.rendering_template} &quot;${renderingTemplate.name}&quot;|">...</h1>
+            <h1 th:text="|#{lbl.rendering_template} &quot;*{name}&quot;|">...</h1>
           </div>
           <div class="col-sm-6">
             <div class="float-right">

--- a/dc-cudami-admin/src/main/resources/templates/renderingtemplates/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/renderingtemplates/view.html
@@ -11,11 +11,9 @@
     <div class="content-header">
       <div class="container-fluid">
         <div class="row">
-
           <div class="col-sm-6">
             <h1 th:text="|#{lbl.rendering_template} &quot;${renderingTemplate.name}&quot;|">...</h1>
           </div>
-
           <div class="col-sm-6">
             <div class="float-right">
               <a class="btn btn-primary" id="edit-button" th:href="@{*{uuid} + '/edit'}" th:text="#{edit}">edit</a>
@@ -31,37 +29,34 @@
       <div class="container-fluid rows-striped">
         <!-- TODO it always contains "und" undefined language? -->
         <th:block th:if="${not #lists.isEmpty(existingLanguages)}">
-          <div id="itemLocaleSwitcher" class="global-action">
+          <div class="language-selection">
             <span th:text="#{lbl.itemlocale}">Show language dependent values in</span>&nbsp;
-            <select name="locales" id="rendering_templates-locales">
+            <select name="locales" id="data-languages">
               <th:block th:each="locale : ${existingLanguages}">
-                <option th:value="${locale.language}" th:text="${locale.getDisplayLanguage(#locale)}" th:selected="${#strings.equals(locale.language, defaultLanguage)}">English</option>
+                <option th:value="${locale.language}" th:text="${locale.getDisplayLanguage(#locale)}" th:selected="${#strings.equals(locale.language, dataLanguage)}">English</option>
               </th:block>
             </select>
           </div>
         </th:block>
 
-        <div class="card">
-          <div class="card-body">
-            <div class="row">
-              <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{lbl.label}">Label</label></div>
-              <div class="col-md-9">
-                <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(*{label}, ${language})"></th:block>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{lbl.description}">Abstract</label></div>
-              <div class="col-md-9">
-                <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(*{description}, ${language})"></th:block>
-              </div>
-            </div>
-          </div>
-        </div>
-
         <th:block th:insert="fragments/uniqueobject::renderFields(${renderingTemplate})"></th:block>
 
+        <hr/>
+
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{lbl.name}">Name</label></div>
+          <div class="col-md-3 multilanguage"><label th:text="#{lbl.label}">Label</label></div>
+          <div class="col-md-9">
+            <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(*{label}, ${dataLanguage})"></th:block>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-3 multilanguage"><label th:text="#{lbl.description}">Abstract</label></div>
+          <div class="col-md-9">
+            <th:block th:insert="cudami/fragments/localizedtext::renderLocalizedText(*{description}, ${dataLanguage})"></th:block>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-3"><label th:text="#{lbl.name}">Name</label></div>
           <div class="col-md-9"><span th:text="*{name}">cool template</span></div>
         </div>
 
@@ -73,13 +68,7 @@
     <div th:replace="fragments/modals/confirm-yes-no :: confirm-yes-no-dialog"></div>
 
     <script type="text/javascript">
-      $(function () {
-        $("#rendering_templates-locales").change(function () {
-          var url = window.location.href.split('?')[0];
-          let itemLocale = $("#rendering_templates-locales").val();
-          window.location.href = url + '?itemLocale=' + itemLocale;
-        });
-      });
+      $(addDataLanguageChangeHandler());
     </script>
   </section>
 </body>

--- a/dc-cudami-admin/src/main/resources/templates/users/view.html
+++ b/dc-cudami-admin/src/main/resources/templates/users/view.html
@@ -59,19 +59,19 @@
         <hr>
         
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{username}">Username / Email</label></div>
+          <div class="col-md-3"><label th:text="#{username}">Username / Email</label></div>
           <div class="col-md-9"><span th:text="*{email}">email@email.de</span></div>
         </div>
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="|#{lastname}, #{firstname}">Lastname, Firstname</label></div>
+          <div class="col-md-3"><label th:text="|#{lastname}, #{firstname}">Lastname, Firstname</label></div>
           <div class="col-md-9"><span th:text="*{lastname}">Lastname</span>, <span th:text="*{firstname}">Firstname</span></div>
         </div>
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{roles}">Role(s)</label></div>
+          <div class="col-md-3"><label th:text="#{roles}">Role(s)</label></div>
           <div class="col-md-9"><th:block th:each="role,rowStat : *{roles}"><span th:text="${role.name()}">ROLE_CONTENT_MANAGER</span><span th:unless="${rowStat.last}">, </span></th:block></div>
         </div>
         <div class="row">
-          <div class="col-md-3"><label class="font-weight-bold mb-0" th:text="#{status}">Status</label></div>
+          <div class="col-md-3"><label th:text="#{status}">Status</label></div>
           <div class="col-md-9"><span th:text="#{${'tooltip.enabled.' + user.enabled}}">active</span></div>
         </div>
       </div>

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/view/CudamiRenderingTemplatesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/view/CudamiRenderingTemplatesClient.java
@@ -20,6 +20,6 @@ public class CudamiRenderingTemplatesClient extends CudamiRestClient<RenderingTe
   }
 
   public List<Locale> getLanguages() throws TechnicalException {
-    return this.doGetRequestForObjectList(baseEndpoint + "/languages", Locale.class);
+    return doGetRequestForObjectList(baseEndpoint + "/languages", Locale.class);
   }
 }


### PR DESCRIPTION
View-Seiten des Admin-Abschnitt überarbeitet
- Sprachumschaltung wie bei Listen jetzt pro Seite mit einem Klappfeld (mit PM so besprochen)
- label: inline-css-classes durch generelle label-regel in main.css
- label, description und preview image nicht mehr in separatem "teaser" (zu designorientiert), sondern wie alle anderen Felder auch nun mit Feldbezeichnung und Wert auf rechter Seite