### PR TITLE
Headword label normalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
     > `?filtering={$OR;lastname:eq:foo;firstname:eq:foo};{$OR;age:gt:30;age:lt:20}` → (lastname == "foo" OR firstname == "foo") AND (age > 30 OR age < 20)
   - within the value(s) of a condition semicolons and braces (i.e. `;{}`) must be backslash escaped; URL encoding is necessary as usual
 
-- Added Lobid-Clients for missing Lobid objects
+- Add Lobid-Clients for missing Lobid objects
+- Add persistence support for new field `Headword.labelNormalized`
+- Add sorting to Buckets and Bucket objects handling in `HeadwordRepositoryImpl` 
 
 ### Changed
 
@@ -52,6 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - Switch language of displayed multilanguage data fields now using a select drop down instead of tabs in view and list pages
   - Switch language of displayed multilanguage data fields now also handling languages with script
 - Thymeleaf Date and TimeValue rendering fragment (date.html) and messages properties moved from cudami admin webapp to cudami client for easy reuse in frontend clients
+- Separate `PageRequest` param handling from `ListRequest` param handling in `BaseRestClient`
+- Reuse logic from `BaseRestClient` in `CudamiHeadwordsClient`
 
 ### Fixed
 
@@ -59,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - **SQL migration** (can be **long running**) replaces every emtpy string key in the labels (that comes from `Locale.ROOT` as language)
 by `"und"`
 - `getByValue` method in `PredicateRepositoryImpl`
+- Comment not supported sorting throwing warning every time in `EntityToEntityRelationRepositoryImpl`
 
 ### Removed
 

