### PR TITLE
Split up joins strings into two...

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/CollectionRepositoryImpl.java
@@ -421,7 +421,7 @@ public class CollectionRepositoryImpl extends EntityRepositoryImpl<Collection>
                     .build())
             .build();
 
-    Collection result = retrieveOne(getSqlSelectReducedFields(), sqlAdditionalJoins, filtering);
+    Collection result = retrieveOne(getSqlSelectReducedFields(), filtering, sqlAdditionalJoins);
     return result;
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/DigitalObjectRepositoryImpl.java
@@ -52,19 +52,26 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
   public static final String MAPPING_PREFIX = "do";
   public static final String TABLE_ALIAS = "d";
 
-  private static final String SQL_SELECT_ALL_FIELDS_JOINS =
-      " LEFT JOIN "
-          + LicenseRepositoryImpl.TABLE_NAME
-          + " AS "
-          + LicenseRepositoryImpl.TABLE_ALIAS
-          + " ON "
-          + TABLE_ALIAS
-          + ".license_uuid = "
-          + LicenseRepositoryImpl.TABLE_ALIAS
-          + ".uuid"
-          + " LEFT JOIN %1$s %2$s ON %2$s.uuid = %3$s.item_uuid"
-              .formatted(
-                  ItemRepositoryImpl.TABLE_NAME, ItemRepositoryImpl.TABLE_ALIAS, TABLE_ALIAS);
+  @Override
+  protected String getSqlSelectAllFieldsJoins() {
+    return super.getSqlSelectAllFieldsJoins()
+        + " LEFT JOIN "
+        + LicenseRepositoryImpl.TABLE_NAME
+        + " AS "
+        + LicenseRepositoryImpl.TABLE_ALIAS
+        + " ON "
+        + TABLE_ALIAS
+        + ".license_uuid = "
+        + LicenseRepositoryImpl.TABLE_ALIAS
+        + ".uuid";
+  }
+
+  @Override
+  protected String getSqlSelectReducedFieldsJoins() {
+    return super.getSqlSelectReducedFieldsJoins()
+        + " LEFT JOIN %1$s %2$s ON %2$s.uuid = %3$s.item_uuid"
+            .formatted(ItemRepositoryImpl.TABLE_NAME, ItemRepositoryImpl.TABLE_ALIAS, TABLE_ALIAS);
+  }
 
   private static final BiConsumer<Map<UUID, DigitalObject>, RowView>
       ADDITIONAL_REDUCE_ROWS_BICONSUMER =
@@ -240,7 +247,6 @@ public class DigitalObjectRepositoryImpl extends EntityRepositoryImpl<DigitalObj
         TABLE_ALIAS,
         MAPPING_PREFIX,
         DigitalObject.class,
-        SQL_SELECT_ALL_FIELDS_JOINS,
         ADDITIONAL_REDUCE_ROWS_BICONSUMER,
         cudamiConfig.getOffsetForAlternativePaging());
   }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/EntityRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/EntityRepositoryImpl.java
@@ -140,26 +140,6 @@ public class EntityRepositoryImpl<E extends Entity> extends IdentifiableReposito
       String tableAlias,
       String mappingPrefix,
       Class<? extends Entity> entityImplClass,
-      String sqlSelectAllFieldsJoins,
-      int offsetForAlternativePaging) {
-    this(
-        dbi,
-        tableName,
-        tableAlias,
-        mappingPrefix,
-        entityImplClass,
-        sqlSelectAllFieldsJoins,
-        null,
-        offsetForAlternativePaging);
-  }
-
-  protected EntityRepositoryImpl(
-      Jdbi dbi,
-      String tableName,
-      String tableAlias,
-      String mappingPrefix,
-      Class<? extends Entity> entityImplClass,
-      String sqlSelectAllFieldsJoins,
       BiConsumer<Map<UUID, E>, RowView> additionalReduceRowsBiConsumer,
       int offsetForAlternativePaging) {
     super(
@@ -168,7 +148,6 @@ public class EntityRepositoryImpl<E extends Entity> extends IdentifiableReposito
         tableAlias,
         mappingPrefix,
         entityImplClass,
-        sqlSelectAllFieldsJoins,
         additionalReduceRowsBiConsumer,
         offsetForAlternativePaging);
   }
