### PR TITLE
Fix autocompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [11.0.0](https://github.com/dbmdz/cudami/releases/tag/11.0.0) - 2026-08-13
 
+### Fixed
+
+- Auto completion for adding entities, e.g. adding digital objects to collections
+
 ### Changed
 
 - **BREAKING:** Upgrade Java to version 25

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.github.dbmdz.cudami</groupId>
   <artifactId>cudami</artifactId>
-  <version>11.0.0-rc.1</version>
+  <version>11.0.0-rc.2</version>
   <packaging>jar</packaging>
 
   <name>DigitalCollections: cudami</name>

--- a/src/main/java/io/github/dbmdz/cudami/controller/AbstractPagingAndSortingController.java
+++ b/src/main/java/io/github/dbmdz/cudami/controller/AbstractPagingAndSortingController.java
@@ -54,13 +54,16 @@ public abstract class AbstractPagingAndSortingController extends AbstractControl
     Filtering filtering = null;
     if (searchProperty != null && searchTerm != null && targetClass != null) {
       String expression = searchProperty;
-      if (isMultiLanguageField(targetClass, searchProperty)) {
-        // FIXME: Does `dataLanguage` contain the script, e.g. "de-Latn"? What about the DB?
-        dataLanguage = getDataLanguage(dataLanguage, languageService);
-        // convention: add datalanguage as "sub"-expression to expression - to be handled later on
-        // serverside
-        expression += "." + dataLanguage;
-      }
+      // TODO: as long as param `dataLanguage` is not in use don't mess around with limiting
+      // language properties!
+      //      if (isMultiLanguageField(targetClass, searchProperty)) {
+      //        // FIXME: Does `dataLanguage` contain the script, e.g. "de-Latn"? What about the DB?
+      //        dataLanguage = getDataLanguage(dataLanguage, languageService);
+      //        // convention: add datalanguage as "sub"-expression to expression - to be handled
+      // later on
+      //        // serverside
+      //        expression += "." + dataLanguage;
+      //      }
       // TODO: default operation is "contains" for now, maybe pass other operators
       // (controller) if
       // we want search in non "string" fields....
@@ -147,6 +150,8 @@ public abstract class AbstractPagingAndSortingController extends AbstractControl
     if (sortBy != null) {
       String sortLanguage = getDataLanguage(dataLanguage, languageService);
       for (Order order : sortBy) {
+        // why would we overwrite an already existing subproperty?
+        if (order.getSubProperty().isPresent()) continue;
         String sortProperty = order.getProperty();
         if (isMultiLanguageField(targetClass, sortProperty)) {
           order.setSubProperty(sortLanguage);

--- a/src/main/java/io/github/dbmdz/cudami/controller/identifiable/AbstractIdentifiablesController.java
+++ b/src/main/java/io/github/dbmdz/cudami/controller/identifiable/AbstractIdentifiablesController.java
@@ -94,7 +94,7 @@ public class AbstractIdentifiablesController<
           }
           pageResponse.setRequest(pageRequest);
           return pageResponse;
-        case "identifier":
+        case "identifiers":
           Pair<String, String> namespaceAndId = ParameterHelper.extractPairOfStrings(searchTerm);
           identifiable =
               ((CudamiIdentifiablesClient<I>) service)

--- a/src/main/java/io/github/dbmdz/cudami/controller/identifiable/entity/DigitalObjectsAPIController.java
+++ b/src/main/java/io/github/dbmdz/cudami/controller/identifiable/entity/DigitalObjectsAPIController.java
@@ -53,7 +53,7 @@ public class DigitalObjectsAPIController
       @RequestParam(name = "sortBy", required = false) List<Order> sortBy)
       throws TechnicalException {
     // TODO ?: add datalanguage as request param to allow search / autocompletion in
-    // selected data language
+    // selected data language – for now we try to ignore it!
     String dataLanguage = null;
     PageRequest pageRequest =
         createPageRequest(

--- a/src/main/resources/templates/fragments/modals/select-entities.html
+++ b/src/main/resources/templates/fragments/modals/select-entities.html
@@ -25,7 +25,7 @@
                     <select class="form-select" id="selectEntitiesDialog-inputType">
                       <option value="label" selected th:text="#{lbl.label}">Label</option>
                       <option value="refId" th:text="#{lbl.ref_id}">Reference ID</option>
-                      <option value="identifier" th:text="#{lbl.identifier}">Identifier</option>
+                      <option value="identifiers" th:text="#{lbl.identifier}">Identifier</option>
                       <option value="uuid" th:text="#{lbl.uuid}">UUID</option>
                     </select>
                     <div class="form-control auto-search-wrapper p-0 border-0">


### PR DESCRIPTION
Adding entities, e.g. a digital object to a collection, was only possible by using UUIDs but not by ref ID or identifier.

Depends on https://github.com/dbmdz/metadata-service/pull/263