--- a/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/semantic/CudamiHeadwordsClient.java
+++ b/dc-cudami-client/src/main/java/de/digitalcollections/cudami/client/semantic/CudamiHeadwordsClient.java
@@ -29,14 +29,7 @@ public class CudamiHeadwordsClient extends CudamiRestClient<Headword> {
     url = url + "?startId=" + startObject.getUuid();
     url = url + "&endId=" + endObject.getUuid();
 
-    int pageNumber = bucketObjectsRequest.getPageNumber();
-    if (pageNumber >= 0) {
-      url = url + "&pageNumber=" + pageNumber;
-    }
-    int pageSize = bucketObjectsRequest.getPageSize();
-    if (pageSize > 0) {
-      url = url + "&pageSize=" + pageSize;
-    }
+    url = url + "&" + getFindParamsAsString(bucketObjectsRequest);
 
     BucketObjectsResponse<Headword> result =
         (BucketObjectsResponse<Headword>) doGetRequestForObject(url, BucketObjectsResponse.class);
@@ -55,6 +48,8 @@ public class CudamiHeadwordsClient extends CudamiRestClient<Headword> {
       url = url + "&startId=" + startObject.getUuid();
       url = url + "&endId=" + endObject.getUuid();
     }
+
+    url = url + "&" + getSortParams(bucketsRequest);
 
     BucketsResponse<Headword> result =
         (BucketsResponse<Headword>) doGetRequestForObject(url, BucketsResponse.class);

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/relation/EntityToEntityRelationRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/identifiable/entity/relation/EntityToEntityRelationRepositoryImpl.java
@@ -118,7 +118,9 @@ public class EntityToEntityRelationRepositoryImpl extends JdbiRepositoryImpl
         new StringBuilder(
             "SELECT rel.subject_uuid rel_subject, rel.predicate rel_predicate, rel.object_uuid rel_object, rel.additional_predicates rel_addpredicates"
                 + commonSql);
-    pageRequest.setSorting(new Sorting(new Order(Direction.ASC, "rel.sortindex")));
+    // FIXME: we get always a warning "rel.sortindex not in allowed sort fields! Ignoring it.",
+    // because "rel.sortindex" is not in allowed order by fields:
+    //    pageRequest.setSorting(new Sorting(new Order(Direction.ASC, "rel.sortindex")));
     addPagingAndSorting(pageRequest, query);
     List<EntityRelation> list =
         dbi.withHandle(

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/HeadwordRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/HeadwordRepositoryImpl.java
@@ -158,8 +158,7 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
 
     // to avoid duplicate "hw.label, hw.label" if sortColumn = "label",
     // just add sortColumn in other cases:
-    String columnNameLabel = getColumnName("label");
-    String selectForLabel = columnNameLabel;
+    String selectForLabel = getColumnName("label");
     if (!sortColumn.equals(selectForLabel)) {
       selectForLabel = selectForLabel + ", " + sortColumn;
     }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/HeadwordRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/HeadwordRepositoryImpl.java
@@ -6,6 +6,7 @@ import de.digitalcollections.cudami.server.backend.api.repository.semantic.Headw
 import de.digitalcollections.cudami.server.backend.impl.jdbi.UniqueObjectRepositoryImpl;
 import de.digitalcollections.model.identifiable.entity.Entity;
 import de.digitalcollections.model.identifiable.resource.FileResource;
+import de.digitalcollections.model.list.ListRequest;
 import de.digitalcollections.model.list.buckets.Bucket;
 import de.digitalcollections.model.list.buckets.BucketObjectsRequest;
 import de.digitalcollections.model.list.buckets.BucketObjectsResponse;
@@ -153,12 +154,25 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
     argumentMappings.put("startUuid", startUuid);
     argumentMappings.put("endUuid", endUuid);
 
+    String sortColumn = getSortColumn(bucketObjectsRequest);
+
+    // to avoid duplicate "hw.label, hw.label" if sortColumn = "label",
+    // just add sortColumn in other cases:
+    String columnNameLabel = getColumnName("label");
+    String selectForLabel = columnNameLabel;
+    if (!sortColumn.equals(selectForLabel)) {
+      selectForLabel = selectForLabel + ", " + sortColumn;
+    }
+
     String baseQuery =
-        "WITH"
-            + " headwords_list AS (SELECT row_number() OVER (ORDER BY label) as num, uuid, label FROM "
-            + tableName
-            + "),"
-            + " hws AS (SELECT * FROM headwords_list WHERE num <@ int8range((SELECT num FROM headwords_list WHERE uuid = :startUuid), (SELECT num FROM headwords_list WHERE uuid = :endUuid), '[]'))";
+        """
+        WITH headwords_list AS (SELECT row_number() OVER (ORDER BY {{sortColumn}}) as num, {{tableAlias}}.uuid, {{selectForLabel}} FROM {{tableName}} AS {{tableAlias}}),
+          hws AS (SELECT * FROM headwords_list WHERE num <@ int8range((SELECT num FROM headwords_list WHERE uuid = :startUuid), (SELECT num FROM headwords_list WHERE uuid = :endUuid), '[]'))
+        """
+            .replace("{{selectForLabel}}", selectForLabel)
+            .replace("{{sortColumn}}", sortColumn)
+            .replace("{{tableAlias}}", tableAlias)
+            .replace("{{tableName}}", tableName);
 
     // query data
     StringBuilder dataQuery = new StringBuilder(baseQuery);
@@ -207,12 +221,23 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
     int numberOfBuckets = bucketsRequest.getNumberOfBuckets();
     argumentMappings.put("numberOfBuckets", numberOfBuckets);
 
+    String sortColumn = getSortColumn(bucketsRequest);
+
     /*
      * - get an alphabetically sorted (ASC: A-Z) and numbered list, - divide it in
      * e.g. 100 (numberOfBuckets) same sized sublists (buckets), - get first and
      * last result of each bucket (lower and upper border)
      */
     StringBuilder sqlQuery = new StringBuilder(0);
+
+    // to avoid duplicate "hw.label, hw.label" if sortColumn = "label",
+    // just add sortColumn in other cases:
+    String columnNameLabel = getColumnName("label");
+    String selectForLabel = columnNameLabel;
+    if (!sortColumn.equals(selectForLabel)) {
+      selectForLabel = selectForLabel + ", " + sortColumn;
+    }
+
     Bucket<Headword> parentBucket = bucketsRequest.getParentBucket();
     if (parentBucket != null) {
       UUID startUuid = parentBucket.getStartObject().getUuid();
@@ -221,23 +246,33 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
       argumentMappings.put("endUuid", endUuid);
 
       sqlQuery.append(
-          "WITH"
-              + " headwords_list AS (SELECT row_number() OVER (ORDER BY label) AS num, uuid, label FROM "
-              + tableName
-              + "),"
-              + " hws AS (SELECT * FROM headwords_list WHERE num <@ int8range((SELECT num FROM headwords_list WHERE uuid = :startUuid), (SELECT num FROM headwords_list WHERE uuid = :endUuid), '[]')),");
+          """
+          WITH headwords_list AS (SELECT row_number() OVER (ORDER BY {{sortColumn}}) AS num, {{tableAlias}}.uuid, {{selectForLabel}} FROM {{tableName}} AS {{tableAlias}}),
+            hws AS (SELECT * FROM headwords_list WHERE num <@ int8range((SELECT num FROM headwords_list WHERE uuid = :startUuid), (SELECT num FROM headwords_list WHERE uuid = :endUuid), '[]')),
+          """
+              .replace("{{selectForLabel}}", selectForLabel)
+              .replace("{{sortColumn}}", sortColumn)
+              .replace("{{tableAlias}}", tableAlias)
+              .replace("{{tableName}}", tableName));
     } else {
       sqlQuery.append(
-          "WITH"
-              + " hws AS (SELECT row_number() OVER (ORDER BY label) AS num, uuid, label FROM "
-              + tableName
-              + "),");
+          """
+          WITH hws AS (SELECT row_number() OVER (ORDER BY {{sortColumn}}) AS num, {{tableAlias}}.uuid, {{selectForLabel}} FROM {{tableName}} AS {{tableAlias}}),
+          """
+              .replace("{{selectForLabel}}", selectForLabel)
+              .replace("{{sortColumn}}", sortColumn)
+              .replace("{{tableAlias}}", tableAlias)
+              .replace("{{tableName}}", tableName));
     }
     sqlQuery.append(
-        " buckets AS (SELECT num, uuid, label, ntile(:numberOfBuckets) OVER (ORDER BY label ASC) AS tile_number FROM hws),"
-            + " buckets_borders_nums AS (SELECT min(num) AS minNum, max(num) AS maxNum, tile_number FROM buckets GROUP BY tile_number ORDER BY tile_number)"
-            + " SELECT num, uuid, label, tile_number FROM buckets"
-            + " WHERE num IN (SELECT minNum FROM buckets_borders_nums UNION SELECT maxNum FROM buckets_borders_nums)");
+        """
+        buckets AS (SELECT {{tableAlias}}.num, {{tableAlias}}.uuid, {{tableAlias}}.label, ntile(:numberOfBuckets) OVER (ORDER BY {{sortColumn}} ASC) AS tile_number FROM hws AS {{tableAlias}}),
+          buckets_borders_nums AS (SELECT min(num) AS minNum, max(num) AS maxNum, tile_number FROM buckets GROUP BY tile_number ORDER BY tile_number)
+          SELECT bu.num, bu.uuid, bu.label, bu.tile_number FROM buckets AS bu WHERE bu.num IN (SELECT minNum FROM buckets_borders_nums UNION SELECT maxNum FROM buckets_borders_nums)
+        """
+            .replace("{{sortColumn}}", sortColumn)
+            .replace("{{tableAlias}}", tableAlias)
+            .replace("{{tableName}}", tableName));
 
     List<Map<String, Object>> rows =
         dbi.withHandle(
@@ -276,6 +311,18 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
 
     BucketsResponse<Headword> bucketsResponse = new BucketsResponse<>(bucketsRequest, content);
     return bucketsResponse;
+  }
+
+  private String getSortColumn(ListRequest bucketsRequest) {
+    // default sorting is by label
+    String sortProperty = "label";
+    Sorting sorting = bucketsRequest.getSorting();
+    if (sorting != null) {
+      // sorting by labelNormalized may be wanted:
+      sortProperty = sorting.getOrders().get(0).getProperty();
+    }
+    String sortColumn = getColumnName(sortProperty);
+    return sortColumn;
   }
 
   @Override