@@ -203,7 +182,7 @@ public class EntityRepositoryImpl<E extends Entity> extends IdentifiableReposito
             .add(FilterCriterion.builder().withExpression("refId").isEquals(refId).build())
             .build();
 
-    return retrieveOne(getSqlSelectAllFields(), sqlSelectAllFieldsJoins, filtering);
+    return retrieveOne(getSqlSelectAllFields(), filtering, null);
   }
 
   @Override

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/HeadwordEntryRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/HeadwordEntryRepositoryImpl.java
@@ -37,16 +37,20 @@ public class HeadwordEntryRepositoryImpl extends EntityRepositoryImpl<HeadwordEn
   private static final Logger LOGGER = LoggerFactory.getLogger(HeadwordEntryRepositoryImpl.class);
 
   public static final String MAPPING_PREFIX = "he";
-  private static final String SQL_SELECT_ALL_FIELDS_JOINS =
-      " LEFT JOIN "
-          + HeadwordRepositoryImpl.TABLE_NAME
-          + " AS "
-          + HeadwordRepositoryImpl.TABLE_ALIAS
-          + " ON "
-          + HeadwordRepositoryImpl.TABLE_ALIAS
-          + ".uuid = he.headword";
   public static final String TABLE_ALIAS = "he";
   public static final String TABLE_NAME = "headwordentries";
+
+  @Override
+  protected String getSqlSelectAllFieldsJoins() {
+    return super.getSqlSelectAllFieldsJoins()
+        + " LEFT JOIN "
+        + HeadwordRepositoryImpl.TABLE_NAME
+        + " AS "
+        + HeadwordRepositoryImpl.TABLE_ALIAS
+        + " ON "
+        + HeadwordRepositoryImpl.TABLE_ALIAS
+        + ".uuid = he.headword";
+  }
 
   private static BiConsumer<Map<UUID, HeadwordEntry>, RowView> ADDITIONAL_REDUCEROWS_BICONSUMER =
       (map, rowView) -> {
@@ -116,7 +120,6 @@ public class HeadwordEntryRepositoryImpl extends EntityRepositoryImpl<HeadwordEn
         TABLE_ALIAS,
         MAPPING_PREFIX,
         HeadwordEntry.class,
-        SQL_SELECT_ALL_FIELDS_JOINS,
         ADDITIONAL_REDUCEROWS_BICONSUMER,
         cudamiConfig.getOffsetForAlternativePaging());
     this.entityRepositoryImpl = entityRepositoryImpl;

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/TopicRepositoryImpl.java
@@ -413,7 +413,7 @@ public class TopicRepositoryImpl extends EntityRepositoryImpl<Topic> implements 
                     .build())
             .build();
 
-    Topic result = retrieveOne(getSqlSelectReducedFields(), sqlAdditionalJoins, filtering);
+    Topic result = retrieveOne(getSqlSelectReducedFields(), filtering, sqlAdditionalJoins);
 
     return result;
   }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/AgentRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/AgentRepositoryImpl.java
@@ -37,7 +37,6 @@ public class AgentRepositoryImpl<A extends Agent> extends EntityRepositoryImpl<A
         MAPPING_PREFIX,
         Agent.class,
         null,
-        null,
         cudamiConfig.getOffsetForAlternativePaging());
   }
 
@@ -47,7 +46,6 @@ public class AgentRepositoryImpl<A extends Agent> extends EntityRepositoryImpl<A
       String tableAlias,
       String mappingPrefix,
       Class<? extends Agent> agentImplClass,
-      String sqlSelectAllFieldsJoins,
       BiConsumer<Map<UUID, A>, RowView> additionalReduceRowsBiConsumer,
       int offsetForAlternativePaging) {
     super(
@@ -56,7 +54,6 @@ public class AgentRepositoryImpl<A extends Agent> extends EntityRepositoryImpl<A
         tableAlias,
         mappingPrefix,
         agentImplClass,
-        sqlSelectAllFieldsJoins,
         additionalReduceRowsBiConsumer,
         offsetForAlternativePaging);
   }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/CorporateBodyRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/agent/CorporateBodyRepositoryImpl.java
