### PR TITLE
Fix migration V14.05.00

### DIFF
--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V14.05.00__DDL_drop_tag_columns_and_add_value_column.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V14.05.00__DDL_drop_tag_columns_and_add_value_column.sql
@@ -1,9 +1,17 @@
-ALTER TABLE tags DROP CONSTRAINT tags_type_namespace_id_key;
+ALTER TABLE tags ADD COLUMN IF NOT EXISTS value varchar COLLATE "ucs_basic";
 
-ALTER TABLE tags DROP COLUMN id CASCADE;
-ALTER TABLE tags DROP COLUMN label CASCADE;
-ALTER TABLE tags DROP COLUMN namespace CASCADE;
-ALTER TABLE tags DROP COLUMN type CASCADE;
+UPDATE tags SET value = format('%s:%s:%s', "type", namespace, id);
 
-ALTER TABLE tags ADD COLUMN value VARCHAR collate "ucs_basic";
-ALTER TABLE tags ADD UNIQUE (value);
+DROP INDEX IF EXISTS idx_tags_split_label;
+ALTER TABLE tags
+  DROP CONSTRAINT IF EXISTS tags_type_namespace_id_key,
+  DROP COLUMN IF EXISTS id CASCADE,
+  DROP COLUMN IF EXISTS label CASCADE,
+  DROP COLUMN IF EXISTS namespace CASCADE,
+  DROP COLUMN IF EXISTS type CASCADE,
+  DROP COLUMN IF EXISTS split_label;
+
+ALTER TABLE tags
+  ALTER COLUMN value SET NOT NULL,
+  ADD CONSTRAINT unique_value UNIQUE (value);
+


### PR DESCRIPTION
Make failsafe and migrate old values (if already exist)

Who has to "rollback" his db can use this script including two example entries.
**DEV must be rolled back**

```
ALTER TABLE tags
  DROP COLUMN IF EXISTS value CASCADE,
  ADD COLUMN IF NOT EXISTS id varchar,
  ADD COLUMN IF NOT EXISTS namespace varchar,
  ADD COLUMN IF NOT EXISTS type varchar;

INSERT INTO tags (
  uuid,
  created,
  last_modified,
  "type",
  namespace,
  id
) VALUES (
  '00000000-0000-0000-0000-000000000001',
  'now',
  'now',
  'IDENTIFIER',
  'oclc',
  '225271758'
), (
  '00000000-0000-0000-0000-000000000002',
  'now',
  'now',
  'IDENTIFIER',
  'isbn',
  '3-525-35892-X'
);

DELETE FROM flyway_schema_history WHERE version = '14.05.00';

```
