### PR TITLE
Add `LegacyPageRequest` to "old" controllers

### DIFF
--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/V5IdentifiableController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/V5IdentifiableController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.IdentifiableService;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.alias.UrlAliasService;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -55,7 +56,7 @@ public class V5IdentifiableController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws JsonProcessingException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/V5FamilyNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/V5FamilyNameController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.agent.FamilyNameService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.agent.FamilyName;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -46,7 +47,7 @@ public class V5FamilyNameController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm,
       @RequestParam(name = "initial", required = false) String initial)
       throws JsonProcessingException, CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(sortBy);
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/V5GivenNameController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/agent/V5GivenNameController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.agent.GivenNameService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.agent.GivenName;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -46,7 +47,7 @@ public class V5GivenNameController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm,
       @RequestParam(name = "initial", required = false) String initial)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(sortBy);
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/alias/V5UrlAliasController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/alias/V5UrlAliasController.java
@@ -8,6 +8,7 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.ali
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.ParameterHelper;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.alias.LocalizedUrlAliases;
 import de.digitalcollections.model.identifiable.alias.UrlAlias;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -74,7 +75,7 @@ public class V5UrlAliasController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       List<Order> migratedSortBy = V5MigrationHelper.migrate(sortBy);
       Sorting sorting = new Sorting(migratedSortBy);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V2ProjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V2ProjectController.java
@@ -7,6 +7,7 @@ import com.github.openjson.JSONObject;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ProjectService;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Project;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -93,7 +94,7 @@ public class V2ProjectController {
           @RequestParam(name = "searchTerm", required = false)
           String searchTerm)
       throws JsonProcessingException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V2WebsiteController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V2WebsiteController.java
@@ -7,6 +7,7 @@ import com.github.openjson.JSONObject;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.WebsiteService;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Website;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -99,7 +100,7 @@ public class V2WebsiteController {
           @RequestParam(name = "searchTerm", required = false)
           String searchTerm)
       throws JsonProcessingException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V3CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V3CollectionController.java
@@ -9,6 +9,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.CollectionService;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
 import de.digitalcollections.cudami.server.controller.legacy.model.LegacyFiltering;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
@@ -105,7 +106,7 @@ public class V3CollectionController {
           String searchTerm)
       throws JsonProcessingException, ServiceException {
     PageRequest searchPageRequest =
-        new PageRequest(searchTerm, pageNumber, pageSize, new Sorting());
+        new LegacyPageRequest(searchTerm, pageNumber, pageSize, new Sorting());
 
     Collection collection = new Collection();
     collection.setUuid(collectionUuid);
@@ -311,7 +312,7 @@ public class V3CollectionController {
           @RequestParam(name = "active", required = false)
           String active)
       throws JsonProcessingException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5ArticleController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5ArticleController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ArticleService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Article;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -44,7 +45,7 @@ public class V5ArticleController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5CollectionController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5CollectionController.java
@@ -7,6 +7,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.CollectionService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -59,7 +60,7 @@ public class V5CollectionController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm,
       @RequestParam(name = "active", required = false) String active)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);
@@ -90,7 +91,7 @@ public class V5CollectionController {
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
 
     Collection collection = new Collection();
     collection.setUuid(collectionUuid);
@@ -118,7 +119,7 @@ public class V5CollectionController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);
@@ -152,7 +153,7 @@ public class V5CollectionController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5DigitalObjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5DigitalObjectController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.DigitalObjectService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.Project;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
@@ -56,7 +57,7 @@ public class V5DigitalObjectController {
       @RequestParam(name = "parent.uuid", required = false)
           FilterCriterion<UUID> parentUuidFilterCriterion)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);
@@ -94,7 +95,7 @@ public class V5DigitalObjectController {
       @RequestParam(name = "parent.uuid", required = false)
           FilterCriterion<UUID> parentUuidFilterCriterion)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);