@@ -64,7 +64,6 @@ public class CorporateBodyRepositoryImpl extends AgentRepositoryImpl<CorporateBo
         MAPPING_PREFIX,
         CorporateBody.class,
         null,
-        null,
         cudamiConfig.getOffsetForAlternativePaging());
   }
 

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/work/ItemRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/work/ItemRepositoryImpl.java
@@ -66,12 +66,14 @@ public class ItemRepositoryImpl extends EntityRepositoryImpl<Item> implements It
             .formatted(tableAlias, mappingPrefix);
   }
 
-  public static final String SQL_SELECT_ALL_FIELDS_JOINS =
-      """
-          LEFT JOIN %1$s %2$s ON %2$s.uuid = ANY(%4$s.holder_uuids)
-          LEFT JOIN %3$s poi ON %4$s.part_of_item = poi.uuid
-          """
-          .formatted(AgentRepositoryImpl.TABLE_NAME, "holdertable", TABLE_NAME, TABLE_ALIAS);
+  @Override
+  protected String getSqlSelectAllFieldsJoins() {
+    return super.getSqlSelectAllFieldsJoins()
+        + """
+        LEFT JOIN %1$s poi ON %2$s.part_of_item = poi.uuid
+        """
+            .formatted(tableName, tableAlias);
+  }
 
   @Override
   public String getSqlSelectReducedFields(String tableAlias, String mappingPrefix) {
@@ -87,6 +89,15 @@ public class ItemRepositoryImpl extends EntityRepositoryImpl<Item> implements It
         + "_manifestation_uuid, "
         + agentRepository.getSqlSelectReducedFields(
             "holdertable", AgentRepositoryImpl.MAPPING_PREFIX);
+  }
+
+  @Override
+  protected String getSqlSelectReducedFieldsJoins() {
+    return super.getSqlSelectReducedFieldsJoins()
+        + """
+        LEFT JOIN %1$s %2$s ON %2$s.uuid = ANY(%3$s.holder_uuids)
+        """
+            .formatted(AgentRepositoryImpl.TABLE_NAME, "holdertable", tableAlias);
   }
 
   @Override
@@ -112,7 +123,6 @@ public class ItemRepositoryImpl extends EntityRepositoryImpl<Item> implements It
         TABLE_ALIAS,
         MAPPING_PREFIX,
         Item.class,
-        SQL_SELECT_ALL_FIELDS_JOINS,
         ItemRepositoryImpl::additionalReduceRows,
         cudamiConfig.getOffsetForAlternativePaging());
     this.digitalObjectRepositoryImpl = digitalObjectRepositoryImpl;

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/resource/FileResourceMetadataRepositoryImpl.java
@@ -111,7 +111,6 @@ public class FileResourceMetadataRepositoryImpl<F extends FileResource>
       String tableName,
       String tableAlias,
       String mappingPrefix,
-      String sqlSelectAllFieldsJoins,
       BiConsumer<Map<UUID, F>, RowView> additionalReduceRowsBiConsumer,
       int offsetForAlternativePaging) {
     super(
@@ -120,7 +119,6 @@ public class FileResourceMetadataRepositoryImpl<F extends FileResource>
         tableAlias,
         mappingPrefix,
         FileResource.class,
-        sqlSelectAllFieldsJoins,
         additionalReduceRowsBiConsumer,
         offsetForAlternativePaging);
   }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/web/WebpageRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/web/WebpageRepositoryImpl.java
@@ -333,7 +333,7 @@ public class WebpageRepositoryImpl extends IdentifiableRepositoryImpl<Webpage>
                     .build())
             .build();
 
-    Webpage result = retrieveOne(getSqlSelectReducedFields(), sqlAdditionalJoins, filtering);
+    Webpage result = retrieveOne(getSqlSelectReducedFields(), filtering, sqlAdditionalJoins);
 
     return result;
   }


### PR DESCRIPTION
depending on selected fields (reduced fields or all fields) to improve performance by removing unnecessary joins.
Ticket: mdz/services/internal/metadata-content-service/-/issues/37