### PR TITLE
SQL & Refactor `getByIdentifier` to increase performance

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/IdentifiableRepositoryImpl.java
@@ -471,10 +471,11 @@ public class IdentifiableRepositoryImpl<I extends Identifiable>
                 h.createQuery(
                         """
             SELECT identifiable FROM identifiers
-            WHERE namespace = ?
-              AND identifier = ?;""")
-                    .bind(0, namespace)
-                    .bind(1, identifierId)
+            WHERE namespace = :namespace
+              AND identifier = :id;
+            """) /* affords index only scan on "unique_namespace_identifier" (V14.04.00) */
+                    .bind("namespace", namespace)
+                    .bind("id", identifierId)
                     .mapTo(UUID.class)
                     .findOne()
                     .orElse(null));

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V14.04.00__DDL_rearrange_indexes_of_identifiers.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V14.04.00__DDL_rearrange_indexes_of_identifiers.sql
@@ -1,0 +1,10 @@
+/**
+ * Rearrangement of the indexes on table identifiers
+ * to support "index only" scans and speed up repo's `getByIdentifier`
+ */
+DROP INDEX IF EXISTS idx_identifiers_uniq;
+ALTER TABLE identifiers
+  DROP CONSTRAINT unique_namespace_identifier,
+  ADD CONSTRAINT unique_namespace_identifier_identifiable UNIQUE (identifiable, namespace, identifier),
+  ADD CONSTRAINT unique_namespace_identifier UNIQUE (namespace, identifier) INCLUDE (identifiable);
+


### PR DESCRIPTION
Rearrange indexes on table identifiers to enable "index only" scans. This decreases execution time by up to 49 percent.

Ticket: mdz/services/internal/metadata-content-service/-/issues/38