@@ -124,7 +125,7 @@ public class V5DigitalObjectController {
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
 
     DigitalObject digitalObject = new DigitalObject();
     digitalObject.setUuid(uuid);
@@ -150,7 +151,7 @@ public class V5DigitalObjectController {
       @RequestParam(name = "active", required = false) String active,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
 
     DigitalObject digitalObject = new DigitalObject();
     digitalObject.setUuid(uuid);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5EntityController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5EntityController.java
@@ -7,6 +7,7 @@ import de.digitalcollections.cudami.server.business.api.service.identifiable.ent
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.relation.EntityToEntityRelationService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.list.filtering.FilterCriterion;
 import de.digitalcollections.model.list.filtering.Filtering;
@@ -55,7 +56,7 @@ public class V5EntityController<E extends Entity> {
       @RequestParam(name = "entityType", required = false)
           FilterCriterion<String> entityTypeCriterion)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);
@@ -88,7 +89,7 @@ public class V5EntityController<E extends Entity> {
       @RequestParam(name = "entityType", required = false)
           FilterCriterion<String> entityTypeCriterion)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5HeadwordEntryController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5HeadwordEntryController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.HeadwordEntryService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.HeadwordEntry;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -45,7 +46,7 @@ public class V5HeadwordEntryController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5ProjectController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5ProjectController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.ProjectService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Project;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -48,7 +49,7 @@ public class V5ProjectController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);
@@ -74,7 +75,7 @@ public class V5ProjectController {
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
 
     Project project = new Project();
     project.setUuid(projectUuid);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5TopicController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5TopicController.java
@@ -7,6 +7,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.TopicService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.entity.Topic;
 import de.digitalcollections.model.identifiable.resource.FileResource;
@@ -55,7 +56,7 @@ public class V5TopicController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);
@@ -115,7 +116,7 @@ public class V5TopicController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);
@@ -166,7 +167,7 @@ public class V5TopicController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5WebsiteController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5WebsiteController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.WebsiteService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.Website;
 import de.digitalcollections.model.identifiable.web.Webpage;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -88,7 +89,7 @@ public class V5WebsiteController {
           @RequestParam(name = "searchTerm", required = false)
           String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);