@@ -334,7 +381,7 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
   @Override
   protected List<String> getAllowedOrderByFields() {
     List<String> allowedOrderByFields = super.getAllowedOrderByFields();
-    allowedOrderByFields.addAll(Arrays.asList("label", "locale"));
+    allowedOrderByFields.addAll(Arrays.asList("label", "labelNormalized", "locale"));
     return allowedOrderByFields;
   }
 
@@ -374,6 +421,8 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
     switch (modelProperty) {
       case "label":
         return tableAlias + ".label";
+      case "labelNormalized":
+        return tableAlias + ".label_normalized";
       case "locale":
         return tableAlias + ".locale";
       default:
@@ -405,12 +454,12 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
 
   @Override
   protected String getSqlInsertFields() {
-    return super.getSqlInsertFields() + ", label, locale";
+    return super.getSqlInsertFields() + ", label, locale, label_normalized";
   }
 
   @Override
   protected String getSqlInsertValues() {
-    return super.getSqlInsertValues() + ", :label, :locale";
+    return super.getSqlInsertValues() + ", :label, :locale, :labelNormalized";
   }
 
   @Override
@@ -427,6 +476,10 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
         + mappingPrefix
         + "_label, "
         + tableAlias
+        + ".label_normalized "
+        + mappingPrefix
+        + "_labelNormalized, "
+        + tableAlias
         + ".locale "
         + mappingPrefix
         + "_locale";
@@ -434,7 +487,8 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
 
   @Override
   protected String getSqlUpdateFieldValues() {
-    return super.getSqlUpdateFieldValues() + ", label=:label, locale=:locale";
+    return super.getSqlUpdateFieldValues()
+        + ", label=:label, locale=:locale, label_normalized=:labelNormalized";
   }
 
   @Override
@@ -452,6 +506,7 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
   protected boolean supportsCaseSensitivityForProperty(String modelProperty) {
     switch (modelProperty) {
       case "label":
+      case "labelNormalized":
       case "locale":
         return true;
       default:

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/HeadwordRepositoryImpl.java
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/java/de/digitalcollections/cudami/server/backend/impl/jdbi/semantic/HeadwordRepositoryImpl.java
@@ -231,8 +231,7 @@ public class HeadwordRepositoryImpl extends UniqueObjectRepositoryImpl<Headword>
 
     // to avoid duplicate "hw.label, hw.label" if sortColumn = "label",
     // just add sortColumn in other cases:
-    String columnNameLabel = getColumnName("label");
-    String selectForLabel = columnNameLabel;
+    String selectForLabel = getColumnName("label");
     if (!sortColumn.equals(selectForLabel)) {
       selectForLabel = selectForLabel + ", " + sortColumn;
     }

--- a/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V14.13.00__DDL_Alter_table_headwords_add_label_normalized.sql
+++ b/dc-cudami-server/dc-cudami-server-backend-jdbi/src/main/resources/de/digitalcollections/cudami/server/backend/impl/database/migration/V14.13.00__DDL_Alter_table_headwords_add_label_normalized.sql
@@ -1,0 +1,1 @@
+ALTER TABLE headwords ADD COLUMN label_normalized VARCHAR COLLATE "ucs_basic";

--- a/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/HeadwordController.java
+++ b/dc-cudami-server/dc-cudami-server-webapp/src/main/java/de/digitalcollections/cudami/server/controller/semantic/HeadwordController.java
@@ -19,6 +19,7 @@ import de.digitalcollections.model.list.filtering.Filtering;
 import de.digitalcollections.model.list.paging.PageRequest;
 import de.digitalcollections.model.list.paging.PageResponse;
 import de.digitalcollections.model.list.sorting.Order;
+import de.digitalcollections.model.list.sorting.Sorting;
 import de.digitalcollections.model.semantic.Headword;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -105,6 +106,7 @@ public class HeadwordController extends AbstractUniqueObjectController<Headword>
   public BucketObjectsResponse<Headword> findBucketObjects(
       @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
       @RequestParam(name = "pageSize", required = false, defaultValue = "25") int pageSize,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "startId", required = true) UUID startId,
       @RequestParam(name = "endId", required = true) UUID endId)
       throws ServiceException {
@@ -113,9 +115,18 @@ public class HeadwordController extends AbstractUniqueObjectController<Headword>
     Headword endHeadword = new Headword();
     endHeadword.setUuid(endId);
     Bucket<Headword> bucket = new Bucket<>(startHeadword, endHeadword);
-    // TODO: sorting is fix (on label), no filtering (e.g. on locale) available:
+
+    // TODO add filtering (e.g. on label or locale) to bucketObjectsRequest
+
     BucketObjectsRequest<Headword> bucketObjectsRequest =
         new BucketObjectsRequest<>(bucket, pageNumber, pageSize, null, null);
+
+    // add sorting
+    if (sortBy != null) {
+      Sorting sorting = new Sorting(sortBy);
+      bucketObjectsRequest.setSorting(sorting);
+    }
+
     return service.find(bucketObjectsRequest);
   }
 
@@ -126,6 +137,7 @@ public class HeadwordController extends AbstractUniqueObjectController<Headword>
   public BucketsResponse<Headword> findBuckets(
       @RequestParam(name = "numberOfBuckets", required = false, defaultValue = "25")
           int numberOfBuckets,
+      @RequestParam(name = "sortBy", required = false) List<Order> sortBy,
       @RequestParam(name = "startId", required = false) UUID startId,
       @RequestParam(name = "endId", required = false) UUID endId)
       throws ServiceException {
@@ -137,9 +149,18 @@ public class HeadwordController extends AbstractUniqueObjectController<Headword>
       endHeadword.setUuid(endId);
       parentBucket = new Bucket<>(startHeadword, endHeadword);
     }
-    // TODO: sorting is fix (on label), no filtering (e.g. on locale) available:
+
+    // TODO add filtering (e.g. on label or locale) to bucketsRequest
+
     BucketsRequest<Headword> bucketsRequest =
         new BucketsRequest<>(numberOfBuckets, parentBucket, null, null);
+
+    // add sorting
+    if (sortBy != null) {
+      Sorting sorting = new Sorting(sortBy);
+      bucketsRequest.setSorting(sorting);
+    }
+
     return service.find(bucketsRequest);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -157,12 +157,12 @@
       <dependency>
         <groupId>de.digitalcollections.model</groupId>
         <artifactId>dc-model</artifactId>
-        <version>12.0.1</version>
+        <version>12.1.0</version>
       </dependency>
       <dependency>
         <groupId>de.digitalcollections.model</groupId>
         <artifactId>dc-model-jackson</artifactId>
-        <version>12.0.1</version>
+        <version>12.1.0</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>


### PR DESCRIPTION
- Add persistence support for new field `Headword.labelNormalized`
- Add sorting to Buckets and Bucket objects handling in `HeadwordRepositoryImpl` 
- Separate `PageRequest` param handling from `ListRequest` param handling in `BaseRestClient`
- Reuse logic from `BaseRestClient` in `CudamiHeadwordsClient`
- Comment not supported sorting throwing warning every time in `EntityToEntityRelationRepositoryImpl`