### PR TITLE
Fix filtering for uniqueobjects

### DIFF
--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClient.java
@@ -6,23 +6,18 @@ import de.digitalcollections.model.exception.TechnicalException;
 import de.digitalcollections.model.exception.http.client.ResourceNotFoundException;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
-import de.digitalcollections.model.list.filtering.FilterCriterion;
-import de.digitalcollections.model.list.filtering.FilterOperation;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.list.sorting.Direction;
 import de.digitalcollections.model.list.sorting.NullHandling;
 import de.digitalcollections.model.list.sorting.Order;
 import de.digitalcollections.model.list.sorting.Sorting;
-import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.binary.Base64;
 
@@ -44,39 +39,6 @@ public class CudamiIdentifiablesClient<I extends Identifiable> extends CudamiRes
         (Class<I>) Identifiable.class,
         mapper,
         API_VERSION_PREFIX + "/identifiables");
-  }
-
-  @Override
-  protected String filterCriterionToUrlParam(FilterCriterion filterCriterion) {
-    Matcher labelOrName = Pattern.compile("^(label|name)").matcher(filterCriterion.getExpression());
-    if (labelOrName.find()) {
-      if (filterCriterion.getValue() == null || !(filterCriterion.getValue() instanceof String)) {
-        return "";
-      }
-      String value = (String) filterCriterion.getValue();
-      if (filterCriterion.getOperation() == FilterOperation.EQUALS) {
-        value = String.format("\"%s\"", value);
-      } else if (filterCriterion.getOperation() != FilterOperation.CONTAINS) {
-        throw new UnsupportedOperationException(
-            "`label` and `name` can only be filtered by using CONTAINS (should be preferred) or EQUALS!");
-      }
-      String urlParams =
-          String.format(
-              "%s=%s", labelOrName.group(1), URLEncoder.encode(value, StandardCharsets.UTF_8));
-      Matcher matchLanguage =
-          Pattern.compile("\\.([\\w_-]+)$").matcher(filterCriterion.getExpression());
-      if (matchLanguage.find()) {
-        // there is a language defined
-        return urlParams
-            + String.format(
-                "&%sLanguage=%s",
-                labelOrName.group(1),
-                URLEncoder.encode(matchLanguage.group(1), StandardCharsets.UTF_8));
-      }
-      return urlParams;
-    }
-
-    return super.filterCriterionToUrlParam(filterCriterion);
   }
 
   public List<I> find(String searchTerm, int maxResults) throws TechnicalException {

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/CudamiRestClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/CudamiRestClientTest.java
@@ -4,14 +4,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
 import java.net.URI;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("The CudamiRestClient")
 public class CudamiRestClientTest {
+
+  private CudamiRestClient client;
+  String serverUrl = "http://localhost:1234/cudami";
+
+  @BeforeEach
+  public void beforeEach() {
+    client =
+        new CudamiRestClient(
+            null, serverUrl, Identifiable.class, new DigitalCollectionsObjectMapper(), "/v999");
+  }
 
   @Test
   public void testCreateFullUriWithPath() {
-    String serverUrl = "http://localhost:1234/cudami";
+
     String requestUrl = "/foo/bar";
     CudamiRestClient base =
         new CudamiRestClient(
@@ -31,5 +46,55 @@ public class CudamiRestClientTest {
     URI result = base.createFullUri(requestUrl);
     URI expectedResult = URI.create(serverUrl + requestUrl);
     assertThat(result).isEqualTo(expectedResult);
+  }
+
+  @Test
+  @DisplayName("params for label filtering are treated different")
+  public void testLabelParams() {
+    FilterCriterion fcLabel =
+        FilterCriterion.builder().withExpression("label").contains("something special").build();
+    String expLabel = "label=something+special";
+
+    FilterCriterion fcLabelWithLanguage =
+        FilterCriterion.builder().withExpression("label.en").contains("something").build();
+    String expLabelWithLanguage = "label=something&labelLanguage=en";
+
+    FilterCriterion fcLabelEquals =
+        FilterCriterion.builder().withExpression("label").isEquals("something special").build();
+    String expLabelEquals = "label=%22something+special%22";
+
+    assertThat(client.filterCriterionToUrlParam(fcLabel)).isEqualTo(expLabel);
+    assertThat(client.filterCriterionToUrlParam(fcLabelWithLanguage))
+        .isEqualTo(expLabelWithLanguage);
+    assertThat(client.filterCriterionToUrlParam(fcLabelEquals)).isEqualTo(expLabelEquals);
+
+    // normal case
+    LocalDate date = LocalDate.now();
+    FilterCriterion fcDate =
+        FilterCriterion.builder().withExpression("lastModified").isEquals(date).build();
+    String expDate = String.format("lastModified=eq:%s", date.toString());
+
+    assertThat(client.filterCriterionToUrlParam(fcDate)).isEqualTo(expDate);
+  }
+
+  @Test
+  @DisplayName("params for name filtering are treated different")
+  public void testNameParams() {
+    FilterCriterion fcLabel =
+        FilterCriterion.builder().withExpression("name").contains("something special").build();
+    String expLabel = "name=something+special";
+
+    FilterCriterion fcLabelWithLanguage =
+        FilterCriterion.builder().withExpression("name.en").contains("something").build();
+    String expLabelWithLanguage = "name=something&nameLanguage=en";
+
+    FilterCriterion fcLabelEquals =
+        FilterCriterion.builder().withExpression("name").isEquals("something special").build();
+    String expLabelEquals = "name=%22something+special%22";
+
+    assertThat(client.filterCriterionToUrlParam(fcLabel)).isEqualTo(expLabel);
+    assertThat(client.filterCriterionToUrlParam(fcLabelWithLanguage))
+        .isEqualTo(expLabelWithLanguage);
+    assertThat(client.filterCriterionToUrlParam(fcLabelEquals)).isEqualTo(expLabelEquals);
   }
 }

--- a/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClientTest.java
+++ b/dc-cudami-client/src/test/java/de/digitalcollections/cudami/client/identifiable/CudamiIdentifiablesClientTest.java
@@ -1,15 +1,10 @@
 package de.digitalcollections.cudami.client.identifiable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.digitalcollections.cudami.client.identifiable.CudamiIdentifiablesClientTest.CudamiIdentifiablesClientForIdentifiables;
 import de.digitalcollections.model.identifiable.Identifiable;
-import de.digitalcollections.model.list.filtering.FilterCriterion;
 import java.net.http.HttpClient;
-import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 @DisplayName("The Identifiables Client for Identifiables")
 public class CudamiIdentifiablesClientTest
@@ -31,55 +26,5 @@ public class CudamiIdentifiablesClientTest
           objectMapper,
           API_VERSION_PREFIX + "/identifiable");
     }
-  }
-
-  @Test
-  @DisplayName("params for label filtering are treated different")
-  public void testLabelParams() {
-    FilterCriterion fcLabel =
-        FilterCriterion.builder().withExpression("label").contains("something special").build();
-    String expLabel = "label=something+special";
-
-    FilterCriterion fcLabelWithLanguage =
-        FilterCriterion.builder().withExpression("label.en").contains("something").build();
-    String expLabelWithLanguage = "label=something&labelLanguage=en";
-
-    FilterCriterion fcLabelEquals =
-        FilterCriterion.builder().withExpression("label").isEquals("something special").build();
-    String expLabelEquals = "label=%22something+special%22";
-
-    assertThat(client.filterCriterionToUrlParam(fcLabel)).isEqualTo(expLabel);
-    assertThat(client.filterCriterionToUrlParam(fcLabelWithLanguage))
-        .isEqualTo(expLabelWithLanguage);
-    assertThat(client.filterCriterionToUrlParam(fcLabelEquals)).isEqualTo(expLabelEquals);
-
-    // normal case
-    LocalDate date = LocalDate.now();
-    FilterCriterion fcDate =
-        FilterCriterion.builder().withExpression("lastModified").isEquals(date).build();
-    String expDate = String.format("lastModified=eq:%s", date.toString());
-
-    assertThat(client.filterCriterionToUrlParam(fcDate)).isEqualTo(expDate);
-  }
-
-  @Test
-  @DisplayName("params for name filtering are treated different")
-  public void testNameParams() {
-    FilterCriterion fcLabel =
-        FilterCriterion.builder().withExpression("name").contains("something special").build();
-    String expLabel = "name=something+special";
-
-    FilterCriterion fcLabelWithLanguage =
-        FilterCriterion.builder().withExpression("name.en").contains("something").build();
-    String expLabelWithLanguage = "name=something&nameLanguage=en";
-
-    FilterCriterion fcLabelEquals =
-        FilterCriterion.builder().withExpression("name").isEquals("something special").build();
-    String expLabelEquals = "name=%22something+special%22";
-
-    assertThat(client.filterCriterionToUrlParam(fcLabel)).isEqualTo(expLabel);
-    assertThat(client.filterCriterionToUrlParam(fcLabelWithLanguage))
-        .isEqualTo(expLabelWithLanguage);
-    assertThat(client.filterCriterionToUrlParam(fcLabelEquals)).isEqualTo(expLabelEquals);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/UniqueObjectRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/UniqueObjectRepository.java
@@ -1,0 +1,18 @@
+package de.digitalcollections.cudami.server.backend.api.repository;
+
+import de.digitalcollections.model.UniqueObject;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.paging.PageResponse;
+import java.util.UUID;
+
+public interface UniqueObjectRepository<U extends UniqueObject> {
+
+  PageResponse<U> find(PageRequest pageRequest);
+
+  default U getByUuid(UUID uuid) {
+    return getByUuidAndFiltering(uuid, null);
+  }
+
+  U getByUuidAndFiltering(UUID uuid, Filtering filtering);
+}

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/IdentifiableRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/IdentifiableRepository.java
@@ -1,11 +1,11 @@
 package de.digitalcollections.cudami.server.backend.api.repository.identifiable;
 
+import de.digitalcollections.cudami.server.backend.api.repository.UniqueObjectRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.exceptions.RepositoryException;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.Identifier;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.resource.FileResource;
-import de.digitalcollections.model.list.filtering.Filtering;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import java.util.ArrayList;
@@ -17,7 +17,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public interface IdentifiableRepository<I extends Identifiable> {
+public interface IdentifiableRepository<I extends Identifiable> extends UniqueObjectRepository<I> {
 
   static String[] splitToArray(String term) {
     term = term.toLowerCase();
@@ -72,8 +72,6 @@ public interface IdentifiableRepository<I extends Identifiable> {
 
   boolean delete(List<UUID> uuids);
 
-  PageResponse<I> find(PageRequest pageRequest);
-
   default List<I> find(String searchTerm, int maxResults) {
     PageRequest request = new PageRequest(searchTerm, 0, maxResults, null);
     PageResponse<I> response = find(request);
@@ -98,12 +96,6 @@ public interface IdentifiableRepository<I extends Identifiable> {
       PageRequest pageRequest, String language, String initial);
 
   I getByIdentifier(Identifier identifier);
-
-  default I getByUuid(UUID uuid) {
-    return getByUuidAndFiltering(uuid, null);
-  }
-
-  I getByUuidAndFiltering(UUID uuid, Filtering filtering);
 
   default I getByIdentifier(String namespace, String id) {
     return getByIdentifier(new Identifier(null, namespace, id));

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/semantic/SubjectRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/identifiable/entity/semantic/SubjectRepository.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.semantic;
 
+import de.digitalcollections.cudami.server.backend.api.repository.UniqueObjectRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.exceptions.RepositoryException;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -7,7 +8,7 @@ import de.digitalcollections.model.semantic.Subject;
 import java.util.List;
 import java.util.UUID;
 
-public interface SubjectRepository {
+public interface SubjectRepository extends UniqueObjectRepository<Subject> {
 
   long count();
 

--- a/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/semantic/TagRepository.java
+++ b/dc-cudami-server/dc-cudami-server-backend-api/src/main/java/de/digitalcollections/cudami/server/backend/api/repository/semantic/TagRepository.java
@@ -1,12 +1,13 @@
 package de.digitalcollections.cudami.server.backend.api.repository.semantic;
 
+import de.digitalcollections.cudami.server.backend.api.repository.UniqueObjectRepository;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.semantic.Tag;
 import java.util.List;
 import java.util.UUID;
 
-public interface TagRepository {
+public interface TagRepository extends UniqueObjectRepository<Tag> {
 
   long count();
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/UniqueObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/UniqueObjectRepositoryImpl.java
@@ -49,7 +49,7 @@ public abstract class UniqueObjectRepositoryImpl<U extends UniqueObject> extends
   protected String getWhereClause(
       FilterCriterion<?> fc, Map<String, Object> argumentMappings, int criterionCount)
       throws IllegalArgumentException, UnsupportedOperationException {
-    Matcher labelOrName = Pattern.compile("^(label|name)").matcher(fc.getExpression());
+    Matcher labelOrName = Pattern.compile("^(label|name)\\b").matcher(fc.getExpression());
     if (labelOrName.find()) {
       if (!(fc.getValue() instanceof String)) {
         throw new IllegalArgumentException("Value of label must be a string!");
@@ -72,7 +72,8 @@ public abstract class UniqueObjectRepositoryImpl<U extends UniqueObject> extends
                 "Filtering by label and by name are mutually exclusive!");
           }
           Matcher matchLanguage = Pattern.compile("\\.([\\w_-]+)$").matcher(fc.getExpression());
-          String language = matchLanguage.find() ? matchLanguage.group(1) : "**";
+          String language =
+              matchLanguage.find() ? "\"%s\"".formatted(matchLanguage.group(1)) : "**";
           argumentMappings.put(
               SearchTermTemplates.JSONB_PATH.placeholder, escapeTermForJsonpath(value));
           return SearchTermTemplates.JSONB_PATH.renderTemplate(

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/UniqueObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/UniqueObjectRepositoryImpl.java
@@ -1,0 +1,100 @@
+package de.digitalcollections.cudami.server.backend.impl.jdbi;
+
+import de.digitalcollections.cudami.server.backend.api.repository.UniqueObjectRepository;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifiableRepository;
+import de.digitalcollections.cudami.server.backend.impl.jdbi.identifiable.SearchTermTemplates;
+import de.digitalcollections.model.UniqueObject;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.paging.PageResponse;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.jdbi.v3.core.Jdbi;
+
+public abstract class UniqueObjectRepositoryImpl<U extends UniqueObject> extends JdbiRepositoryImpl
+    implements UniqueObjectRepository<U> {
+
+  public UniqueObjectRepositoryImpl(
+      Jdbi jdbi,
+      String tableName,
+      String tableAlias,
+      String mappingPrefix,
+      int offsetForAlternativePaging) {
+    super(jdbi, tableName, tableAlias, mappingPrefix, offsetForAlternativePaging);
+  }
+
+  @Override
+  public PageResponse find(PageRequest pageRequest) {
+    return null;
+  }
+
+  @Override
+  public U getByUuid(UUID uuid) {
+    return UniqueObjectRepository.super.getByUuid(uuid);
+  }
+
+  @Override
+  public U getByUuidAndFiltering(UUID uuid, Filtering filtering) {
+    return null;
+  }
+
+  @Override
+  protected String getWhereClause(
+      FilterCriterion<?> fc, Map<String, Object> argumentMappings, int criterionCount)
+      throws IllegalArgumentException, UnsupportedOperationException {
+    Matcher labelOrName = Pattern.compile("^(label|name)").matcher(fc.getExpression());
+    if (labelOrName.find()) {
+      if (!(fc.getValue() instanceof String)) {
+        throw new IllegalArgumentException("Value of label must be a string!");
+      }
+      String value = (String) fc.getValue();
+      switch (fc.getOperation()) {
+        case CONTAINS:
+          if (argumentMappings.containsKey(SearchTermTemplates.ARRAY_CONTAINS.placeholder)) {
+            throw new IllegalArgumentException(
+                "Filtering by label and by name are mutually exclusive!");
+          }
+          argumentMappings.put(
+              SearchTermTemplates.ARRAY_CONTAINS.placeholder,
+              IdentifiableRepository.splitToArray(value));
+          return SearchTermTemplates.ARRAY_CONTAINS.renderTemplate(
+              tableAlias, "split_" + labelOrName.group(1));
+        case EQUALS:
+          if (argumentMappings.containsKey(SearchTermTemplates.JSONB_PATH.placeholder)) {
+            throw new IllegalArgumentException(
+                "Filtering by label and by name are mutually exclusive!");
+          }
+          Matcher matchLanguage = Pattern.compile("\\.([\\w_-]+)$").matcher(fc.getExpression());
+          String language = matchLanguage.find() ? matchLanguage.group(1) : "**";
+          argumentMappings.put(
+              SearchTermTemplates.JSONB_PATH.placeholder, escapeTermForJsonpath(value));
+          return SearchTermTemplates.JSONB_PATH.renderTemplate(
+              tableAlias, labelOrName.group(1), language);
+        default:
+          throw new UnsupportedOperationException(
+              "Filtering by label only supports CONTAINS (to be preferred) or EQUALS operator!");
+      }
+    }
+
+    return super.getWhereClause(fc, argumentMappings, criterionCount);
+  }
+
+  public String[] splitToArray(LocalizedText localizedText) {
+    if (localizedText == null) {
+      return new String[0];
+    }
+    List<String> splitLabels =
+        localizedText.values().stream()
+            .map(text -> IdentifiableRepository.splitToArray(text))
+            .flatMap(Arrays::stream)
+            .collect(Collectors.toList());
+    return splitLabels.toArray(new String[splitLabels.size()]);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/semantic/SubjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/semantic/SubjectRepositoryImpl.java
@@ -164,7 +164,7 @@ public class SubjectRepositoryImpl extends UniqueObjectRepositoryImpl<Subject>
             + tableAlias
             + " left join unnest(subj.identifiers) as "
             + tableAlias
-            + "_identifier on true ";
+            + "_identifier on true";
     StringBuilder commonSqlBuilder = new StringBuilder(commonSql);
     String executedSearchTerm = addSearchTerm(pageRequest, commonSqlBuilder, argumentMappings);
     addFiltering(pageRequest, commonSqlBuilder, argumentMappings);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/TagRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/TagRepositoryImpl.java
@@ -2,7 +2,7 @@ package de.digitalcollections.cudami.server.backend.impl.jdbi.semantic;
 
 import de.digitalcollections.cudami.model.config.CudamiConfig;
 import de.digitalcollections.cudami.server.backend.api.repository.semantic.TagRepository;
-import de.digitalcollections.cudami.server.backend.impl.jdbi.JdbiRepositoryImpl;
+import de.digitalcollections.cudami.server.backend.impl.jdbi.UniqueObjectRepositoryImpl;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.semantic.Tag;
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 @Repository
-public class TagRepositoryImpl extends JdbiRepositoryImpl implements TagRepository {
+public class TagRepositoryImpl extends UniqueObjectRepositoryImpl<Tag> implements TagRepository {
 
   public static final String TABLE_NAME = "tags";
   public static final String TABLE_ALIAS = "tags";

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/TagRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/TagRepositoryImpl.java
@@ -28,9 +28,9 @@ public class TagRepositoryImpl extends UniqueObjectRepositoryImpl<Tag> implement
   public static final String MAPPING_PREFIX = "tags";
 
   public static final String SQL_INSERT_FIELDS =
-      " uuid, label, namespace, id, type, created, last_modified";
+      " uuid, label, namespace, id, type, created, last_modified, split_label";
   public static final String SQL_INSERT_VALUES =
-      " :uuid, :label::JSONB, :namespace, :id, :type, :created, :lastModified";
+      " :uuid, :label::JSONB, :namespace, :id, :type, :created, :lastModified, :split_label";
   public static final String SQL_REDUCED_FIELDS_TAGS =
       String.format(
           " %1$s.uuid as %2$s_uuid, %1$s.label as %2$s_label, %1$s.namespace as %2$s_namespace, %1$s.id as %2$s_id, %1$s.type as %2$s_type, %1$s.created as %2$s_created, %1$s.last_modified as %2$s_last_modified",
@@ -80,7 +80,13 @@ public class TagRepositoryImpl extends UniqueObjectRepositoryImpl<Tag> implement
 
     Tag result =
         dbi.withHandle(
-            h -> h.createQuery(sql).bindBean(tag).mapToBean(Tag.class).findOne().orElse(null));
+            h ->
+                h.createQuery(sql)
+                    .bindBean(tag)
+                    .bind("split_label", splitToArray(tag.getLabel()))
+                    .mapToBean(Tag.class)
+                    .findOne()
+                    .orElse(null));
     return result;
   }
 
@@ -91,11 +97,17 @@ public class TagRepositoryImpl extends UniqueObjectRepositoryImpl<Tag> implement
     final String sql =
         "UPDATE "
             + tableName
-            + " SET label=:label::JSONB, last_modified=:lastModified, namespace=:namespace, id=:id, type=:type WHERE uuid=:uuid RETURNING *";
+            + " SET label=:label::JSONB, last_modified=:lastModified, namespace=:namespace, id=:id, type=:type, split_label=:split_label WHERE uuid=:uuid RETURNING *";
 
     Tag result =
         dbi.withHandle(
-            h -> h.createQuery(sql).bindBean(tag).mapToBean(Tag.class).findOne().orElse(null));
+            h ->
+                h.createQuery(sql)
+                    .bindBean(tag)
+                    .bind("split_label", splitToArray(tag.getLabel()))
+                    .mapToBean(Tag.class)
+                    .findOne()
+                    .orElse(null));
     return result;
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V13.11.00__DML_add_split_label_to_subjects.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V13.11.00__DML_add_split_label_to_subjects.sql
@@ -1,6 +1,7 @@
 -- see V12.03.00
 
 ALTER TABLE subjects ADD COLUMN IF NOT EXISTS split_label TEXT[];
+ALTER TABLE tags ADD COLUMN IF NOT EXISTS split_label TEXT[];
 
 
 CREATE FUNCTION label_splitting (lbl jsonb) RETURNS TEXT[]
@@ -28,10 +29,12 @@ END;
 $function$;
 
 UPDATE subjects SET split_label = label_splitting("label") WHERE split_label IS NULL;
+UPDATE tags SET split_label = label_splitting("label") WHERE split_label IS NULL;
 
 DROP FUNCTION label_splitting;
 
 -- we only create indexes that are really necessary, and this one shall be neccessary
 CREATE INDEX IF NOT EXISTS idx_subjects_split_label ON subjects USING GIN (split_label);
+CREATE INDEX IF NOT EXISTS idx_tags_split_label ON tags USING GIN (split_label);
 
 ANALYZE;

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V13.11.00__DML_add_split_label_to_subjects.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V13.11.00__DML_add_split_label_to_subjects.sql
@@ -1,0 +1,37 @@
+-- see V12.03.00
+
+ALTER TABLE subjects ADD COLUMN IF NOT EXISTS split_label TEXT[];
+
+
+CREATE FUNCTION label_splitting (lbl jsonb) RETURNS TEXT[]
+IMMUTABLE
+PARALLEL SAFE
+RETURNS NULL ON NULL INPUT
+LANGUAGE plpgsql AS $function$
+DECLARE
+  lbltext TEXT;
+  split_hyphen_words TEXT[] = ARRAY[]::TEXT[];
+  hw RECORD;
+BEGIN
+  SELECT INTO lbltext string_agg(lower(value), ' ') FROM jsonb_each_text(lbl);
+
+  -- remove all special symbols and standalone hyphens
+  lbltext := regexp_replace(lbltext, '[^[:space:]\w_-]|(?<=\s)-(?=\s)', '', 'g');
+
+  -- split up words with hyphens additionally
+  FOR hw IN SELECT regexp_matches(lbltext, '(\y\w+(-\w+)+\y)', 'g') AS rmtch LOOP
+    split_hyphen_words := split_hyphen_words || regexp_split_to_array(trim(BOTH FROM hw.rmtch[1]), '-+');
+  END LOOP;
+
+  RETURN regexp_split_to_array(trim(BOTH FROM lbltext), '\s+') || split_hyphen_words;
+END;
+$function$;
+
+UPDATE subjects SET split_label = label_splitting("label") WHERE split_label IS NULL;
+
+DROP FUNCTION label_splitting;
+
+-- we only create indexes that are really necessary, and this one shall be neccessary
+CREATE INDEX IF NOT EXISTS idx_subjects_split_label ON subjects USING GIN (split_label);
+
+ANALYZE;

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImplTest.java
@@ -67,7 +67,7 @@ class IdentifiableRepositoryImplTest
 
     this.repo.save(identifiable);
 
-    Identifiable actual = this.repo.getByUuid(identifiable.getUuid());
+    Identifiable actual = (Identifiable) this.repo.getByUuid(identifiable.getUuid());
     assertThat(actual).isEqualTo(identifiable);
   }
 
@@ -137,7 +137,7 @@ class IdentifiableRepositoryImplTest
     assertThat(identifiable.getLastModified()).isNotNull();
     assertThat(identifiable.getUuid()).isNotNull();
 
-    Identifiable persisted = repo.getByUuid(identifiable.getUuid());
+    Identifiable persisted = (Identifiable) repo.getByUuid(identifiable.getUuid());
     assertThat(identifiable).isEqualToComparingFieldByField(persisted);
   }
 
@@ -171,7 +171,7 @@ class IdentifiableRepositoryImplTest
 
     // Finally, we ensure that the Identifiable, with which the update method
     // works is identical to the Identificable, which is persisted in the database
-    Identifiable persisted = repo.getByUuid(identifiable.getUuid());
+    Identifiable persisted = (Identifiable) repo.getByUuid(identifiable.getUuid());
     assertThat(identifiable).isEqualToComparingFieldByField(persisted);
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/semantic/SubjectRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/semantic/SubjectRepositoryImplTest.java
@@ -238,6 +238,31 @@ class SubjectRepositoryImplTest extends AbstractRepositoryImplTest {
     assertThat(pageResponse.getContent()).containsExactly(savedSubject);
   }
 
+  @DisplayName("can find exact by label")
+  @Test
+  void findExactByLabel() throws RepositoryException {
+    Subject savedSubject =
+        ensureSavedSubject(Locale.forLanguageTag("und-Latn"), "Karl Ranseier", null, null, "type");
+    ensureSavedSubject(Locale.forLanguageTag("und-Latn"), "Hans Dampf", null, null, "type");
+
+    PageResponse<Subject> pageResponse =
+        repo.find(
+            PageRequest.builder()
+                .pageNumber(0)
+                .pageSize(2)
+                .filtering(
+                    Filtering.builder()
+                        .add(
+                            FilterCriterion.builder()
+                                .withExpression("label.und-Latn")
+                                .isEquals("\"Karl Ranseier\"")
+                                .build())
+                        .build())
+                .build());
+
+    assertThat(pageResponse.getContent()).containsExactly(savedSubject);
+  }
+
   // ------------------------------------------------------
 
   private Subject ensureSavedSubject(

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/semantic/SubjectRepositoryImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/test/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/semantic/SubjectRepositoryImplTest.java
@@ -213,6 +213,31 @@ class SubjectRepositoryImplTest extends AbstractRepositoryImplTest {
     assertThat(foundSubject).isEqualTo(savedSubject);
   }
 
+  @DisplayName("can find 'like' by label")
+  @Test
+  void findByLabel() throws RepositoryException {
+    Subject savedSubject =
+        ensureSavedSubject(Locale.forLanguageTag("und-Latn"), "Testsubject1", null, null, "type");
+    ensureSavedSubject(Locale.GERMAN, "Testsubject2", null, null, "type");
+
+    PageResponse<Subject> pageResponse =
+        repo.find(
+            PageRequest.builder()
+                .pageNumber(0)
+                .pageSize(2)
+                .filtering(
+                    Filtering.builder()
+                        .add(
+                            FilterCriterion.builder()
+                                .withExpression("label.und-Latn")
+                                .contains("Testsubject1")
+                                .build())
+                        .build())
+                .build());
+
+    assertThat(pageResponse.getContent()).containsExactly(savedSubject);
+  }
+
   // ------------------------------------------------------
 
   private Subject ensureSavedSubject(
@@ -224,9 +249,12 @@ class SubjectRepositoryImplTest extends AbstractRepositoryImplTest {
                 labelLocale != null && labelText != null
                     ? new LocalizedText(labelLocale, labelText)
                     : null)
-            .identifier(Identifier.builder().namespace(namespace).id(id).build())
             .type(type)
             .build();
+
+    if ((namespace != null) && (id != null)) {
+      subject.setIdentifiers(Set.of(Identifier.builder().namespace(namespace).id(id).build()));
+    }
 
     repo.save(subject);
     return subject;

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/UniqueObjectService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/UniqueObjectService.java
@@ -1,0 +1,10 @@
+package de.digitalcollections.cudami.server.business.api.service;
+
+import de.digitalcollections.model.UniqueObject;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.paging.PageResponse;
+
+public interface UniqueObjectService<U extends UniqueObject> {
+
+  PageResponse<U> find(PageRequest pageRequest);
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/IdentifiableService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/IdentifiableService.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.server.business.api.service.identifiable;
 
+import de.digitalcollections.cudami.server.business.api.service.UniqueObjectService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ConflictException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
@@ -14,7 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
-public interface IdentifiableService<I extends Identifiable> {
+public interface IdentifiableService<I extends Identifiable> extends UniqueObjectService<I> {
 
   default void addRelatedEntity(I identifiable, Entity entity) {
     if (identifiable == null || entity == null) {
@@ -75,8 +76,6 @@ public interface IdentifiableService<I extends Identifiable> {
   }
 
   boolean delete(List<UUID> uuids) throws ConflictException, ServiceException;
-
-  PageResponse<I> find(PageRequest pageRequest);
 
   List<I> find(String searchTerm, int maxResults);
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/semantic/SubjectService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/identifiable/entity/semantic/SubjectService.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.server.business.api.service.identifiable.entity.semantic;
 
+import de.digitalcollections.cudami.server.business.api.service.UniqueObjectService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -7,7 +8,7 @@ import de.digitalcollections.model.semantic.Subject;
 import java.util.List;
 import java.util.UUID;
 
-public interface SubjectService {
+public interface SubjectService extends UniqueObjectService<Subject> {
 
   long count();
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/semantic/TagService.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/api/service/semantic/TagService.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.cudami.server.business.api.service.semantic;
 
+import de.digitalcollections.cudami.server.business.api.service.UniqueObjectService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -7,7 +8,7 @@ import de.digitalcollections.model.semantic.Tag;
 import java.util.List;
 import java.util.UUID;
 
-public interface TagService {
+public interface TagService extends UniqueObjectService<Tag> {
 
   long count();
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/UniqueObjectServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/UniqueObjectServiceImpl.java
@@ -1,0 +1,134 @@
+package de.digitalcollections.cudami.server.business.impl.service;
+
+import de.digitalcollections.cudami.server.backend.api.repository.UniqueObjectRepository;
+import de.digitalcollections.cudami.server.backend.api.repository.identifiable.IdentifiableRepository;
+import de.digitalcollections.cudami.server.business.api.service.UniqueObjectService;
+import de.digitalcollections.model.UniqueObject;
+import de.digitalcollections.model.identifiable.entity.NamedEntity;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.FilterOperation;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.paging.PageResponse;
+import de.digitalcollections.model.list.sorting.Direction;
+import de.digitalcollections.model.list.sorting.Order;
+import de.digitalcollections.model.list.sorting.Sorting;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class UniqueObjectServiceImpl<U extends UniqueObject, R extends UniqueObjectRepository<U>>
+    implements UniqueObjectService<U> {
+
+  protected R repository;
+
+  protected UniqueObjectServiceImpl(R repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Special logic to filter by label, optionally paying attention to the language. The passed
+   * {@code PageResponse} could be modified.
+   *
+   * @param pageResponse the response from the repo, must always contain the request too (if
+   *     everything goes right)
+   */
+  protected void filterBySplitField(
+      PageResponse<U> pageResponse,
+      FilterCriterion<String> filter,
+      Function<U, Optional<LocalizedText>> retrieveField) {
+    if (!pageResponse.hasContent()) {
+      return;
+    }
+    // we must differentiate several cases
+    if (filter.getOperation() == FilterOperation.EQUALS) {
+      // everything has been done by repo already
+      return;
+    }
+
+    // for CONTAINS the language, if any, has not been taken into account yet
+    Matcher matchLanguage = Pattern.compile("\\.([\\w_-]+)$").matcher(filter.getExpression());
+    if (matchLanguage.find()) {
+      // there is a language...
+      Locale language = Locale.forLanguageTag(matchLanguage.group(1));
+      List<String> searchTerms =
+          Arrays.asList(IdentifiableRepository.splitToArray((String) filter.getValue()));
+      List<U> filteredContent =
+          pageResponse.getContent().parallelStream()
+              .filter(
+                  identifiable -> {
+                    String text =
+                        retrieveField.apply(identifiable).orElse(new LocalizedText()).get(language);
+                    if (text == null) {
+                      return false;
+                    }
+                    List<String> splitText =
+                        Arrays.asList(IdentifiableRepository.splitToArray(text));
+                    return splitText.containsAll(searchTerms);
+                  })
+              .collect(Collectors.toList());
+      // fix total elements count roughly
+      pageResponse.setTotalElements(
+          pageResponse.getTotalElements()
+              - (pageResponse.getContent().size() - filteredContent.size()));
+      pageResponse.setContent(filteredContent);
+    }
+  }
+
+  @Override
+  public PageResponse<U> find(PageRequest pageRequest) {
+    setDefaultSorting(pageRequest);
+    // filter by label or name (NamedEntity) is quite special due to optimization
+    FilterCriterion<String> labelFilter = null;
+    FilterCriterion<String> nameFilter = null;
+    if (pageRequest.hasFiltering()) {
+      labelFilter =
+          pageRequest.getFiltering().getFilterCriteria().stream()
+              .filter(fc -> fc.getExpression().startsWith("label"))
+              .findAny()
+              .orElse(null);
+      nameFilter =
+          pageRequest.getFiltering().getFilterCriteria().stream()
+              .filter(fc -> fc.getExpression().startsWith("name"))
+              .findAny()
+              .orElse(null);
+    }
+    PageResponse<U> response = repository.find(pageRequest);
+    if (labelFilter == null && nameFilter == null) {
+      // nothing special here, go on
+      return response;
+    }
+    // filter by label or name specials go here, it is an either-or though
+    if (labelFilter != null) {
+      filterBySplitField(response, labelFilter, extractLabelFunction());
+    } else {
+      filterBySplitField(
+          response,
+          nameFilter,
+          i ->
+              i instanceof NamedEntity
+                  ? Optional.ofNullable(((NamedEntity) i).getName())
+                  : Optional.empty());
+    }
+    // TODO: what happens if all entries have been removed by the filter?
+    return response;
+  }
+
+  protected void setDefaultSorting(PageRequest pageRequest) {
+    // business logic: default sorting if no other sorting given: lastModified descending, uuid
+    // ascending
+    if (!pageRequest.hasSorting()) {
+      Sorting sorting = new Sorting(new Order(Direction.DESC, "lastModified"), new Order("uuid"));
+      pageRequest.setSorting(sorting);
+    }
+  }
+
+  protected Function<U, Optional<LocalizedText>> extractLabelFunction() {
+    return null;
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/UniqueObjectServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/UniqueObjectServiceImpl.java
@@ -22,7 +22,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-public class UniqueObjectServiceImpl<U extends UniqueObject, R extends UniqueObjectRepository<U>>
+public abstract class UniqueObjectServiceImpl<
+        U extends UniqueObject, R extends UniqueObjectRepository<U>>
     implements UniqueObjectService<U> {
 
   protected R repository;
@@ -61,9 +62,9 @@ public class UniqueObjectServiceImpl<U extends UniqueObject, R extends UniqueObj
       List<U> filteredContent =
           pageResponse.getContent().parallelStream()
               .filter(
-                  identifiable -> {
+                  uniqueObject -> {
                     String text =
-                        retrieveField.apply(identifiable).orElse(new LocalizedText()).get(language);
+                        retrieveField.apply(uniqueObject).orElse(new LocalizedText()).get(language);
                     if (text == null) {
                       return false;
                     }
@@ -110,10 +111,7 @@ public class UniqueObjectServiceImpl<U extends UniqueObject, R extends UniqueObj
       filterBySplitField(
           response,
           nameFilter,
-          i ->
-              i instanceof NamedEntity
-                  ? Optional.ofNullable(((NamedEntity) i).getName())
-                  : Optional.empty());
+          i -> i instanceof NamedEntity ne ? Optional.ofNullable(ne.getName()) : Optional.empty());
     }
     // TODO: what happens if all entries have been removed by the filter?
     return response;
@@ -128,7 +126,5 @@ public class UniqueObjectServiceImpl<U extends UniqueObject, R extends UniqueObj
     }
   }
 
-  protected Function<U, Optional<LocalizedText>> extractLabelFunction() {
-    return null;
-  }
+  protected abstract Function<U, Optional<LocalizedText>> extractLabelFunction();
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -9,30 +9,22 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Valid
 import de.digitalcollections.cudami.server.business.api.service.identifiable.IdentifiableService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.IdentifierService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
+import de.digitalcollections.cudami.server.business.impl.service.UniqueObjectServiceImpl;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.Identifier;
 import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
 import de.digitalcollections.model.identifiable.alias.UrlAlias;
 import de.digitalcollections.model.identifiable.entity.Entity;
-import de.digitalcollections.model.identifiable.entity.NamedEntity;
 import de.digitalcollections.model.identifiable.resource.FileResource;
-import de.digitalcollections.model.list.filtering.FilterCriterion;
-import de.digitalcollections.model.list.filtering.FilterOperation;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
-import de.digitalcollections.model.list.sorting.Direction;
-import de.digitalcollections.model.list.sorting.Order;
-import de.digitalcollections.model.list.sorting.Sorting;
 import de.digitalcollections.model.text.LocalizedText;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,23 +34,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service("identifiableService")
 @Transactional(rollbackFor = {Exception.class})
-public class IdentifiableServiceImpl<I extends Identifiable> implements IdentifiableService<I> {
+public class IdentifiableServiceImpl<I extends Identifiable, R extends IdentifiableRepository<I>>
+    extends UniqueObjectServiceImpl<I, R> implements IdentifiableService<I> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IdentifiableServiceImpl.class);
 
   private CudamiConfig cudamiConfig;
   protected IdentifierService identifierService;
   private LocaleService localeService;
-  protected IdentifiableRepository<I> repository;
+
   private UrlAliasService urlAliasService;
 
   public IdentifiableServiceImpl(
-      @Qualifier("identifiableRepositoryImpl") IdentifiableRepository<I> repository,
+      @Qualifier("identifiableRepositoryImpl") R repository,
       IdentifierService identifierService,
       UrlAliasService urlAliasService,
       LocaleService localeService,
       CudamiConfig cudamiConfig) {
-    this.repository = repository;
+    super(repository);
     this.identifierService = identifierService;
     this.urlAliasService = urlAliasService;
     this.localeService = localeService;
@@ -104,94 +97,6 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
     }
     identifierService.delete(identifiable.getIdentifiers());
     return true;
-  }
-
-  /**
-   * Special logic to filter by label, optionally paying attention to the language. The passed
-   * {@code PageResponse} could be modified.
-   *
-   * @param pageResponse the response from the repo, must always contain the request too (if
-   *     everything goes right)
-   */
-  protected void filterBySplitField(
-      PageResponse<I> pageResponse,
-      FilterCriterion<String> filter,
-      Function<I, Optional<LocalizedText>> retrieveField) {
-    if (!pageResponse.hasContent()) {
-      return;
-    }
-    // we must differentiate several cases
-    if (filter.getOperation() == FilterOperation.EQUALS) {
-      // everything has been done by repo already
-      return;
-    }
-
-    // for CONTAINS the language, if any, has not been taken into account yet
-    Matcher matchLanguage = Pattern.compile("\\.([\\w_-]+)$").matcher(filter.getExpression());
-    if (matchLanguage.find()) {
-      // there is a language...
-      Locale language = Locale.forLanguageTag(matchLanguage.group(1));
-      List<String> searchTerms =
-          Arrays.asList(IdentifiableRepository.splitToArray((String) filter.getValue()));
-      List<I> filteredContent =
-          pageResponse.getContent().parallelStream()
-              .filter(
-                  identifiable -> {
-                    String text =
-                        retrieveField.apply(identifiable).orElse(new LocalizedText()).get(language);
-                    if (text == null) {
-                      return false;
-                    }
-                    List<String> splitText =
-                        Arrays.asList(IdentifiableRepository.splitToArray(text));
-                    return splitText.containsAll(searchTerms);
-                  })
-              .collect(Collectors.toList());
-      // fix total elements count roughly
-      pageResponse.setTotalElements(
-          pageResponse.getTotalElements()
-              - (pageResponse.getContent().size() - filteredContent.size()));
-      pageResponse.setContent(filteredContent);
-    }
-  }
-
-  @Override
-  public PageResponse<I> find(PageRequest pageRequest) {
-    setDefaultSorting(pageRequest);
-    // filter by label or name (NamedEntity) is quite special due to optimization
-    FilterCriterion<String> labelFilter = null;
-    FilterCriterion<String> nameFilter = null;
-    if (pageRequest.hasFiltering()) {
-      labelFilter =
-          pageRequest.getFiltering().getFilterCriteria().stream()
-              .filter(fc -> fc.getExpression().startsWith("label"))
-              .findAny()
-              .orElse(null);
-      nameFilter =
-          pageRequest.getFiltering().getFilterCriteria().stream()
-              .filter(fc -> fc.getExpression().startsWith("name"))
-              .findAny()
-              .orElse(null);
-    }
-    PageResponse<I> response = repository.find(pageRequest);
-    if (labelFilter == null && nameFilter == null) {
-      // nothing special here, go on
-      return response;
-    }
-    // filter by label or name specials go here, it is an either-or though
-    if (labelFilter != null) {
-      filterBySplitField(response, labelFilter, i -> Optional.ofNullable(i.getLabel()));
-    } else {
-      filterBySplitField(
-          response,
-          nameFilter,
-          i ->
-              i instanceof NamedEntity
-                  ? Optional.ofNullable(((NamedEntity) i).getName())
-                  : Optional.empty());
-    }
-    // TODO: what happens if all entries have been removed by the filter?
-    return response;
   }
 
   @Override
@@ -332,15 +237,6 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
     }
   }
 
-  protected void setDefaultSorting(PageRequest pageRequest) {
-    // business logic: default sorting if no other sorting given: lastModified descending, uuid
-    // ascending
-    if (!pageRequest.hasSorting()) {
-      Sorting sorting = new Sorting(new Order(Direction.DESC, "lastModified"), new Order("uuid"));
-      pageRequest.setSorting(sorting);
-    }
-  }
-
   @Override
   public List<Entity> setRelatedEntities(UUID identifiableUuid, List<Entity> entities) {
     return repository.setRelatedEntities(identifiableUuid, entities);
@@ -447,5 +343,10 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
     } catch (ServiceException e) {
       throw new ValidationException("Cannot validate: " + e, e);
     }
+  }
+
+  @Override
+  protected Function<I, Optional<LocalizedText>> extractLabelFunction() {
+    return i -> Optional.ofNullable(i.getLabel());
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/IdentifiableServiceImpl.java
@@ -116,7 +116,7 @@ public class IdentifiableServiceImpl<I extends Identifiable> implements Identifi
   protected void filterBySplitField(
       PageResponse<I> pageResponse,
       FilterCriterion<String> filter,
-      Function<Identifiable, Optional<LocalizedText>> retrieveField) {
+      Function<I, Optional<LocalizedText>> retrieveField) {
     if (!pageResponse.hasContent()) {
       return;
     }

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/FamilyNameServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/FamilyNameServiceImpl.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-public class FamilyNameServiceImpl extends IdentifiableServiceImpl<FamilyName>
+public class FamilyNameServiceImpl extends IdentifiableServiceImpl<FamilyName, FamilyNameRepository>
     implements FamilyNameService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FamilyNameServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/GivenNameServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/agent/GivenNameServiceImpl.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-public class GivenNameServiceImpl extends IdentifiableServiceImpl<GivenName>
+public class GivenNameServiceImpl extends IdentifiableServiceImpl<GivenName, GivenNameRepository>
     implements GivenNameService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GivenNameServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImpl.java
@@ -219,15 +219,6 @@ public class CollectionServiceImpl extends EntityServiceImpl<Collection>
     return ((CollectionRepository) repository).setDigitalObjects(collectionUuid, digitalObjects);
   }
 
-  /**
-   * Only for testing purposes
-   *
-   * @param nodeRepository The NodeRepository
-   */
-  protected void setNodeRepository(NodeRepository<Collection> nodeRepository) {
-    repository = nodeRepository;
-  }
-
   @Override
   public boolean updateChildrenOrder(UUID parentUuid, List<Collection> children) {
     return ((NodeRepository<Collection>) repository).updateChildrenOrder(parentUuid, children);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/EntityServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/EntityServiceImpl.java
@@ -34,8 +34,8 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service("entityService")
-public class EntityServiceImpl<E extends Entity> extends IdentifiableServiceImpl<E>
-    implements EntityService<E> {
+public class EntityServiceImpl<E extends Entity>
+    extends IdentifiableServiceImpl<E, EntityRepository<E>> implements EntityService<E> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EntityServiceImpl.class);
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/semantic/SubjectServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/semantic/SubjectServiceImpl.java
@@ -4,22 +4,25 @@ import de.digitalcollections.cudami.server.backend.api.repository.exceptions.Rep
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.semantic.SubjectRepository;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.semantic.SubjectService;
+import de.digitalcollections.cudami.server.business.impl.service.UniqueObjectServiceImpl;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.semantic.Subject;
+import de.digitalcollections.model.text.LocalizedText;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(rollbackFor = Exception.class)
-public class SubjectServiceImpl implements SubjectService {
-
-  private final SubjectRepository repository;
+public class SubjectServiceImpl extends UniqueObjectServiceImpl<Subject, SubjectRepository>
+    implements SubjectService {
 
   public SubjectServiceImpl(SubjectRepository repository) {
-    this.repository = repository;
+    super(repository);
   }
 
   @Override
@@ -56,8 +59,13 @@ public class SubjectServiceImpl implements SubjectService {
   }
 
   @Override
+  protected Function<Subject, Optional<LocalizedText>> extractLabelFunction() {
+    return s -> Optional.ofNullable(s.getLabel());
+  }
+
+  @Override
   public PageResponse<Subject> find(PageRequest pageRequest) {
-    return repository.find(pageRequest);
+    return super.find(pageRequest);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ApplicationFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ApplicationFileResourceServiceImpl.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
 public class ApplicationFileResourceServiceImpl
-    extends IdentifiableServiceImpl<ApplicationFileResource>
+    extends IdentifiableServiceImpl<ApplicationFileResource, ApplicationFileResourceRepository>
     implements ApplicationFileResourceService {
 
   private static final Logger LOGGER =

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/AudioFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/AudioFileResourceServiceImpl.java
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-public class AudioFileResourceServiceImpl extends IdentifiableServiceImpl<AudioFileResource>
+public class AudioFileResourceServiceImpl
+    extends IdentifiableServiceImpl<AudioFileResource, AudioFileResourceRepository>
     implements AudioFileResourceService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AudioFileResourceServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/FileResourceMetadataServiceImpl.java
@@ -32,7 +32,8 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service("fileResourceMetadataService")
-public class FileResourceMetadataServiceImpl extends IdentifiableServiceImpl<FileResource>
+public class FileResourceMetadataServiceImpl
+    extends IdentifiableServiceImpl<FileResource, FileResourceMetadataRepository<FileResource>>
     implements FileResourceMetadataService<FileResource> {
 
   private static final Logger LOGGER =

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ImageFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/ImageFileResourceServiceImpl.java
@@ -17,7 +17,8 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-public class ImageFileResourceServiceImpl extends IdentifiableServiceImpl<ImageFileResource>
+public class ImageFileResourceServiceImpl
+    extends IdentifiableServiceImpl<ImageFileResource, ImageFileResourceRepository>
     implements ImageFileResourceService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ImageFileResourceServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/LinkedDataFileResourceServiceImpl.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
 public class LinkedDataFileResourceServiceImpl
-    extends IdentifiableServiceImpl<LinkedDataFileResource>
+    extends IdentifiableServiceImpl<LinkedDataFileResource, LinkedDataFileResourceRepository>
     implements LinkedDataFileResourceService {
 
   private static final Logger LOGGER =

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/TextFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/TextFileResourceServiceImpl.java
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-public class TextFileResourceServiceImpl extends IdentifiableServiceImpl<TextFileResource>
+public class TextFileResourceServiceImpl
+    extends IdentifiableServiceImpl<TextFileResource, TextFileResourceRepository>
     implements TextFileResourceService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TextFileResourceServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/VideoFileResourceServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/resource/VideoFileResourceServiceImpl.java
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Service;
 
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-public class VideoFileResourceServiceImpl extends IdentifiableServiceImpl<VideoFileResource>
+public class VideoFileResourceServiceImpl
+    extends IdentifiableServiceImpl<VideoFileResource, VideoFileResourceRepository>
     implements VideoFileResourceService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VideoFileResourceServiceImpl.class);

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/web/WebpageServiceImpl.java
@@ -30,7 +30,8 @@ import org.springframework.stereotype.Service;
 /** Service for Webpage handling. */
 // @Transactional should not be set in derived class to prevent overriding, check base class instead
 @Service
-public class WebpageServiceImpl extends IdentifiableServiceImpl<Webpage> implements WebpageService {
+public class WebpageServiceImpl extends IdentifiableServiceImpl<Webpage, WebpageRepository>
+    implements WebpageService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebpageServiceImpl.class);
 

--- a/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/semantic/TagServiceImpl.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/main/java/de/digitalcollections/cudami/server/business/impl/service/semantic/TagServiceImpl.java
@@ -3,22 +3,25 @@ package de.digitalcollections.cudami.server.business.impl.service.semantic;
 import de.digitalcollections.cudami.server.backend.api.repository.semantic.TagRepository;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.semantic.TagService;
+import de.digitalcollections.cudami.server.business.impl.service.UniqueObjectServiceImpl;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.semantic.Tag;
+import de.digitalcollections.model.text.LocalizedText;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(rollbackFor = Exception.class)
-public class TagServiceImpl implements TagService {
-
-  private final TagRepository repository;
+public class TagServiceImpl extends UniqueObjectServiceImpl<Tag, TagRepository>
+    implements TagService {
 
   public TagServiceImpl(TagRepository repository) {
-    this.repository = repository;
+    super(repository);
   }
 
   @Override
@@ -47,8 +50,13 @@ public class TagServiceImpl implements TagService {
   }
 
   @Override
+  protected Function<Tag, Optional<LocalizedText>> extractLabelFunction() {
+    return t -> Optional.ofNullable(t.getLabel());
+  }
+
+  @Override
   public PageResponse<Tag> find(PageRequest pageRequest) {
-    return repository.find(pageRequest);
+    return super.find(pageRequest);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/CollectionServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.digitalcollections.cudami.server.backend.api.repository.identifiable.NodeRepository;
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.CollectionRepository;
 import de.digitalcollections.cudami.server.business.api.service.LocaleService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ConflictException;
@@ -55,11 +54,8 @@ class CollectionServiceImplTest extends AbstractServiceImplTest {
   public void execeptionOnDeletionOfCollectionWithChildren() {
     PageResponse<Collection> pageResponse = mock(PageResponse.class);
     when(pageResponse.getTotalElements()).thenReturn(1l);
-    NodeRepository<Collection> nodeRepository = mock(NodeRepository.class);
-    when(nodeRepository.findChildren(any(UUID.class), any(PageRequest.class)))
+    when(collectionRepository.findChildren(any(UUID.class), any(PageRequest.class)))
         .thenReturn(pageResponse);
-    collectionService.setNodeRepository(nodeRepository);
-
     assertThrows(ConflictException.class, () -> collectionService.delete(UUID.randomUUID()));
   }
 

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/semantic/SubjectServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/semantic/SubjectServiceImplTest.java
@@ -94,7 +94,7 @@ class SubjectServiceImplTest {
                             .build())
                     .build())
             .build();
-    PageResponse<Subject> expectedPageResponse =
+    PageResponse<Subject> pageResponse =
         PageResponse.builder()
             .withContent(
                 List.of(
@@ -107,9 +107,67 @@ class SubjectServiceImplTest {
                         .label(new LocalizedText(Locale.forLanguageTag("de"), "Altertum"))
                         .build()))
             .build();
-    when(subjectRepository.find(eq(expectedPageRequest))).thenReturn(expectedPageResponse);
+    when(subjectRepository.find(eq(expectedPageRequest))).thenReturn(pageResponse);
 
     PageResponse<Subject> actual = subjectService.find(expectedPageRequest);
+
+    PageResponse<Subject> expectedPageResponse =
+        PageResponse.builder()
+            .withContent(
+                List.of(
+                    Subject.builder()
+                        .label(
+                            new LocalizedText(
+                                Locale.forLanguageTag("und-Latn"), "Antike und Altertum"))
+                        .build()))
+            .build();
+
+    assertThat(actual).isEqualTo(expectedPageResponse);
+  }
+
+  @DisplayName("can find 'like' subjects with partially matching contents")
+  @Test
+  public void findLikeWithPartiallyMatchingContents() {
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .contains("Altertum")
+                            .build())
+                    .build())
+            .build();
+    PageResponse<Subject> pageResponse =
+        PageResponse.builder()
+            .withContent(
+                List.of(
+                    Subject.builder()
+                        .label(
+                            new LocalizedText(
+                                Locale.forLanguageTag("und-Latn"), "Antike und Altertum"))
+                        .build(),
+                    Subject.builder()
+                        .label(new LocalizedText(Locale.forLanguageTag("de"), "Altertum"))
+                        .build()))
+            .build();
+    when(subjectRepository.find(eq(expectedPageRequest))).thenReturn(pageResponse);
+
+    PageResponse<Subject> actual = subjectService.find(expectedPageRequest);
+
+    PageResponse<Subject> expectedPageResponse =
+        PageResponse.builder()
+            .withContent(
+                List.of(
+                    Subject.builder()
+                        .label(
+                            new LocalizedText(
+                                Locale.forLanguageTag("und-Latn"), "Antike und Altertum"))
+                        .build()))
+            .build();
 
     assertThat(actual).isEqualTo(expectedPageResponse);
   }

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/semantic/SubjectServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/identifiable/entity/semantic/SubjectServiceImplTest.java
@@ -1,12 +1,22 @@
 package de.digitalcollections.cudami.server.business.impl.service.identifiable.entity.semantic;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import de.digitalcollections.cudami.server.backend.api.repository.identifiable.entity.semantic.SubjectRepository;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.paging.PageResponse;
+import de.digitalcollections.model.semantic.Subject;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,5 +43,74 @@ class SubjectServiceImplTest {
     assertThrows(
         ServiceException.class,
         () -> subjectService.getByTypeAndIdentifier("type", "namespace", "id"));
+  }
+
+  @DisplayName("can find exact subjects")
+  @Test
+  public void findExact() {
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .isEquals("\"Antike und Altertum\"")
+                            .build())
+                    .build())
+            .build();
+    PageResponse<Subject> expectedPageResponse =
+        PageResponse.builder()
+            .withContent(
+                List.of(
+                    Subject.builder()
+                        .label(
+                            new LocalizedText(
+                                Locale.forLanguageTag("und-Latn"), "Antike und Altertum"))
+                        .build()))
+            .build();
+    when(subjectRepository.find(eq(expectedPageRequest))).thenReturn(expectedPageResponse);
+
+    PageResponse<Subject> actual = subjectService.find(expectedPageRequest);
+
+    assertThat(actual).isEqualTo(expectedPageResponse);
+  }
+
+  @DisplayName("can find 'like' subjects")
+  @Test
+  public void findLike() {
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .contains("Antike und Altertum")
+                            .build())
+                    .build())
+            .build();
+    PageResponse<Subject> expectedPageResponse =
+        PageResponse.builder()
+            .withContent(
+                List.of(
+                    Subject.builder()
+                        .label(
+                            new LocalizedText(
+                                Locale.forLanguageTag("und-Latn"), "Antike und Altertum"))
+                        .build(),
+                    Subject.builder()
+                        .label(new LocalizedText(Locale.forLanguageTag("de"), "Altertum"))
+                        .build()))
+            .build();
+    when(subjectRepository.find(eq(expectedPageRequest))).thenReturn(expectedPageResponse);
+
+    PageResponse<Subject> actual = subjectService.find(expectedPageRequest);
+
+    assertThat(actual).isEqualTo(expectedPageResponse);
   }
 }

--- a/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/semantic/TagServiceImplTest.java
+++ b/dc-cudami-server/dc-cudami-server-business/src/test/java/de/digitalcollections/cudami/server/business/impl/service/semantic/TagServiceImplTest.java
@@ -1,0 +1,66 @@
+package de.digitalcollections.cudami.server.business.impl.service.semantic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.digitalcollections.cudami.server.backend.api.repository.semantic.TagRepository;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.paging.PageResponse;
+import de.digitalcollections.model.semantic.Subject;
+import de.digitalcollections.model.semantic.Tag;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The TagService")
+class TagServiceImplTest {
+
+  private TagServiceImpl tagService;
+  private TagRepository tagRepository;
+
+  @BeforeEach
+  public void beforeEach() {
+    tagRepository = mock(TagRepository.class);
+    tagService = new TagServiceImpl(tagRepository);
+  }
+
+  @DisplayName("can find tags")
+  @Test
+  public void find() {
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .isEquals("\"Antike und Altertum\"")
+                            .build())
+                    .build())
+            .build();
+    PageResponse<Tag> expectedPageResponse =
+        PageResponse.builder()
+            .withContent(
+                List.of(
+                    Subject.builder()
+                        .label(
+                            new LocalizedText(
+                                Locale.forLanguageTag("und-Latn"), "Antike und Altertum"))
+                        .build()))
+            .build();
+    when(tagRepository.find(eq(expectedPageRequest))).thenReturn(expectedPageResponse);
+
+    PageResponse<Tag> actual = tagService.find(expectedPageRequest);
+
+    assertThat(actual).isEqualTo(expectedPageResponse);
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/AbstractUniqueObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/AbstractUniqueObjectController.java
@@ -1,0 +1,138 @@
+package de.digitalcollections.cudami.server.controller;
+
+import de.digitalcollections.cudami.server.business.api.service.UniqueObjectService;
+import de.digitalcollections.model.UniqueObject;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.FilterOperation;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.paging.PageResponse;
+import de.digitalcollections.model.list.sorting.Order;
+import de.digitalcollections.model.list.sorting.Sorting;
+import java.util.List;
+import java.util.Locale;
+import org.apache.commons.lang3.tuple.Pair;
+
+public abstract class AbstractUniqueObjectController<U extends UniqueObject> {
+
+  protected abstract UniqueObjectService<U> getService();
+
+  /**
+   * The usual find implementation
+   *
+   * <p>For {@code filterCriteria} we use a varargs parameter instead of a {@code Map<String,
+   * FilterCriterion<?>>}, because the beautiful shorthand {@code Map.of} does not support null
+   * values and so it would make things unnecessary difficult inside the extending class.
+   *
+   * <p>Do not mess things up by passing {@code null} for {@code filterCriteria} if there are not
+   * any. Since it is varargs you can just omit this parameter.
+   *
+   * @param pageNumber
+   * @param pageSize
+   * @param sortBy
+   * @param searchTerm
+   * @param labelTerm
+   * @param labelLanguage
+   * @param filterCriteria must be {@code Pair}s of a {@code String}, the expression, and the
+   *     corresponding {@code FilterCriterion}
+   * @return
+   */
+  public PageResponse<U> find(
+      int pageNumber,
+      int pageSize,
+      List<Order> sortBy,
+      String searchTerm,
+      String labelTerm,
+      Locale labelLanguage,
+      Pair<String, FilterCriterion<?>>... filterCriteria) {
+    return find(
+        pageNumber,
+        pageSize,
+        sortBy,
+        searchTerm,
+        labelTerm,
+        labelLanguage,
+        null,
+        null,
+        filterCriteria);
+  }
+
+  /**
+   * The usual find implementation
+   *
+   * <p>For {@code filterCriteria} we use a varargs parameter instead of a {@code Map<String,
+   * FilterCriterion<?>>}, because the beautiful shorthand {@code Map.of} does not support null
+   * values and so it would make things unnecessary difficult inside the extending class.
+   *
+   * <p>Do not mess things up by passing {@code null} for {@code filterCriteria} if there are not
+   * any. Since it is varargs you can just omit this parameter.
+   *
+   * @param pageNumber
+   * @param pageSize
+   * @param sortBy
+   * @param searchTerm
+   * @param labelTerm
+   * @param labelLanguage
+   * @param nameTerm
+   * @param nameLanguage
+   * @param filterCriteria must be {@code Pair}s of a {@code String}, the expression, and the
+   *     corresponding {@code FilterCriterion}
+   * @return
+   */
+  public PageResponse<U> find(
+      int pageNumber,
+      int pageSize,
+      List<Order> sortBy,
+      String searchTerm,
+      String labelTerm,
+      Locale labelLanguage,
+      String nameTerm,
+      Locale nameLanguage,
+      Pair<String, FilterCriterion<?>>... filterCriteria) {
+    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    if (sortBy != null) {
+      Sorting sorting = new Sorting(sortBy);
+      pageRequest.setSorting(sorting);
+    }
+
+    // Since Map.of doesn't support null values we try it this varargs-way.
+    for (Pair<String, FilterCriterion<?>> criterionPair : filterCriteria) {
+      if (criterionPair.getRight() == null) {
+        continue;
+      }
+      String expression = criterionPair.getLeft();
+      FilterCriterion<?> criterion = criterionPair.getRight();
+      criterion.setExpression(expression);
+      pageRequest.add(new Filtering(List.of(criterion)));
+    }
+
+    addLabelFilter(pageRequest, labelTerm, labelLanguage);
+    addNameFilter(pageRequest, nameTerm, nameLanguage);
+    return getService().find(pageRequest);
+  }
+
+  protected void addLabelFilter(PageRequest pageRequest, String labelTerm, Locale labelLanguage) {
+    addFilterForSplitField("label", pageRequest, labelTerm, labelLanguage);
+  }
+
+  protected void addNameFilter(PageRequest pageRequest, String nameTerm, Locale nameLanguage) {
+    addFilterForSplitField("name", pageRequest, nameTerm, nameLanguage);
+  }
+
+  private void addFilterForSplitField(
+      String expression, PageRequest pageRequest, String term, Locale language) {
+    if (expression == null || pageRequest == null || term == null) {
+      return;
+    }
+    term = term.trim();
+    if (language != null) {
+      expression += "." + language.getLanguage();
+    }
+    FilterOperation operation = FilterOperation.CONTAINS;
+    if (term.matches("\".+\"")) {
+      operation = FilterOperation.EQUALS;
+    }
+    pageRequest.add(
+        Filtering.builder().add(new FilterCriterion<>(expression, operation, term)).build());
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/AbstractIdentifiableController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/AbstractIdentifiableController.java
@@ -3,23 +3,16 @@ package de.digitalcollections.cudami.server.controller.identifiable;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.IdentifiableService;
+import de.digitalcollections.cudami.server.controller.AbstractUniqueObjectController;
 import de.digitalcollections.cudami.server.controller.ParameterHelper;
 import de.digitalcollections.model.identifiable.Identifiable;
-import de.digitalcollections.model.list.filtering.FilterCriterion;
-import de.digitalcollections.model.list.filtering.FilterOperation;
-import de.digitalcollections.model.list.filtering.Filtering;
-import de.digitalcollections.model.list.paging.PageRequest;
-import de.digitalcollections.model.list.paging.PageResponse;
-import de.digitalcollections.model.list.sorting.Order;
-import de.digitalcollections.model.list.sorting.Sorting;
-import java.util.List;
-import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-public abstract class AbstractIdentifiableController<T extends Identifiable> {
+public abstract class AbstractIdentifiableController<T extends Identifiable>
+    extends AbstractUniqueObjectController<T> {
 
   public ResponseEntity<T> getByIdentifier(HttpServletRequest request)
       throws ServiceException, ValidationException {
@@ -50,124 +43,6 @@ public abstract class AbstractIdentifiableController<T extends Identifiable> {
     return namespaceAndId;
   }
 
-  /**
-   * The usual find implementation
-   *
-   * <p>For {@code filterCriteria} we use a varargs parameter instead of a {@code Map<String,
-   * FilterCriterion<?>>}, because the beautiful shorthand {@code Map.of} does not support null
-   * values and so it would make things unnecessary difficult inside the extending class.
-   *
-   * <p>Do not mess things up by passing {@code null} for {@code filterCriteria} if there are not
-   * any. Since it is varargs you can just omit this parameter.
-   *
-   * @param pageNumber
-   * @param pageSize
-   * @param sortBy
-   * @param searchTerm
-   * @param labelTerm
-   * @param labelLanguage
-   * @param filterCriteria must be {@code Pair}s of a {@code String}, the expression, and the
-   *     corresponding {@code FilterCriterion}
-   * @return
-   */
-  protected PageResponse<T> find(
-      int pageNumber,
-      int pageSize,
-      List<Order> sortBy,
-      String searchTerm,
-      String labelTerm,
-      Locale labelLanguage,
-      Pair<String, FilterCriterion<?>>... filterCriteria) {
-    return find(
-        pageNumber,
-        pageSize,
-        sortBy,
-        searchTerm,
-        labelTerm,
-        labelLanguage,
-        null,
-        null,
-        filterCriteria);
-  }
-
-  /**
-   * The usual find implementation
-   *
-   * <p>For {@code filterCriteria} we use a varargs parameter instead of a {@code Map<String,
-   * FilterCriterion<?>>}, because the beautiful shorthand {@code Map.of} does not support null
-   * values and so it would make things unnecessary difficult inside the extending class.
-   *
-   * <p>Do not mess things up by passing {@code null} for {@code filterCriteria} if there are not
-   * any. Since it is varargs you can just omit this parameter.
-   *
-   * @param pageNumber
-   * @param pageSize
-   * @param sortBy
-   * @param searchTerm
-   * @param labelTerm
-   * @param labelLanguage
-   * @param nameTerm
-   * @param nameLanguage
-   * @param filterCriteria must be {@code Pair}s of a {@code String}, the expression, and the
-   *     corresponding {@code FilterCriterion}
-   * @return
-   */
-  protected PageResponse<T> find(
-      int pageNumber,
-      int pageSize,
-      List<Order> sortBy,
-      String searchTerm,
-      String labelTerm,
-      Locale labelLanguage,
-      String nameTerm,
-      Locale nameLanguage,
-      Pair<String, FilterCriterion<?>>... filterCriteria) {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
-    if (sortBy != null) {
-      Sorting sorting = new Sorting(sortBy);
-      pageRequest.setSorting(sorting);
-    }
-
-    // Since Map.of doesn't support null values we try it this varargs-way.
-    for (Pair<String, FilterCriterion<?>> criterionPair : filterCriteria) {
-      if (criterionPair.getRight() == null) {
-        continue;
-      }
-      String expression = criterionPair.getLeft();
-      FilterCriterion<?> criterion = criterionPair.getRight();
-      criterion.setExpression(expression);
-      pageRequest.add(new Filtering(List.of(criterion)));
-    }
-
-    addLabelFilter(pageRequest, labelTerm, labelLanguage);
-    addNameFilter(pageRequest, nameTerm, nameLanguage);
-    return getService().find(pageRequest);
-  }
-
+  @Override
   protected abstract IdentifiableService<T> getService();
-
-  protected void addLabelFilter(PageRequest pageRequest, String labelTerm, Locale labelLanguage) {
-    addFilterForSplitField("label", pageRequest, labelTerm, labelLanguage);
-  }
-
-  protected void addNameFilter(PageRequest pageRequest, String nameTerm, Locale nameLanguage) {
-    addFilterForSplitField("name", pageRequest, nameTerm, nameLanguage);
-  }
-
-  private void addFilterForSplitField(
-      String expression, PageRequest pageRequest, String term, Locale language) {
-    if (expression == null || pageRequest == null || term == null) {
-      return;
-    }
-    term = term.trim();
-    if (language != null) {
-      expression += "." + language.getLanguage();
-    }
-    FilterOperation operation = FilterOperation.CONTAINS;
-    if (term.matches("\".+\"")) {
-      operation = FilterOperation.EQUALS;
-    }
-    pageRequest.add(
-        Filtering.builder().add(new FilterCriterion<>(expression, operation, term)).build());
-  }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/semantic/SubjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/semantic/SubjectController.java
@@ -1,17 +1,18 @@
 package de.digitalcollections.cudami.server.controller.identifiable.entity.semantic;
 
+import de.digitalcollections.cudami.server.business.api.service.UniqueObjectService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.semantic.SubjectService;
+import de.digitalcollections.cudami.server.controller.AbstractUniqueObjectController;
 import de.digitalcollections.cudami.server.controller.ParameterHelper;
-import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.list.sorting.Order;
-import de.digitalcollections.model.list.sorting.Sorting;
 import de.digitalcollections.model.semantic.Subject;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
@@ -30,7 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Tag(name = "Subject controller")
-public class SubjectController {
+public class SubjectController extends AbstractUniqueObjectController<Subject> {
 
   private final SubjectService service;
 
@@ -46,13 +47,10 @@ public class SubjectController {
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
-      @RequestParam(name = "searchTerm", required = false) String searchTerm) {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
-    if (sortBy != null) {
-      Sorting sorting = new Sorting(sortBy);
-      pageRequest.setSorting(sorting);
-    }
-    return service.find(pageRequest);
+      @RequestParam(name = "searchTerm", required = false) String searchTerm,
+      @RequestParam(name = "label", required = false) String labelTerm,
+      @RequestParam(name = "labelLanguage", required = false) Locale labelLanguage) {
+    return super.find(pageNumber, pageSize, sortBy, searchTerm, labelTerm, labelLanguage);
   }
 
   @Operation(
@@ -105,5 +103,10 @@ public class SubjectController {
     assert Objects.equals(uuid, subject.getUuid());
     service.update(subject);
     return subject;
+  }
+
+  @Override
+  protected UniqueObjectService<Subject> getService() {
+    return service;
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/TagController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/TagController.java
@@ -1,16 +1,17 @@
 package de.digitalcollections.cudami.server.controller.semantic;
 
+import de.digitalcollections.cudami.server.business.api.service.UniqueObjectService;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ValidationException;
 import de.digitalcollections.cudami.server.business.api.service.semantic.TagService;
+import de.digitalcollections.cudami.server.controller.AbstractUniqueObjectController;
 import de.digitalcollections.cudami.server.controller.ParameterHelper;
-import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.list.sorting.Order;
-import de.digitalcollections.model.list.sorting.Sorting;
 import de.digitalcollections.model.semantic.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
@@ -29,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @io.swagger.v3.oas.annotations.tags.Tag(name = "Tag controller")
-public class TagController {
+public class TagController extends AbstractUniqueObjectController<Tag> {
 
   private final TagService service;
 
@@ -45,13 +46,10 @@ public class TagController {
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
-      @RequestParam(name = "searchTerm", required = false) String searchTerm) {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
-    if (sortBy != null) {
-      Sorting sorting = new Sorting(sortBy);
-      pageRequest.setSorting(sorting);
-    }
-    return service.find(pageRequest);
+      @RequestParam(name = "searchTerm", required = false) String searchTerm,
+      @RequestParam(name = "label", required = false) String labelTerm,
+      @RequestParam(name = "labelLanguage", required = false) Locale labelLanguage) {
+    return super.find(pageNumber, pageSize, sortBy, searchTerm, labelTerm, labelLanguage);
   }
 
   @Operation(
@@ -101,5 +99,10 @@ public class TagController {
   public Tag update(@PathVariable UUID uuid, @RequestBody Tag tag, BindingResult errors) {
     assert Objects.equals(uuid, tag.getUuid());
     return service.update(tag);
+  }
+
+  @Override
+  protected UniqueObjectService<Tag> getService() {
+    return service;
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/PersonControllerTest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.when;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.PersonService;
 import de.digitalcollections.cudami.server.controller.BaseControllerTest;
 import de.digitalcollections.model.identifiable.entity.agent.Person;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.jupiter.api.DisplayName;
@@ -64,5 +67,131 @@ class PersonControllerTest extends BaseControllerTest {
             + Base64.getEncoder().encodeToString("foo:bar/bla".getBytes(StandardCharsets.UTF_8)));
 
     verify(personService, times(1)).getByIdentifier(eq("foo"), eq("bar/bla"));
+  }
+
+  @DisplayName("can retrieve by localized exact label")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/persons?label=\"Karl Ranseier\"&labelLanguage=und-Latn"})
+  public void findByLocalizedExactLabel(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(5)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .isEquals("\"Karl Ranseier\"")
+                            .build())
+                    .build())
+            .build();
+    verify(personService, times(1)).find(eq(expectedPageRequest));
+  }
+
+  @DisplayName("can retrieve by localized 'like' label")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/persons?label=Karl Ranseier&labelLanguage=und-Latn"})
+  public void findByLocalizedLikeLabel(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(5)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .contains("Karl Ranseier")
+                            .build())
+                    .build())
+            .build();
+    verify(personService, times(1)).find(eq(expectedPageRequest));
+  }
+
+  @DisplayName("can retrieve by localized exact name")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/persons?name=\"Karl Ranseier\"&nameLanguage=de"})
+  public void findByLocalizedExactName(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(5)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("name.de")
+                            .isEquals("\"Karl Ranseier\"")
+                            .build())
+                    .build())
+            .build();
+    verify(personService, times(1)).find(eq(expectedPageRequest));
+  }
+
+  @DisplayName("can retrieve by localized 'like' name")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/persons?name=Karl Ranseier&nameLanguage=und-Latn"})
+  public void findByLocalizedLikeName(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(5)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("name.und-latn")
+                            .contains("Karl Ranseier")
+                            .build())
+                    .build())
+            .build();
+    verify(personService, times(1)).find(eq(expectedPageRequest));
+  }
+
+  @DisplayName("can retrieve by non-localized exact name")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/persons?name=\"Karl Ranseier\""})
+  public void findByNonLocalizedExactName(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(5)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("name")
+                            .isEquals("\"Karl Ranseier\"")
+                            .build())
+                    .build())
+            .build();
+    verify(personService, times(1)).find(eq(expectedPageRequest));
+  }
+
+  @DisplayName("can retrieve by non-localized 'like' name")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/persons?name=Karl Ranseier"})
+  public void findByNonLocalizedLikeName(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(5)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("name")
+                            .contains("Karl Ranseier")
+                            .build())
+                    .build())
+            .build();
+    verify(personService, times(1)).find(eq(expectedPageRequest));
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/semantic/SubjectControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/semantic/SubjectControllerTest.java
@@ -1,16 +1,23 @@
 package de.digitalcollections.cudami.server.controller.identifiable.entity.semantic;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.semantic.SubjectService;
 import de.digitalcollections.cudami.server.controller.BaseControllerTest;
 import de.digitalcollections.model.identifiable.Identifier;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.semantic.Subject;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -47,5 +54,47 @@ class SubjectControllerTest extends BaseControllerTest {
     when(subjectService.getByTypeAndIdentifier(eq("type"), eq("namespace"), eq("id")))
         .thenReturn(null);
     testNotFound(path);
+  }
+
+  @DisplayName("can retrieve by localized exact label")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/subjects?label=\"Antike und Altertum\"&labelLanguage=und-Latn"})
+  public void findByLocalizedExactLabel(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .isEquals("\"Antike und Altertum\"")
+                            .build())
+                    .build())
+            .build();
+    verify(subjectService, times(1)).find(eq(expectedPageRequest));
+  }
+
+  @DisplayName("can retrieve by localized 'like' label")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/subjects?label=Antike&labelLanguage=und-Latn"})
+  public void findByLocalizedLikeLabel(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .contains("Antike")
+                            .build())
+                    .build())
+            .build();
+    verify(subjectService, times(1)).find(eq(expectedPageRequest));
   }
 }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/semantic/TagControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/semantic/TagControllerTest.java
@@ -1,0 +1,65 @@
+package de.digitalcollections.cudami.server.controller.semantic;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.digitalcollections.cudami.server.business.api.service.semantic.TagService;
+import de.digitalcollections.cudami.server.controller.BaseControllerTest;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(TagController.class)
+@DisplayName("The TagController")
+class TagControllerTest extends BaseControllerTest {
+
+  @MockBean private TagService tagService;
+
+  @DisplayName("can retrieve by localized exact label")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/tags?label=\"Antike und Altertum\"&labelLanguage=und-Latn"})
+  public void findByLocalizedExactLabel(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .isEquals("\"Antike und Altertum\"")
+                            .build())
+                    .build())
+            .build();
+    verify(tagService, times(1)).find(eq(expectedPageRequest));
+  }
+
+  @DisplayName("can retrieve by localized 'like' label")
+  @ParameterizedTest
+  @ValueSource(strings = {"/v6/tags?label=Antike&labelLanguage=und-Latn"})
+  public void findByLocalizedLikeLabel(String path) throws Exception {
+    testHttpGet(path);
+    PageRequest expectedPageRequest =
+        PageRequest.builder()
+            .pageSize(25)
+            .pageNumber(0)
+            .filtering(
+                Filtering.builder()
+                    .add(
+                        FilterCriterion.builder()
+                            .withExpression("label.und-latn")
+                            .contains("Antike")
+                            .build())
+                    .build())
+            .build();
+    verify(tagService, times(1)).find(eq(expectedPageRequest));
+  }
+}


### PR DESCRIPTION
This PR allows UniqueObjects to be filtered, too. Currently, `Tag` and `Subject` can be filtered agains their `label`.