@@ -147,7 +148,7 @@ public class V5WebsiteController {
           @RequestParam(name = "searchTerm", required = false)
           String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     PageResponse<Webpage> pageResponse =
         websiteService.findRootWebpages(Website.builder().uuid(uuid).build(), searchPageRequest);
     try {

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/V2CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/V2CorporateBodyController.java
@@ -7,6 +7,7 @@ import com.github.openjson.JSONObject;
 import de.digitalcollections.cudami.server.business.api.service.exceptions.ServiceException;
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.CorporateBodyService;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -95,7 +96,7 @@ public class V2CorporateBodyController {
           @RequestParam(name = "searchTerm", required = false)
           String searchTerm)
       throws JsonProcessingException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/V5CorporateBodyController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/V5CorporateBodyController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.CorporateBodyService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -48,7 +49,7 @@ public class V5CorporateBodyController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/V5PersonController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/agent/V5PersonController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.agent.PersonService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.agent.Person;
 import de.digitalcollections.model.identifiable.entity.geo.location.GeoLocation;
 import de.digitalcollections.model.list.filtering.FilterCriterion;
@@ -58,7 +59,7 @@ public class V5PersonController {
           FilterCriterion<UUID> previewImageFilter,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/V5GeoLocationController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/geo/location/V5GeoLocationController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.geo.location.GeoLocationService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.geo.location.GeoLocation;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -51,7 +52,7 @@ public class V5GeoLocationController {
       @RequestParam(name = "initial", required = false) String initial,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/V5ItemController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/V5ItemController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.work.ItemService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
 import de.digitalcollections.model.identifiable.entity.item.Item;
 import de.digitalcollections.model.list.paging.PageRequest;
@@ -52,7 +53,7 @@ public class V5ItemController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm,
       @RequestParam(name = "initial", required = false) String initial)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(sortBy);
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/V5WorkController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/entity/work/V5WorkController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.entity.work.WorkService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.entity.work.Work;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
@@ -45,7 +46,7 @@ public class V5WorkController {
       @RequestParam(name = "searchTerm", required = false) String searchTerm,
       @RequestParam(name = "initial", required = false) String initial)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(sortBy);
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/V5FileResourceMetadataController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/V5FileResourceMetadataController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.FileResourceMetadataService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.resource.FileResource;
 import de.digitalcollections.model.list.filtering.FilterCriterion;
 import de.digitalcollections.model.list.filtering.Filtering;
@@ -61,7 +62,7 @@ public class V5FileResourceMetadataController {
       @RequestParam(name = "uri", required = false)
           FilterCriterion<String> encodedUriFilterCriterion)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);
@@ -105,7 +106,7 @@ public class V5FileResourceMetadataController {
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws CudamiControllerException, ServiceException {
-    PageRequest pageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest pageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       pageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/V5LinkedDataFileResourceController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/resource/V5LinkedDataFileResourceController.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.resource.LinkedDataFileResourceService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
 import de.digitalcollections.model.list.filtering.FilterCriterion;
 import de.digitalcollections.model.list.filtering.Filtering;
@@ -94,7 +95,7 @@ public class V5LinkedDataFileResourceController {
       @RequestParam(name = "uri", required = false)
           FilterCriterion<String> encodedUriFilterCriterion)
       throws CudamiControllerException, ServiceException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/V5WebpageController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/identifiable/web/V5WebpageController.java
@@ -7,6 +7,7 @@ import de.digitalcollections.cudami.server.business.api.service.exceptions.Servi
 import de.digitalcollections.cudami.server.business.api.service.identifiable.web.WebpageService;
 import de.digitalcollections.cudami.server.controller.CudamiControllerException;
 import de.digitalcollections.cudami.server.controller.legacy.V5MigrationHelper;
+import de.digitalcollections.cudami.server.controller.legacy.model.LegacyPageRequest;
 import de.digitalcollections.model.identifiable.web.Webpage;
 import de.digitalcollections.model.list.filtering.FilterCriterion;
 import de.digitalcollections.model.list.filtering.Filtering;
@@ -94,7 +95,7 @@ public class V5WebpageController {
       @RequestParam(name = "active", required = false) String active,
       @RequestParam(name = "searchTerm", required = false) String searchTerm)
       throws ServiceException, CudamiControllerException {
-    PageRequest searchPageRequest = new PageRequest(searchTerm, pageNumber, pageSize);
+    PageRequest searchPageRequest = new LegacyPageRequest(searchTerm, pageNumber, pageSize);
     if (sortBy != null) {
       Sorting sorting = new Sorting(V5MigrationHelper.migrate(sortBy));
       searchPageRequest.setSorting(sorting);

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/legacy/V5MigrationHelper.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/legacy/V5MigrationHelper.java
@@ -82,6 +82,10 @@ public class V5MigrationHelper {
                     pageRequest.getJSONObject("filtering").toString(), Filtering.class));
         pageRequest.put(
             "filtering", new JSONObject(objectMapper.writeValueAsString(legacyFiltering)));
+        if (legacyFiltering.getFilterCriterionFor("label") != null) {
+          pageRequest.put("query", legacyFiltering.getFilterCriterionFor("label").getValue());
+          jsonObject.put("query", legacyFiltering.getFilterCriterionFor("label").getValue());
+        }
       }
       jsonObject.put("pageRequest", pageRequest);
     }

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/legacy/model/LegacyPageRequest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/legacy/model/LegacyPageRequest.java
@@ -1,0 +1,44 @@
+package de.digitalcollections.cudami.server.controller.legacy.model;
+
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.FilterLogicalOperator;
+import de.digitalcollections.model.list.filtering.Filtering;
+import de.digitalcollections.model.list.paging.PageRequest;
+import de.digitalcollections.model.list.sorting.Sorting;
+
+/** {@link PageRequest} that sets filters for label and description if {@code searchTerm} is set. */
+public final class LegacyPageRequest extends PageRequest {
+
+  public LegacyPageRequest(String searchTerm, int pageNumber, int pageSize) {
+    super(searchTerm, pageNumber, pageSize);
+  }
+
+  public LegacyPageRequest(String searchTerm, int pageNumber, int pageSize, Sorting sorting) {
+    super(searchTerm, pageNumber, pageSize, sorting);
+  }
+
+  public LegacyPageRequest(
+      int pageNumber, int pageSize, Sorting sorting, Filtering filtering, String searchTerm) {
+    super(pageNumber, pageSize, sorting, filtering, searchTerm);
+  }
+
+  @Override
+  protected void init() {
+    super.init();
+    if (searchTerm != null) {
+      // add filtering on label and description
+      add(
+          Filtering.builder()
+              .filterCriterion(
+                  FilterLogicalOperator.OR,
+                  FilterCriterion.builder().withExpression("label").isEquals(searchTerm).build())
+              .filterCriterion(
+                  FilterLogicalOperator.OR,
+                  FilterCriterion.builder()
+                      .withExpression("description")
+                      .isEquals(searchTerm)
+                      .build())
+              .build());
+    }
+  }
+}

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5CollectionControllerTest.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/java/de/digitalcollections/cudami/server/controller/identifiable/entity/V5CollectionControllerTest.java
@@ -9,6 +9,9 @@ import de.digitalcollections.cudami.server.controller.BaseControllerTest;
 import de.digitalcollections.model.identifiable.Identifier;
 import de.digitalcollections.model.identifiable.entity.Collection;
 import de.digitalcollections.model.identifiable.entity.digitalobject.DigitalObject;
+import de.digitalcollections.model.list.filtering.FilterCriterion;
+import de.digitalcollections.model.list.filtering.FilterLogicalOperator;
+import de.digitalcollections.model.list.filtering.Filtering;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import java.util.List;
@@ -29,30 +32,47 @@ class V5CollectionControllerTest extends BaseControllerTest {
 
   @DisplayName("shall return a paged list of collections")
   @ParameterizedTest
-  @ValueSource(strings = {"/v5/collections/search?pageSize=1&pageNumber=0"})
+  @ValueSource(
+      strings = {"/v5/collections/search?pageSize=1&pageNumber=0&searchTerm=Test-Sammlung"})
   void testFind(String path) throws Exception {
     PageResponse<Collection> expected =
-        (PageResponse<Collection>)
-            PageResponse.builder()
-                .forRequestPage(0)
-                .forPageSize(1)
-                .withTotalElements(156)
-                .forDescendingOrderedField("lastModified")
-                .forAscendingOrderedField("uuid")
-                .withContent(
-                    List.of(
-                        Collection.builder()
-                            .created("2022-03-31T11:32:04.189939")
-                            .lastModified("2022-05-02T16:18:52.710802")
-                            .uuid("900fbf70-12de-4483-a0e3-9d77ea49626e")
-                            .label(Locale.GERMAN, "Test-Sammlung")
-                            .publicationStart("2022-05-02")
-                            .build()))
-                .build();
+        PageResponse.builder()
+            .forRequestPage(0)
+            .forPageSize(1)
+            .withTotalElements(156)
+            .forDescendingOrderedField("lastModified")
+            .forAscendingOrderedField("uuid")
+            .withContent(
+                List.of(
+                    Collection.builder()
+                        .created("2022-03-31T11:32:04.189939")
+                        .lastModified("2022-05-02T16:18:52.710802")
+                        .uuid("900fbf70-12de-4483-a0e3-9d77ea49626e")
+                        .label(Locale.GERMAN, "Test-Sammlung")
+                        .publicationStart("2022-05-02")
+                        .build()))
+            .build();
+    expected
+        .getRequest()
+        .add(
+            Filtering.builder()
+                .filterCriterion(
+                    FilterLogicalOperator.OR,
+                    FilterCriterion.builder()
+                        .withExpression("label")
+                        .isEquals("Test-Sammlung")
+                        .build())
+                .filterCriterion(
+                    FilterLogicalOperator.OR,
+                    FilterCriterion.builder()
+                        .withExpression("description")
+                        .isEquals("Test-Sammlung")
+                        .build())
+                .build());
 
     when(collectionService.find(any(PageRequest.class))).thenReturn(expected);
 
-    testJson(path, "/v5/collections/find_with_result.json");
+    testJson(path, "/v5/collections/find_with_result_and_query.json");
   }
 
   @DisplayName("shall return a paged list of digital objects for a collections")
@@ -63,29 +83,28 @@ class V5CollectionControllerTest extends BaseControllerTest {
       })
   void testFindDigitalobjects(String path) throws Exception {
     PageResponse<DigitalObject> expected =
-        (PageResponse<DigitalObject>)
-            PageResponse.builder()
-                .forRequestPage(0)
-                .forPageSize(1)
-                .withTotalElements(71)
-                .forDescendingOrderedField("lastModified")
-                .forAscendingOrderedField("uuid")
-                .withContent(
-                    List.of(
-                        DigitalObject.builder()
-                            .created("2020-10-14T00:00:00")
-                            .lastModified("2020-10-14T00:00:00")
-                            .uuid("dde78cea-985b-4863-a782-1233978db71a")
-                            .label(Locale.GERMAN, "Testdigitalisat")
-                            .identifier(
-                                Identifier.builder()
-                                    .namespace("mdz-obj")
-                                    .id("bsb12345678")
-                                    .uuid("73724e05-4972-436c-a8ba-79240f675b46")
-                                    .build())
-                            .refId(529)
-                            .build()))
-                .build();
+        PageResponse.builder()
+            .forRequestPage(0)
+            .forPageSize(1)
+            .withTotalElements(71)
+            .forDescendingOrderedField("lastModified")
+            .forAscendingOrderedField("uuid")
+            .withContent(
+                List.of(
+                    DigitalObject.builder()
+                        .created("2020-10-14T00:00:00")
+                        .lastModified("2020-10-14T00:00:00")
+                        .uuid("dde78cea-985b-4863-a782-1233978db71a")
+                        .label(Locale.GERMAN, "Testdigitalisat")
+                        .identifier(
+                            Identifier.builder()
+                                .namespace("mdz-obj")
+                                .id("bsb12345678")
+                                .uuid("73724e05-4972-436c-a8ba-79240f675b46")
+                                .build())
+                        .refId(529)
+                        .build()))
+            .build();
 
     when(collectionService.findDigitalObjects(any(Collection.class), any(PageRequest.class)))
         .thenReturn(expected);
@@ -101,23 +120,22 @@ class V5CollectionControllerTest extends BaseControllerTest {
       })
   void testFindSubcollections(String path) throws Exception {
     PageResponse<Collection> expected =
-        (PageResponse<Collection>)
-            PageResponse.builder()
-                .forRequestPage(0)
-                .forPageSize(1)
-                .withTotalElements(156)
-                .forDescendingOrderedField("lastModified")
-                .forAscendingOrderedField("uuid")
-                .withContent(
-                    List.of(
-                        Collection.builder()
-                            .created("2022-03-31T11:32:04.189939")
-                            .lastModified("2022-05-02T16:18:52.710802")
-                            .uuid("900fbf70-12de-4483-a0e3-9d77ea49626e")
-                            .label(Locale.GERMAN, "Test-Sammlung")
-                            .publicationStart("2022-05-02")
-                            .build()))
-                .build();
+        PageResponse.builder()
+            .forRequestPage(0)
+            .forPageSize(1)
+            .withTotalElements(156)
+            .forDescendingOrderedField("lastModified")
+            .forAscendingOrderedField("uuid")
+            .withContent(
+                List.of(
+                    Collection.builder()
+                        .created("2022-03-31T11:32:04.189939")
+                        .lastModified("2022-05-02T16:18:52.710802")
+                        .uuid("900fbf70-12de-4483-a0e3-9d77ea49626e")
+                        .label(Locale.GERMAN, "Test-Sammlung")
+                        .publicationStart("2022-05-02")
+                        .build()))
+            .build();
 
     when(collectionService.findChildren(any(Collection.class), any(PageRequest.class)))
         .thenReturn(expected);
@@ -130,23 +148,22 @@ class V5CollectionControllerTest extends BaseControllerTest {
   @ValueSource(strings = {"/v5/collections/top?pageSize=1&pageNumber=0"})
   void testFindTopCollections(String path) throws Exception {
     PageResponse<Collection> expected =
-        (PageResponse<Collection>)
-            PageResponse.builder()
-                .forRequestPage(0)
-                .forPageSize(1)
-                .withTotalElements(156)
-                .forDescendingOrderedField("lastModified")
-                .forAscendingOrderedField("uuid")
-                .withContent(
-                    List.of(
-                        Collection.builder()
-                            .created("2022-03-31T11:32:04.189939")
-                            .lastModified("2022-05-02T16:18:52.710802")
-                            .uuid("900fbf70-12de-4483-a0e3-9d77ea49626e")
-                            .label(Locale.GERMAN, "Test-Sammlung")
-                            .publicationStart("2022-05-02")
-                            .build()))
-                .build();
+        PageResponse.builder()
+            .forRequestPage(0)
+            .forPageSize(1)
+            .withTotalElements(156)
+            .forDescendingOrderedField("lastModified")
+            .forAscendingOrderedField("uuid")
+            .withContent(
+                List.of(
+                    Collection.builder()
+                        .created("2022-03-31T11:32:04.189939")
+                        .lastModified("2022-05-02T16:18:52.710802")
+                        .uuid("900fbf70-12de-4483-a0e3-9d77ea49626e")
+                        .label(Locale.GERMAN, "Test-Sammlung")
+                        .publicationStart("2022-05-02")
+                        .build()))
+            .build();
 
     when(collectionService.findRootNodes(any(PageRequest.class))).thenReturn(expected);
 

--- a/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v5/collections/find_with_result_and_query.json
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/test/resources/json/v5/collections/find_with_result_and_query.json
@@ -1,0 +1,40 @@
+{
+  "content": [
+    {
+      "objectType": "COLLECTION",
+      "created": "2022-03-31T11:32:04.189939",
+      "lastModified": "2022-05-02T16:18:52.710802",
+      "uuid": "900fbf70-12de-4483-a0e3-9d77ea49626e",
+      "identifiers": [],
+      "label": {
+        "de": "Test-Sammlung"
+      },
+      "type": "ENTITY",
+      "entityType": "COLLECTION",
+      "publicationStart": "2022-05-02"
+    }
+  ],
+  "pageRequest": {
+    "query": "Test-Sammlung",
+    "sorting": {
+      "orders": [
+        {
+          "direction": "DESC",
+          "ignoreCase": true,
+          "nullHandling": "NATIVE",
+          "property": "lastModified"
+        },
+        {
+          "direction": "ASC",
+          "ignoreCase": true,
+          "nullHandling": "NATIVE",
+          "property": "uuid"
+        }
+      ]
+    },
+    "pageNumber": 0,
+    "pageSize": 1
+  },
+  "totalElements": 156,
+  "query": "Test-Sammlung"
+}


### PR DESCRIPTION
`LegacyPageRequest` sets filters on label and description if the `searchTerm` is filled. Thus the former behavior is reactivated (after refactoring).